### PR TITLE
Fix hugo download url for Windows

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -11,7 +11,6 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            -- shasum of the release archive
             sha256 = "177f6dbd0ab794a019a9b303e1bff010499e9d5e4ef9dde18ae1455ac743041b",
             resources = {
                 {
@@ -25,7 +24,6 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            -- shasum of the release archive
             sha256 = "9e5b7cd79e4732c4fdf82210450e39cc588935fdc8ecf4a590219d7b4b2a389a",
             resources = {
                 {
@@ -38,8 +36,7 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.tar.gz",
-            -- shasum of the release archive
+            url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
             sha256 = "b6d6db48d1d7a72352e685805339df5f8e76ef24a1f9c19f50d75ee7a227a01e",
             resources = {
                 {


### PR DESCRIPTION
Just changed `tar.gz` to `zip`.

--------------

FYI, the AppVeyor build exits with code 0 even when there is an issue with tests. ([AppVeyor build](https://ci.appveyor.com/project/bacongobbler/fish-food/build/34#L19853))