### PR TITLE
Fix glooctl shasums

### DIFF
--- a/Food/glooctl.lua
+++ b/Food/glooctl.lua
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/solo-io/gloo/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64",
             -- shasum of the release archive
-            sha256 = "f9f69c18464c0a4916adf3b72f0e12296ec2c62821ca65215657ed982805c275",
+            sha256 = "c68e9a64f9c5753d5846776150bffb5f02ede17ca7f7014b42c84b27582c44fe",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/solo-io/gloo/releases/download/v" .. version .. "/" .. name .. "-linux-amd64",
             -- shasum of the release archive
-            sha256 = "fd75ffff41264b631cc7dc648f471e55876c304d06e9aa5cfb1a3c3f0ef06c41",
+            sha256 = "ebd0bf79ee9d0802d70b5abef0d59035e608d0202429964b19d33246cb482953",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/solo-io/gloo/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.exe",
             -- shasum of the release archive
-            sha256 = "b95ba5df61acefdfb47b64391d69996fee0a996182d46004be4a365ec93046aa",
+            sha256 = "35afdcd97123f55a62dec32a33ec7df41f9b80cf69f2477b08ba04c3e39b3dfe",
             resources = {
                 {
                     path = name .. "-windows-amd64" .. ".exe",


### PR DESCRIPTION
The CI run for #132 failed because the `glooctl` shasums didn't match. This updates them so hopefully things pass again. (Did they update the binaries? Booo.)