### PR TITLE
k9s 0.17.4

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,7 +1,7 @@
 local name = "k9s"
 local org = "derailed"
-local release = "v0.17.3"
-local version = "0.17.3"
+local release = "v0.17.4"
+local version = "0.17.4"
 food = {
     name = name,
     description = "🐶 Kubernetes CLI To Manage Your Clusters In Style!",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "8ee586f5eb0eada8a4007d9f720ee7ba0463d2e471c9dc56ca4ef95e429e0103",
+            sha256 = "c63cb3af18535b8f67fe9c74ffe676522fd92f461e9a8599ca17efdf6d7042bb",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "aa63daa3e559923969d713a86aebc0de273ba50d305f2dc9fe2df1f9735e9fab",
+            sha256 = "c4b4018db65e854548a49ccff87d4159664781282c8a249aa1d4bb665cab06b0",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "e34f55525dc1e037bffa3d1d5ee7f497edf35ebc6ef1b2412aa019a3fc0a1a72",
+            sha256 = "f3a99bc752783e8757504b34bc8a8eb02fab9a976d5ffcaa9305d6434d6baf7c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.17.4. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.17.4

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better is as ever very much noticed and appreciated!

Also if you dig this tool, please consider sponsoring 👆us or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

---

<center>
<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/story/this_is_fine_300.png" align="center" width="500" height="auto"/>
</center>

## Pulses Part Duh!

In this drop, we've updated pulses to now show used/allocatable resources for cpu and mem as recommended by the awesome and kind [Eldad Assis](https://github.com/eldada)! We've also added the concept of threshold to alert you when things in your clusters are going south. These currently come in the shape of cpu and mem thresholds. They are set at the cluster level. K9s will now let you know when these limits are reached or surpassed. As it stands, the k9s logo will change color and a flash message will appear to let you know which resource thresold was exceeded. Once the load subsumes the logo/flash will return to their orginal states.

In order to override the default thresholds (cpu/mem: 80% ), you will need to modify your `$HOME/.k9s/config.yml` using the new config section named `thresholds` as follows:

```yaml
# $HOME/.k9s/config.yml
k9s:
  refreshRate: 2
  headless: false
  ...
  # Specify resources thresholds percentages
  thresholds:
    cpu:    80 # default is 80
    memory: 55 # default is 80
  ...
```

<center>
<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/story/pulses_tripped.png" align="center" width="700" height="auto"/>
</center>

## Resolved Bugs/Features/PRs

- [Issue #596](https://github.com/derailed/k9s/issues/596)
- [Issue #593](https://github.com/derailed/k9s/issues/593)
- [Issue #560](https://github.com/derailed/k9s/issues/560)
  - NOTE!! All credits here goes to [Bruno Meneguello](https://github.com/bkmeneguello) and [Michael Cristina](https://github.com/mcristina422) for making this possible in K9s!

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

