### PR TITLE
kubebuilder 2.3.0

### DIFF
--- a/Food/kubebuilder.lua
+++ b/Food/kubebuilder.lua
@@ -1,7 +1,7 @@
 local name = "kubebuilder"
 local org = "kubernetes-sigs"
-local release = "v2.2.0"
-local version = "2.2.0"
+local release = "v2.3.0"
+local version = "2.3.0"
 food = {
     name = name,
     description = "Kubebuilder - SDK for building Kubernetes APIs using CRDs",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "5ccb9803d391e819b606b0c702610093619ad08e429ae34401b3e4d448dd2553",
+            sha256 = "b44f6c7ba1edf0046354ff29abffee3410d156fabae6eb3fa62da806988aa8bd",
             resources = {
                 {
                     path = name .. "_" .. version .. "_darwin_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "9ef35a4a4e92408f7606f1dd1e68fe986fa222a88d34e40ecc07b6ffffcc8c12",
+            sha256 = "a8ffea619f8d6e6c9fab2df8543cf0912420568e3979f44340a7613de5944141",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,


### PR DESCRIPTION
Updating package kubebuilder to release v2.3.0. 

# Release info 

 Kubebuilder supports multi-group project now.

## Changelog

3da1b848 :book: admission webhook for core types
0de1a5f8 :book: update command in running webhook section
a800e88b :book: use v2.2.0 in quick start
d360f016 :bug: end users should not have permissions to edit */status
7971516f :bug: scaffold clusterrole for access the protected metrics
8a2d01e0 :running: fix kubebuilder go links
d0921943 :sparkles: bump CR to v0.5.0 and CT to v0.2.5
e3e66264 :sparkles: default leader election ID using hash of repo + domain name
cb7c1c26 Add interface validation check for missing types
0a274ac6 Add webhook scaffolding to docs
80395c5b Added copyrights - #1281
232a8d0f Addressing NITs raised in 1375 to improve the documentation of the scaffolder
debd22cc Bikeshed styling on code blocks in books a bit
dc1f6257 Bump up the version of kind to 0.7.0
fdb36acb Clean old users from the OWNERS file
ca41e56c Create resource Options to split the two step resource creation into two different types
5a4e54ed Delegate go vet and go fmt to golangci-lint
a697d900 Delete file scaffolding tests in unitary tests as they are overlapping with the golden test
41765a3a Enable linters for golangci-lint
63fc6f8c Extract from templates internal subpackage the file updating machinery
fd794bf0 Fix "if modules enabled" check in common.sh
db6e519f Fix Travis goimports linting error
fdba7163 Fix a typo and a broken link.
62cefcec Fix code errors in finalizer example
ed8438ec Fix issues raised by Go Report Card (mainly comments and style related changes)
93e9649e Fix minor typo
d120230f Fix multiversion deployment example
95874c79 Fix the wrong tests link
5e483956 Fix typo
9e15b448 Fix unofficial way of handling already existing files
db66ebdd Fix wrong paths in multi-group migratig doc
266e1ab7 Gofmt -s related fixes
4e7ec4bb Group and order imports
733fe419 Homogenize all File receivers to f
6d5e8bb2 Homogenize commands through Scaffolder interface
65346608 Include PROJECT file information into model.Universe
887037d0 Introduce .golangci.yml
9d7c0649 Move configuration file related types and functions to separate package
f3a1adc9 Move file related models to pkg/model/file
f96d453b Move scaffold machinery to its own internal package
66baebf8 Move templates to internal package
461ef849 OWNERS,OWNER_ALIASES: add joelanford as reviewer
e68184be OWNERS: add estroz to reviewers
df46138a Order Travis stages
d2ae129d Order linters
f9f8f599 Remove ignoreNotFound and rely on client
4d00eb55 Remove noop validations
cbbb0054 Remove outdated utils code
e4b49e8a Remove overlapping tests with Prow
99f56687 Remove scaffolding fields that were not used
ae308ba6 Resolve package and variable name collision
ec5c4adc Resource replacer that injects resource information into strings
23262461 Split injecting fields and validating files
e49d9438 Support mixed case Kind
e80f0a15 Template interface (phase 1)
6f191bf1 Template interface (phase 2) including insert code fragments logic
435f946f Template mixins
7bbf76b4 Update /testdata autogenerated copyrights to 2020
9f597a29 Update OWNERS and OWNERS_ALIASES files to new format
06844dae Update book
9989706d Update guestbook types in Quick Start
d46d7298 Use zap helpers
b94203f2 Validate resources for webhooks and tests
1e47a41e Verify that AdmissionWebhooks implements File
aba2d3f2 add camilamacedo86 as approver
5b31a7eb add doc to setup Prometheus via operator and remove ref of  manager_prometheus_metrics_patch.yaml which is no longer used in v2
1d356a3b add missing lints to keep enabled all default ones
b6478503 add new interface system and link to feature branch
6e1ddabb adding scafold file fixes for travis
c2848736 clarify sentence on project type; add Name() to Plugin interface
15f19e78 community: fix discussion group links
53afd47a designs: extensible CLI and scaffolding plugins
46b0632f doc: add info to check changes in the docs
1256310e doc: improve manager info
e9a2da60 docs/book: small grammar/spelling tweaks
6fef12e8 enable gocycle lint check
ade6f5f2 enable golint check
c52ba01d enable golint lll check
c581f28e enable gosec
c6f43a62 enable lint goconst
9c34b133 enable lint-goimport check
93980719 enable maligned lint check
5187a15b explain PROJECT file updates and plugin version/name conventions
24d31be4 feat add coverage tests
e7485951 feat(lint) : add golangci-lint
af8cf2da feat: add multigroup support for v2
9776f54c fix invalid validation marker in example in quick-start.md
19f09b74 fix matchLabel missing in ServiceMonitor template
3294fac5 helpfully show progress of kubebuilder download
3546827c improve travis
0a446206 replace pkg/runtime/log for pkg/log in just the v2 scaffolding.
82dc5076 repository and sub-project name is cluster-addons now
4240869b scaffold: Don't hardcode the boilerplate path in the Makefile
3c9a09ff tests: delete kind cluster after e2e
a3c965b2 upgrade golangci version used to v1.23.3
5dba28fb use suggested wording
a370c786 🏃 Bump k8s tools to 1.16.4
6f5dad51 🏃‍♂️ fix kind kubeconfig export and docs
d2c8166e 🛠 fix prow presubmits
