### PR TITLE
Add support for eksctl

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -3,7 +3,7 @@ local version = "0.13.0"
 
 food = {
     name = name,
-    description = "enter description here",
+    description = "The official CLI for Amazon EKS",
     homepage = "https://eksctl.io/",
     version = version,
     packages = {

--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,0 +1,52 @@
+local name = "eksctl"
+local version = "0.13.0"
+
+food = {
+    name = name,
+    description = "enter description here",
+    homepage = "https://eksctl.io/",
+    version = version,
+    packages = {
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
+            -- shasum of the release archive
+            sha256 = "b2aa450e2285d79e0631ba8410c709970585b2d34c7a7e7ee17ba38de221f01e",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
+            -- shasum of the release archive
+            sha256 = "73328372c14e8c0fb0571882a0497ee2e33d9c3d0e3d4987f035f07e4c4cd4a6",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
+            -- shasum of the release archive
+            sha256 = "41b025473df428b934710c056a798566a2c2800a937ac2b9acd9a328dcb09d70",
+            resources = {
+                {
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
There are several typical Kubernetes tools here already, but what was missing for my typical work, which defaults to download a GitHub Release, was eksctl. This is the first fish food stuff I build, but it works for me and seems right.