### PR TITLE
bump minikube to 0.26.1

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,5 +1,5 @@
 local name = "minikube"
-local version = "0.26.0"
+local version = "0.26.1"
 
 food = {
     name = name,
@@ -11,7 +11,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-darwin-amd64",
-            sha256 = "0b2c63c6f5a00525e679b01948edffcb16e3bdb37ea0db3ed89431dd0e4c3b3c",
+            sha256 = "8cabcaa244a7d62697ad8f4393e3661c9e9cd598a75df79a8d1ffe803f80b209",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -24,7 +24,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-linux-amd64",
-            sha256 = "65dcc26a595c73b5bd2a3e47c3d5aa3bbdef81fe603f8d56f947d37cb12c74fc",
+            sha256 = "3c956459ee8dad9452c97d54463f982d1d511a9afaa0f3851d88320bd5dcf58a",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -37,7 +37,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-windows-amd64",
-            sha256 = "a7d8edb6713b819a8f44b732314a1b8fe5b77a4397693c633f641592fe6e32f1",
+            sha256 = "498f9f090972c047836fcb1580bb6fcee53fe920955377569d903ba72a0c425e",
             resources = {
                 {
                     path = name .. "-windows-amd64",


### PR DESCRIPTION
Checksum for windows image calculated from both github release and GCS downloads. Others are the sha256 files available on the github release page.