### PR TITLE
saml2aws 2.22.1

### DIFF
--- a/Food/saml2aws.lua
+++ b/Food/saml2aws.lua
@@ -1,7 +1,7 @@
 local name = "saml2aws"
 local org = "Versent"
-local release = "v2.22.0"
-local version = "2.22.0"
+local release = "v2.22.1"
+local version = "2.22.1"
 food = {
     name = name,
     description = "CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "044e17eaef8683f3c96f626934556c07326da75cc502bfb461b668c2e21c76e9",
+            sha256 = "6eb89894abaff85fb7d36a7f8e960b0277f764149254961406c9ed0d86a911eb",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "3961ac43e742e2725522583cfdb6a3dc932e6a33fc3a6286556f6aa6125725a8",
+            sha256 = "03a70142417a34c9276cdc6f3cbb645c7f151387d32b0c3594bbd238a89190ee",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.tar.gz",
-            sha256 = "36c8273715ce05bf7b5b2c43bf421f59a52fbbddcc71e5feaf5f8be14418d272",
+            sha256 = "8922c99c27ee1b5a9434473f093b442b2f7c742fc253562996dbc734cd5fe645",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package saml2aws to release v2.22.1. 

# Release info 

 * Export AWS_CREDENTIAL_EXPIRATION with token expiration #413
* Removes call to open FIDO device in Okta #415
* fix(console) Updated issuer to use correct value #420
* fix(console) Refactor token / config checks to login correctly #412