### PR TITLE
minikube 1.7.2

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.6.2"
-local version = "1.6.2"
+local release = "v1.7.2"
+local version = "1.7.2"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "5ea5168a80597ee6221bf50a524429a24a37f0c0f36725e6b297dc5a7a6a2105",
+            sha256 = "fcfb05f44620e54ce81fe8ac415196230ceb42c4007171533ef2049b7d4e8646",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "eabd027438953d29a4b0f7b810c801919cc13bef3ebe7aff08c9534ac2b091ab",
+            sha256 = "9f543f464b4d93a259f7d5a7578edff1316370d45b5a0679b86ed7a61b01634d",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "79d66c874cfe3497656e9ba191680cc95abd92d2f722b10de38f00b76ef82393",
+            sha256 = "cbbe30445baffa9a3d77834d4e24c1ec595ecc2b7933db21109aa90aa79eaddd",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package minikube to release v1.7.2. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.7.2 - 2020-02-07

* Fix to delete context when delete minikube [#6541](https://github.com/kubernetes/minikube/pull/6541)
* Fix usage of quotes in cruntime format strings [#6549](https://github.com/kubernetes/minikube/pull/6549)
* Add ca-certificates directory for distros that do not include it [#6545](https://github.com/kubernetes/minikube/pull/6545)
* kubeadm template: Combine apiserver certSANs with extraArgs [#6547](https://github.com/kubernetes/minikube/pull/6547)
* Add --install-addons=false toggle for users who don't want them [#6536](https://github.com/kubernetes/minikube/pull/6536)
* Fix a variety of bugs in `docker-env` output [#6540](https://github.com/kubernetes/minikube/pull/6540)
* Remove kubeadm pull images [#6514](https://github.com/kubernetes/minikube/pull/6514)

Special thanks go out to our contributors for these fixes:

- Anders F Björklund
- anencore94
- David Taylor
- Priya Wadhwa
- Ruben
- Sharif Elgamal
- Thomas Strömberg

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`872680848f55f6afc83573d3cd30a94c891688ae1748d74df3bab5b2d3789e4c`