### PR TITLE
helmfile 0.101.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.100.2"
+local version = "0.101.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "e12e38f482d8f18cee9db03d62ba873db232b080c510188e64e48bf3263a83bc",
+            sha256 = "07494b877d33d76d12e35f26d0513078be8efff04d2028b0f77a5eb47383dd5d",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "29c41ac74d177dde94b58b145ef58bcaf0158448824a413ee9998af4c41a3e39",
+            sha256 = "5aa73d371a1053a4f30b18d100dd95082fef257509f676e5d263c7b8e4443979",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "7aaa608ba8ec70b2625b33d73cbdcaa97fa536c08e4f7bd7a54a5ba0fcf81a78",
+            sha256 = "93f6bd7bb1759d134f67efabb120da1277fdd7905cbf51898319dc013a2ff89b",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "6a7cd02e38de985f2d5da468eb39ca7f932772478767bf54e2ceab0708151d3c",
+            sha256 = "18d101d465941e2684ec1844f182866cfbcd5843595c9071b67001ef181a76a0",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "0797338550c08be0922e0f87bf72dbd914bb416fff0c97b1c0d9c75682d4cf22",
+            sha256 = "d2971df423c25695640a17d7068ea6acdf2a8015ceac34cbb134c534361db412",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "cf1a5d8a1880dfd79b446c8c71b3614a01472eaaa3633d86c2aa8158b773e516",
+            sha256 = "3795de71adbd5dd23f8e1668f15dea4ae241041a438ed560ae01a9e0a9071574",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.101.0. 

# Release info 

 0186254 (HEAD, tag: v0.101.0, origin/master, origin/HEAD, master) feat: --detailed-exitcode for `helmfile apply` (#1120)
8acbbc5 new here, fixing very minor typo (#1121) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/4094)