### PR TITLE
Update to kubectl v1.11.1

### DIFF
--- a/Food/kubectl.lua
+++ b/Food/kubectl.lua
@@ -1,21 +1,21 @@
 local name = "kubectl"
-local version = "1.11.0"
+local version = "1.11.1"
 
 food = {
     name = name,
     description = "The Kubernetes cluster manager",
     license = "Apache-2.0",
-    homepage = "https://github.com/kubernetes/kubernetes",
+    homepage = "https://kubernetes.io",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://storage.googleapis.com/kubernetes-release/release/v" .. version .. "/bin/darwin/amd64/kubectl",
-            sha256 = "caf2121289ec3013904495d6a4250d34f3feb5c97154b42a16a2258f33822efb",
+            url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-darwin-amd64.tar.gz",
+            sha256 = "5d6ce0f956b789840baf207b6d2bb252a4f8f0eaf6981207eb7df25e39871452",
             resources = {
                 {
-                    path = name,
+                    path = "kubernetes/client/bin/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -24,11 +24,11 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://storage.googleapis.com/kubernetes-release/release/v" .. version .. "/bin/linux/amd64/kubectl",
-            sha256 = "7fc84102a20aba4c766245714ce9555e3bf5d4116aab38a15b11419070a0fa90",
+            url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-linux-amd64.tar.gz",
+            sha256 = "a6c7537434fedde75fb77c593b2d2978be1aed00896a354120c5b7164e54aa99",
             resources = {
                 {
-                    path = name,
+                    path = "kubernetes/client/bin/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -37,11 +37,11 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://storage.googleapis.com/kubernetes-release/release/v" .. version .. "/bin/windows/amd64/kubectl.exe",
-            sha256 = "4c043ec311e76dd463d8a48163a64139dac413a43597d8f31fa3cca89bb9203b",
+            url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-windows-amd64.tar.gz",
+            sha256 = "ab2c21e627a2fab52193ad7af0aabc001520975aac35660dc5f857320176e6c4",
             resources = {
                 {
-                    path = name .. ".exe",
+                    path = "kubernetes\\client\\bin\\" .. name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }


### PR DESCRIPTION
This updates to the latest dot-release, and also changes the URLs to match what's published at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.11.md