### PR TITLE
skaffold 1.3.1

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,7 +1,7 @@
 local name = "skaffold"
 local org = "GoogleContainerTools"
-local release = "v1.2.0"
-local version = "1.2.0"
+local release = "v1.3.1"
+local version = "1.3.1"
 food = {
     name = name,
     description = "Easy and Repeatable Kubernetes Development",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "16d6eb05991a304f2065f2cc443196212a1a68371db8c1e42265f5f68bff54d8",
+            sha256 = "e2f9eb8277e95db95384e2093afbb5bd571347ea065689d8cfd54bae2b301b9a",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "8c435b3faab09f697724f4ae48bb0cf203ae8490c431db35329674ef2aab5660",
+            sha256 = "ab5b4b832e63add8795cdecdd59f89055a8d0bd625de3e59ace918ecb25db27b",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "87364b1ecd214c16cb5a2c914f848e02fb9912e990ceaabb036d970aec4b1393",
+            sha256 = "611cc9e9fd685b40830ab67d9970591c66eddbbac43679010f48bb3568304dad",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.3.1. 

# Release info 

 # v1.3.1 Release - 01/31/2020
This is a minor release to to fix skaffold image `gcr.io/k8s-skaffold/skaffold:v1.3.0` issue [#3622](https://github.com/GoogleContainerTools/skaffold/issues/3622)

No changes since [v1.3.0](https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.3.0)

**Linux**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.3.1/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**macOS**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.3.1/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**Windows**
 https://storage.googleapis.com/skaffold/releases/v1.3.1/skaffold-windows-amd64.exe

**Docker image**
`gcr.io/k8s-skaffold/skaffold:v1.3.1`
