### PR TITLE
kompose 1.21.0

### DIFF
--- a/Food/kompose.lua
+++ b/Food/kompose.lua
@@ -1,5 +1,5 @@
 local name = "kompose"
-local version = "1.20.0"
+local version = "1.21.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "66d9652ee3b0953e3e2a7793534d8bd454305a3780b010f8721e6e8a0b4dabaf",
+            sha256 = "9384e5233859d1bdc676c3ff80f2609e084a23fd5993e81a0a54e9976d18adf1",
             resources = {
                 {
                     path = name.."-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "66b8785fec6113a36d120c5b171bbef9346e7d801b712a9e2d12e15f3e4b9741",
+            sha256 = "88cac7b503cce5a4f83d3ac7690311307bc62a380e29b22a6557581c2b4c6d4d",
             resources = {
                 {
                     path = name.."-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.exe",
             -- shasum of the release archive
-            sha256 = "b62c28ffb79ab2c42e0ab7da74824b1aa43dc97e775198c9e744fd89a3cd2b84",
+            sha256 = "0a01f3eb0cb810b61a4d7aaa5b59824e829f2e9042f061ff27f3c419822f08d3",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package kompose to release v1.21.0. 

# Release info 

 Kompose 1.21.0!

Here's the new features in 1.21.0:

- Ingress path names are now supported (https://github.com/kubernetes/kompose/pull/1245)
- V2 restart unless-stopped is not supported (https://github.com/kubernetes/kompose/pull/1244)
- You're now able to provide an external apiserver for Kubernetes (https://github.com/kubernetes/kompose/pull/1243)
- MacPorts support has been added to the documentation (https://github.com/kubernetes/kompose/pull/1242)
- `deploy.update_config` will now convert to `rolling update` within Kubernetes (https://github.com/kubernetes/kompose/pull/1232)
- Deployment labels are now supported (https://github.com/kubernetes/kompose/pull/1231) 
- Config short syntax bug fixes (https://github.com/kubernetes/kompose/pull/1230)
- Code refactoring (https://github.com/kubernetes/kompose/pull/1228)
- Support port expose (https://github.com/kubernetes/kompose/pull/1227)
- Updated documentation regarding push image (https://github.com/kubernetes/kompose/pull/1225)
- Fix duplicate in container spec (https://github.com/kubernetes/kompose/pull/1223)
- Fixed v3 hostpath path error (https://github.com/kubernetes/kompose/pull/1222)
- Fixed hostpath path translate error (https://github.com/kubernetes/kompose/pull/1221)
- Added notes regarding windows (https://github.com/kubernetes/kompose/pull/1220)
- Fixed YAML indentation (https://github.com/kubernetes/kompose/pull/1219)
- Dep update (https://github.com/kubernetes/kompose/pull/1218)
- Added support for configmap as a volume (https://github.com/kubernetes/kompose/pull/1216)
- Fixed configmap name case error (https://github.com/kubernetes/kompose/pull/1215)
- Merge will include deploy resources (https://github.com/kubernetes/kompose/pull/1214)
- User a service name when image name is empty when built (https://github.com/kubernetes/kompose/pull/1213)
- Fixed build (https://github.com/kubernetes/kompose/pull/1212)
- Support assign nodeport port in labels (https://github.com/kubernetes/kompose/pull/1212)
- Use new go version for build (https://github.com/kubernetes/kompose/pull/1209)
- Add flag to support store manifest when using kompose up (https://github.com/kubernetes/kompose/pull/1208)
- Updated API versioning (https://github.com/kubernetes/kompose/pull/1207)
- Removed duplicated entries of configmap (https://github.com/kubernetes/kompose/pull/1206)
- Fixed chart lint (https://github.com/kubernetes/kompose/pull/1205)
- Modify default kubernetes client apiserver URL (https://github.com/kubernetes/kompose/pull/1204)

#### Providing an external apiserver for Kubernetes

With this release, you're now able to supply what server to be used when deploying.

For example:

```sh
kompose up --server https://127.0.0.1:6443
```

# Installation

__Linux and macOS:__

```sh
# Linux
curl -L https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-linux-amd64 -o kompose

# macOS
curl -L https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-darwin-amd64 -o kompose

chmod +x kompose
sudo mv ./kompose /usr/local/bin/kompose
```

__Windows:__

Download from [GitHub](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-windows-amd64.exe) and add the binary to your PATH.

__Checksums:__

| Filename        | SHA256 Hash |
| ------------- |:-------------:|
[kompose-1.21.0-1.x86_64.rpm](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-1.21.0-1.x86_64.rpm) | 2697238545d1a5801172c40f3e5a863a50f979fdb805c47deae66a2ed190d9d4
[kompose-1.21.0-1.x86_64.rpm.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-1.21.0-1.x86_64.rpm.tar.gz) | 8baf2195b36dfaab248f98e6ce19afc4627eed75cf54ffcf6d340304150f60c8
[kompose_1.21.0_amd64.deb](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose_1.21.0_amd64.deb) | 5210fbae874c1695aea0b80eea0d89621e3f84389e9680ccb6605dadca7a5abf
[kompose_1.21.0_amd64.deb.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose_1.21.0_amd64.deb.tar.gz) | 1e4698c06c258d98e31e053e8caf1cede13a255230becadf13b82286d4cc262e
[kompose-darwin-amd64](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-darwin-amd64) | 894e1d9e350d12b69501349e0610c1cde68ddae5dd92a0cbdba748ec059ed9ef
[kompose-darwin-amd64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-darwin-amd64.tar.gz) | 9384e5233859d1bdc676c3ff80f2609e084a23fd5993e81a0a54e9976d18adf1
[kompose-linux-amd64](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-linux-amd64) | 488d786fce0fab4e0c6c0668bfe6229cce58b2d3635936ba33cae7ab702bd0d7
[kompose-linux-amd64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-linux-amd64.tar.gz) | 88cac7b503cce5a4f83d3ac7690311307bc62a380e29b22a6557581c2b4c6d4d
[kompose-linux-arm](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-linux-arm) | 2f1b39d288bb9c6c29406bc056ad17053885e9fc8bf868e6595456b14bff0d1e
[kompose-linux-arm.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-linux-arm.tar.gz) | 62acb45751ba8b2e6c787882b944a2b2f8aa7ca5390e876a439c13763b0b30e8
[kompose-windows-amd64.exe](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-windows-amd64.exe) | 0a01f3eb0cb810b61a4d7aaa5b59824e829f2e9042f061ff27f3c419822f08d3
[kompose-windows-amd64.exe.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-windows-amd64.exe.tar.gz) | 06e1a70d11c9e9e03fbd95883ffb8b0a2a83ce4d16cf37b4321e40d653693e17
[SHA256_SUM](https://github.com/kubernetes/kompose/releases/download/v1.21.0/SHA256_SUM) | 71c9df33690b3b0ddcaa1a3e6ba8100ee6bfd70dc1922054bc7143b2cec09fb6