### PR TITLE
bump dependencies

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -12,5 +12,6 @@ cd "$ROOT"
 
 for i in $(ls Food/); do
   package="${i%.*}"
+  gofish lint $package
   gofish install $package
 done

--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,18 +1,18 @@
-local name = "acs-engine"
-local version = "0.26.2"
+local name = "aks-engine"
+local version = "0.29.1"
 
 food = {
     name = name,
-    description = "Azure Container Service Engine - a place for community to collaborate and build the best open Docker container infrastructure for Azure",
+    description = "Azure Kubernetes Engine - a place for the community to collaborate and build the best Kubernetes infrastructure for Azure",
     license = "MIT",
-    homepage = "https://github.com/Azure/acs-engine",
+    homepage = "https://github.com/Azure/aks-engine",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "a2f48470773d7860064e3f01792983774e54ea49e12cf15de12fd684a4339864",
+            sha256 = "c3e0594e997b50952905060a8fe4ef9b8b30477951e2a84a7f050e26eb9f3744",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "4729714c26aeabe0f9c8f4cfb08ef8ffe67bf40e3b4b26e47ea581d3eac3f0b3",
+            sha256 = "36624cd3751f4dcd14803134967ac78ee5c048313490962536c52d73b747fc30",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "a8a6e0f18ad12dc0366bd125b3de6f0dab0bb21f63f4aa75ab7e126a815b3a7f",
+            sha256 = "7168130e4d9e4ad5e5dea1ad51121d979cb883dfd18fce5a55fff15c41c08c12",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",

--- a/Food/buffalo.lua
+++ b/Food/buffalo.lua
@@ -1,5 +1,5 @@
 local name = "buffalo"
-local version = "0.13.10"
+local version = "0.13.12"
 
 food = {
     name = name,
@@ -11,7 +11,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "99639a2837213204bcaa2001aa83a71aec443544fa364f938ee86841032138d4",
+            sha256 = "b76582a12cc1e4e84bd248a189b1efeb73502a9f16f673c9782c427233ac729a",
             resources = {
                 {
                     path = name .. "-no-sqlite",
@@ -24,7 +24,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "7af64129190a44fbac6fcfc2cd3521abc0e081ec404b10febabac822e6a4d4f3",
+            sha256 = "dff7c9cfe6c5cc502f86821f9d3ef60595b88ae0f7f8700424760e6841ce55bb",
             resources = {
                 {
                     path = name .. "-no-sqlite",
@@ -37,7 +37,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.tar.gz",
-            sha256 = "dd62a385d9ee808c1242ac622c25f926424db3522e545f4daae3ec98c84dd639",
+            sha256 = "8f2b4a05d8b8b983e3541d344b0e3a63004c9674ba6912726e631c2b7ae73fcf",
             resources = {
                 {
                     path = name .. "-no-sqlite.exe",

--- a/Food/go.lua
+++ b/Food/go.lua
@@ -1,5 +1,5 @@
 local name = "go"
-local version = "1.11.2"
+local version = "1.11.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://dl.google.com/go/go" .. version .. ".darwin-amd64.tar.gz",
-            sha256 = "be2a9382ef85792280951a78e789e8891ddb1df4ac718cd241ea9d977c85c683",
+            sha256 = "48ea987fb610894b3108ecf42e7a4fd1c1e3eabcaeb570e388c75af1f1375f80",
             resources = {
                 {
                     path = "go/bin/go",
@@ -35,7 +35,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://dl.google.com/go/go" .. version .. ".linux-amd64.tar.gz",
-            sha256 = "1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d",
+            sha256 = "fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b",
             resources = {
                 {
                     path = "go/bin/go",
@@ -58,7 +58,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://dl.google.com/go/go" .. version .. ".windows-amd64.zip",
-            sha256 = "086c59df0dce54d88f30edd50160393deceb27e73b8d6b46b9ee3f88b0c02e28",
+            sha256 = "eeb20e21702f2b9469d9381df5de85e2f731b64a1f54effe196d0f7d0227fe14",
             resources = {
                 {
                     path = "go\\bin\\go.exe",

--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "2.12.0"
+local version = "2.12.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://storage.googleapis.com/kubernetes-helm/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "2b7e4fb460d7c641be1b90aad38a882462f88fd47975cc91aa17600ab5152590",
+            sha256 = "10f8e200fdfe4f4b6b0cbe6f5420b99eec2a34f666b4126ae7881b9bd6dddb39",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://storage.googleapis.com/kubernetes-helm/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "9f96a6e4fc52b5df906da381532cc2eb2f3f57cc203ccaec2b11cf5dc26a7dfc",
+            sha256 = "edad6d5e594408b996b8d758a04948f89dab15fa6c6ea6daee3709f8c099df6d",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://storage.googleapis.com/kubernetes-helm/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "d0eeb122505cc833e526c8649c13d963103a7a769563b1cb27f8f7399e6e7c8f",
+            sha256 = "54dc234a5a1063554d26763c473f74635fa93b8114742748d4149681ee98ca6d",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",

--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.52"
+local version = "0.53"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "98f123a24a3c3e7a181cb289451f055215ecaf386eae10c7b1c3e1c9267f8d10",
+            sha256 = "2585972ad3da65b15a8dda90d6098ee637b2ab0b10724b3d51e5f54e280ed36c",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "b4d1fe91023e3fe7e92953af12e08344d66ab10a46feb9cbcffbab2b0c14ba44",
+            sha256 = "0e4424c90ce5c7a0c0f7ad24a558dd0c2f1500256023f6e3c0004f57a20ee119",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "b89767b37e1379e1261f6ec5aa10d242793118c7d2b6c66fd520b99a959337d2",
+            sha256 = "46590f8b2a24d910dc67c4b6c218dd3e53188c16fbe7aec72d7158be695e1549",
             resources = {
                 {
                     path = name .. ".exe",

--- a/Food/kubectl.lua
+++ b/Food/kubectl.lua
@@ -1,5 +1,5 @@
 local name = "kubectl"
-local version = "1.13.0"
+local version = "1.13.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-darwin-amd64.tar.gz",
-            sha256 = "4c2f17635fcef1a49a6cc509b2b95ed452277d750ad69f8b535eb7288258b796",
+            sha256 = "dcfcbd86946dc8e52f5a669e38878a5533d6c2ed04c1356d3b0776158f607d1d",
             resources = {
                 {
                     path = "kubernetes/client/bin/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-linux-amd64.tar.gz",
-            sha256 = "34ab952c65aabd6639b729158625631b7a4ccc3d7d48b0ecaaed953ab7a42802",
+            sha256 = "e9eb53e4550f84f2df31a51a89395d333dc47083147b19ab81878d7f7ffe3617",
             resources = {
                 {
                     path = "kubernetes/client/bin/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-windows-amd64.tar.gz",
-            sha256 = "4cea00a63c48a185cfd2a70ad8cf1f4c9f68745f90c738d3d8057a0388b16317",
+            sha256 = "7f5ecbe2e1168b2de06ac7f4e1465a3468fcfff81d38118293150ce7487c282d",
             resources = {
                 {
                     path = "kubernetes\\client\\bin\\" .. name .. ".exe",

--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,5 +1,5 @@
 local name = "minikube"
-local version = "0.30.0"
+local version = "0.33.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-darwin-amd64",
-            sha256 = "e09789c4eb751969f712947a43effd79cf73488163563e79d98bc3d15d06831e",
+            sha256 = "bfa1b27ef6ad3912a24917c07237409db033e1454fe9c8df063c1fb1180b3b7a",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-linux-amd64",
-            sha256 = "f6fcd916adbdabc84fceb4ff3cadd58586f0ef6e576233b1bd03ead1f8f04afa",
+            sha256 = "8a2eb70571993efbd5b44eda7ed3b04853ef877973bfe1a2c768ce649f8e5af5",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/minikube/releases/download/v" .. version .. "/minikube-windows-amd64",
-            sha256 = "8f09d63c64a2a0c4810c492066b16ccd4bd63e2f3c2d0eb55e49c51c915493f6",
+            sha256 = "1ea3386fc15dc96577ce6a2f2f2193d1f4e63673146c3528970c8f4d49c0304b",
             resources = {
                 {
                     path = name .. "-windows-amd64",


### PR DESCRIPTION
acs-engine -> aks-engine 0.29.1
buffalo 0.13.12
go 1.11.4
helm 2.12.2
hugo 0.53
kubectl 1.13.2
minikube 0.33.0

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>