### PR TITLE
istioctl 1.4.6

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,7 +1,7 @@
 local name = "istioctl"
 local org = "istio"
-local release = "1.4.5"
-local version = "1.4.5"
+local release = "1.4.6"
+local version = "1.4.6"
 food = {
     name = name,
     description = "Connect, secure, control, and observe services.",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "4621c209bb1b1a7252b65ea8e8fb41822faebc909c23d9f454bb4096710b51f8",
+            sha256 = "a50b3316d065d8cfab4f8be2928574ff29af7d2700525a24df95f993ec2a38b6",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-linux.tar.gz",
-            sha256 = "8c7d33c22cfe9b4ef965dc0718931527d24a7c33657fa173e011f00b367a82cf",
+            sha256 = "74480f2c73fad95aba923d16fbdda641f5ac55d1476a716d71cd2a350f48ff10",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "37b57407743dc1b046298b88678e5a189ab9277853e4be2efa6a9253189653a0",
+            sha256 = "86497e7171a43ec882a5989e6d9272c2fd87fc35356116255ff20d7eb400a736",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.4.6. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.4.6/)
[Release Notes](https://istio.io/news/announcing-1.4.6/)