### PR TITLE
aks-engine 0.47.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.46.3"
+local version = "0.47.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "fb59de230b38ef7eaceaff362a5f063d5ceb6040d44b1d9e773a02a618425411",
+            sha256 = "34ee90e14ab35343a7a7e7f88a6b741f899b53331524e25b8af8fddbe5dec2ab",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "d4f97ed4839cdbcf4ccbb4c2837713e8d5dd7a01f5445bfd01fcfc231e24fa09",
+            sha256 = "2f61400cad9c25f5a2c0e62bb47bc6fcdcaaa8301342d28f1a5be8498c227fd1",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "6107effe592af4ad35660291d809be7045a983fd9ed0195c9feded673942f78f",
+            sha256 = "064be8ec4fa3e26de3e358d59e7f39aa6ef89d50dadb55305c0c7800d4eed966",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.47.0. 

# Release info 

 <a name="v0.47.0"></a>
# [v0.47.0] - 2020-02-18
### Bug Fixes 🐞
- raising dynamic port range for windows to better support clusters with 200+ services ([#2688](https://github.com/Azure/aks-engine/issues/2688))
- update CSE moby version substring match ([#2662](https://github.com/Azure/aks-engine/issues/2662))
- don't expire adminUser account ([#2661](https://github.com/Azure/aks-engine/issues/2661))
- remove extra param from 'systemctl_restart' invocation ([#2654](https://github.com/Azure/aks-engine/issues/2654))
- persist new pool after addpool operation ([#2653](https://github.com/Azure/aks-engine/issues/2653))
- make Windows scaling work ([#2643](https://github.com/Azure/aks-engine/issues/2643))
- default LB AllocatedOutboundPorts to 0 ([#2526](https://github.com/Azure/aks-engine/issues/2526))
- stop using type nesting in billing extensions to address SDK-for-Go breaking change ([#2640](https://github.com/Azure/aks-engine/issues/2640))
- custom kube-controller-manager template should reference hyperkube ([#2639](https://github.com/Azure/aks-engine/issues/2639))
- create role assignment for master VMs ([#2583](https://github.com/Azure/aks-engine/issues/2583))
- Skip storage class e2e test when ephemeral disk is used ([#2604](https://github.com/Azure/aks-engine/issues/2604))
- Moving publish release notes step after e2e test runs so windows vhd pipeline can be re-run ([#2595](https://github.com/Azure/aks-engine/issues/2595))

### Build 🏭
- fetch k8s Windows .zip from kubernetesartifacts storage ([#2655](https://github.com/Azure/aks-engine/issues/2655))
- fetch etcd from MCR container image ([#2644](https://github.com/Azure/aks-engine/issues/2644))
- fetch cni-plugins from kubernetesartifacts storage ([#2617](https://github.com/Azure/aks-engine/issues/2617))
- fetch azure-vnet-cni from kubernetesartifacts storage ([#2593](https://github.com/Azure/aks-engine/issues/2593))

### Code Refactoring 💎
- extract common script parameters into function ([#2651](https://github.com/Azure/aks-engine/issues/2651))
- cleanup duplicate functions and move apiversions to consts ([#2659](https://github.com/Azure/aks-engine/issues/2659))

### Continuous Integration 💜
- change apiVersion of prow deployments from v1beta2 to v1 ([#2669](https://github.com/Azure/aks-engine/issues/2669))

### Documentation 📘
- refer to kubernetesartifacts storage in examples and comments ([#2656](https://github.com/Azure/aks-engine/issues/2656))
- add support note to main readme ([#2623](https://github.com/Azure/aks-engine/issues/2623))
- remove VHD code comment suggesting registry is temporary ([#2602](https://github.com/Azure/aks-engine/issues/2602))

### Features 🌈
- updating windows VHD for Feb k8s versions ([#2731](https://github.com/Azure/aks-engine/issues/2731))
- add support for Kubernetes 1.15.10 ([#2709](https://github.com/Azure/aks-engine/issues/2709))
- add support for Kubernetes 1.16.7 ([#2710](https://github.com/Azure/aks-engine/issues/2710))
- add support for Kubernetes 1.17.3 ([#2707](https://github.com/Azure/aks-engine/issues/2707))
- abort/warn if apimodel contains properties not supported by Azure Stack ([#2717](https://github.com/Azure/aks-engine/issues/2717))
- read vm size from instance metadata service for windows cse telemetry ([#2663](https://github.com/Azure/aks-engine/issues/2663))
- add new VM SKUs ([#2647](https://github.com/Azure/aks-engine/issues/2647))
- validate VHD availability on azurestack ([#2342](https://github.com/Azure/aks-engine/issues/2342))
- add support for Kubernetes 1.16.6 ([#2588](https://github.com/Azure/aks-engine/issues/2588))
- fetching collect-windows-logs.ps1 during windows CSE ([#2615](https://github.com/Azure/aks-engine/issues/2615))
- add support for Kubernetes 1.15.9 ([#2589](https://github.com/Azure/aks-engine/issues/2589))
- add support for Kubernetes 1.17.2 ([#2612](https://github.com/Azure/aks-engine/issues/2612))
- add support for Kubernetes 1.18.0-alpha.2 ([#2610](https://github.com/Azure/aks-engine/issues/2610))
- Updating aks-windows vhd to to include jan patches ([#2603](https://github.com/Azure/aks-engine/issues/2603))

### Maintenance 🔧
- rev AKS Engine Linux VHDs to 2020.02.12 ([#2728](https://github.com/Azure/aks-engine/issues/2728))
- Add ProgressPreference=SilentlyContinue to disable progress bar ([#2693](https://github.com/Azure/aks-engine/issues/2693))
- don't refer to hyperkube in template if > 1.16 ([#2676](https://github.com/Azure/aks-engine/issues/2676))
- update Azure NPM to v1.0.32 ([#2665](https://github.com/Azure/aks-engine/issues/2665))
- rev Linux VHDs to 2020.01.30 ([#2660](https://github.com/Azure/aks-engine/issues/2660))
- use IsVMSSToBeUpgraded func to validate vmss pools in upgrade ([#2650](https://github.com/Azure/aks-engine/issues/2650))
- Bump moby to 3.0.10 ([#2613](https://github.com/Azure/aks-engine/issues/2613))
- update Azure cloud-provider components to v0.4.1 ([#2627](https://github.com/Azure/aks-engine/issues/2627))
- support v1.15.9 on Azure Stack ([#2628](https://github.com/Azure/aks-engine/issues/2628))
- Updating NPM CPU and Memory requests and limits ([#2530](https://github.com/Azure/aks-engine/issues/2530))
- Adding 1.17.1 package to windows vhd ([#2607](https://github.com/Azure/aks-engine/issues/2607))
### Testing 💚
- replace containerd+kubenet with containerd+azure ([#2678](https://github.com/Azure/aks-engine/issues/2678))
- enable scale/upgrade for base E2E cluster config ([#2670](https://github.com/Azure/aks-engine/issues/2670))
- delete pod if exists in run pod scenario ([#2668](https://github.com/Azure/aks-engine/issues/2668))
- wait for "Ready" nodes, where appropriate ([#2657](https://github.com/Azure/aks-engine/issues/2657))
- zones aren't available everywhere ([#2633](https://github.com/Azure/aks-engine/issues/2633))
- allow cluster-autoscaler more nodes in everything test config ([#2629](https://github.com/Azure/aks-engine/issues/2629))
- modify vm sku during e2e upgrade tests ([#2625](https://github.com/Azure/aks-engine/issues/2625))
- HPA/cluster-autoscaler fixes so we don't scale up too many pods ([#2626](https://github.com/Azure/aks-engine/issues/2626))
- configurable pvc E2E tests ([#2620](https://github.com/Azure/aks-engine/issues/2620))
- don't test for static node count if add node pool context ([#2619](https://github.com/Azure/aks-engine/issues/2619))
- consolidate E2E test cluster configurations ([#2586](https://github.com/Azure/aks-engine/issues/2586))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.47.0...HEAD
[v0.47.0]: https://github.com/Azure/aks-engine/compare/v0.46.3...v0.47.0