### PR TITLE
brig 1.3.0

### DIFF
--- a/Food/brig.lua
+++ b/Food/brig.lua
@@ -1,5 +1,5 @@
 local name = "brig"
-local version = "1.2.1"
+local version = "1.3.0"
 local baseURL = "https://github.com/Azure/brigade/releases/download"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "0389302aaf8ec2717982322010783c72cf0f1f4d639e8d25df148d44abd9e870",
+            sha256 = "b45e0c414f97ea7e9bfd5e949444ea99ac4a290b1cb248985a6d18fa7b2de1cc",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "cceb71b19aab0ed56eef7f413cea61e94aa9be8c48721aea8073514634b93af6",
+            sha256 = "a2ad724573ba5bb9c3ec6652d931e2a5ba72022a33d2e35cf02da7a21290a3a5",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "3867141111c04c1d37b3886bbbce47330f711bad16cdefb66feb995d334868c5",
+            sha256 = "0b624237f28865b7e42b298d543310bc76df413fdfb21009c25a98b2f1d60d14",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package brig to release v1.3.0. 

# Release info 

 ### Announcing the Brigade v1.3.0 release!

#### A few highlights:

* A new `brig term` command which runs the terminal-based dashboard courtesy the [Brigadeterm](https://github.com/slok/brigadeterm) project.  (https://github.com/brigadecore/brigade/pull/991)
* A [KinD](https://github.com/kubernetes-sigs/kind)-based E2E testing target (`make e2e`), now hooked up to CI and running on PRs (https://github.com/brigadecore/brigade/pull/955)
* Support for GitHub SSH Certificates (https://github.com/brigadecore/brigade/pull/1008)
* First-class support for supplying a Brigade config (`brigade.json`) at run/re-run time (https://github.com/brigadecore/brigade/pull/1017 and https://github.com/brigadecore/brigade/pull/1030)
* New or updated docs for:
   * [Linkerd + Brigade](https://github.com/brigadecore/brigade/pull/1025)
   * [NFS storage setup](https://github.com/brigadecore/brigade/pull/1047)
   * [Cert-Manager setup](https://github.com/brigadecore/brigade/pull/1022)

Thank you for all your contributions!

#### Here is the full changeset:

- fix(brigade-controller): update the service account regex if service account overridden (#1052) 8cbf9fda33e7c19f4c7b6c1454082f2a99185f8b (Vaughn Dice)
- docs(storage.md): update nfs instructions (#1047) 9cd050ac7f3ea82e44cbde6164d4dbf681dc5c9b (Vaughn Dice)
- ci(brigade.js): run tests before proceeding with a release (#1033) 4cf9ff1fa7d57fe9a1238b8228b2cab041f8fbf0 (Vaughn Dice)
- feat(*): parity for brigade.json defaults/fallbacks (#1030) 8ffeb29d3e8133826851d8c7471915b7c50fe412 (Vaughn Dice)
- add optional title fields to build type b1d7855e2f9832113fa7a08be4a9104ad2cb4e93 (Kent Rancourt)
- ref(brigade-worker): remove yarn docs target (#1027) 781f57ffc16a5108e435b639a49e7e4d3b0efe47 (Vaughn Dice)
- docs(): add linkerd setup example/instructions (#1025) ff55aecba364de2739d3cf0c1d013bc1cf19c2bb (Vaughn Dice)
- fix(brigade-worker): bump handlebars resolution to satisfy yarn audit (#1026) d7b2b114d3b7adc9a4943e7a8bb82ad725466178 (Vaughn Dice)
- docs(ingress.md): update cert-manager install instructions/manifests (#1022) 96a68820ebf9d7309c726ff6697d0f5e02c31ac4 (Vaughn Dice)
- feat(*): enable passing brigade.json via brig run (#1017) 33c888d6d4e13b62399a4b1f9e06755adba1de8b (Vaughn Dice)
- Revert "take default command from image instead of controller" 8210b26c138d44cefbd7481308ce7f2a2b362f87 (Kent Rancourt)
- take default command from image instead of controller 8a5e0ae414002de2f543db0f39b11892fa64dcc6 (Kent Rancourt)
- document docker-in-docker (#1014) 3a23a994d5b4db62f34f85f04f1cd285e98fdac3 (Matt Butcher)
- explain how to store brigade.js on a project or in a ConfigMap. (#1012) 6c4b02ed9e495c5d273d8857fb303814f83a86bd (Matt Butcher)
- ref(brigade.js): remove master gate for check suite event (#1010) ada74038fc74f11ae76cb86d7f93fe5028e08f4b (Vaughn Dice)
- feat(project): enable complex secret values (#1005) ce278f87e59598d1c6ae8f29c2367d2102ac0ab6 (Vaughn Dice)
- Adding support for ssh certificates. (#1008) 579d22e235303704379e8438ab291bf419162919 (Valera)
- chore(brigade-worker): check in yarn/node_modules updates (#1013) 767aab8ed70d48ea56b30b676a34e15f1318cafa (Vaughn Dice)
- fix(brigade-worker): bump handlebars resolution per yarn audit (#1011) d90252ea2bb91b36d5bf1a472fa93fe071a19109 (Vaughn Dice)
- fix(README.md): update build badge URL (#1009) f3bd263426b691fc9ba6ae71c0b9f1af7b9d52d1 (Vaughn Dice)
- fix(brigade.js): supply details URL to new Check(..) (#1006) 38501215a6c53d11f77ea8ecc4185a3d6556fc2b (Vaughn Dice)
- Fix link to gateway documentation (#1004) 832ed025c320eca0491ccb1b988dcf5c02c5afeb (Michele Mastrogiovanni)
- Remove unused top-level node_modules directory (#1000) 2218bcf12b4005256713c4caa0ca9e5cb87e89ab (Radu M)
- ci(brigade.js): add e2e job (#955) a787590aa105d4bb3b9a03f480e233f9327d6835 (Vaughn Dice)
- Add JSON output for brig X get and list commands (#996) 7f560817ad274b85edc06918a7897faf3615c8f4 (Radu M)
- Add brig term command that starts Brigadeterm (#991) 45d5a932398d6f8ee3f22e49c7a7dab26a4c5870 (Radu M)
- fix(brigade-worker): return no logs found if job canceled and pod undefined/pending (#998) 20e32cdc90e92b3e300d4d187061a8a255fcaac4 (Vaughn Dice)
- Check message before logging it (#997) 3ac4c99ad7ae2b8704400e8b6c4933932d99203d (Aidarbek Suleimenov)
- return to break outer for loop instead of inner select loop (#989) 3971ab0555369ed4f1fe99d25537f5f6e6bcbbe5 (Guangming Wang)
- Move brig README to docs page (#992) bbfd9bd4d385a0c73d94c38c2bbbe658f2fe51bf (Radu M)
