### PR TITLE
hugo 0.64.1

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.64.0"
+local version = "0.64.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "1989dc1521e2777c84de757e94cf68363065dfc2c78db5687478b7032e446294",
+            sha256 = "8dcc23fb3ce831b823de4669596ece37995fdeda8441970be2a887f64d5f717a",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "99c4752bd46c72154ec45336befdf30c28e6a570c3ae7cc237375cf116cba1f8",
+            sha256 = "5c5573be0bf4113b280c4674eba0aff62224c4b076c9ef7c2e626cbd29f5b439",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "063745f5d2c010e1f269bfd04c40848f4607aa4ad9bb050a69b2812249f6da56",
+            sha256 = "1b591f2b81823c63a11651c9bc96fc909888921f03925482734deb96e3889602",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.64.1. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* hugofs: Fix mount with hole regression [b78576fd](https://github.com/gohugoio/hugo/commit/b78576fd38a76bbdaab5ad21228c8e5a559090b1) [@bep](https://github.com/bep) [#6854](https://github.com/gohugoio/hugo/issues/6854)
* Fix bundle resource ordering regression [18888e09](https://github.com/gohugoio/hugo/commit/18888e09bbb5325bdd63f2cd93116ff490dd37ab) [@bep](https://github.com/bep) [#6851](https://github.com/gohugoio/hugo/issues/6851)
* CONTRIBUTING: Fix note about CGO [7f0ebd4a](https://github.com/gohugoio/hugo/commit/7f0ebd4a3c9e016afddc2cf5e7dfe6a820aa099a) [@moorereason](https://github.com/moorereason) 
* Update Go version requirement [23ea4318](https://github.com/gohugoio/hugo/commit/23ea43180b84e35d99e88083a83e7ca1916b3b36) [@bep](https://github.com/bep) [#6853](https://github.com/gohugoio/hugo/issues/6853)




