### PR TITLE
k9s 0.17.6

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,7 +1,7 @@
 local name = "k9s"
 local org = "derailed"
-local release = "v0.17.4"
-local version = "0.17.4"
+local release = "v0.17.6"
+local version = "0.17.6"
 food = {
     name = name,
     description = "🐶 Kubernetes CLI To Manage Your Clusters In Style!",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "c63cb3af18535b8f67fe9c74ffe676522fd92f461e9a8599ca17efdf6d7042bb",
+            sha256 = "e7a0250b027ca5c0d0276226b3da50c936e34d9b9567693392d39e73a3a9beb2",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "c4b4018db65e854548a49ccff87d4159664781282c8a249aa1d4bb665cab06b0",
+            sha256 = "83861bfd61633ff2995ccd980e41464e130c40a1f15f444164771cda36d31697",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "f3a99bc752783e8757504b34bc8a8eb02fab9a976d5ffcaa9305d6434d6baf7c",
+            sha256 = "5f9aba731a6c046d99ddfc1247eac2cfffbdbe10d25eb51030bc583efc74b4d8",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.17.6. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.17.6

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better is as ever very much noticed and appreciated!

Also if you dig this tool, please consider sponsoring 👆us or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

---

## Get A Rope!

This was in the backlogs for a while, so I've decided to give it a bit of TLC. Thank you [Mitchell Maler](https://github.com/mitchellmaler) for this issue!

🏝Feeling your clusters could use a bit of spring cleaning 🧽🧼?
As of this drop, you can now perform direct cluster nodes maintenance by leveraging cordon `c`, uncordon `u` and drain `d` while in node view! Each operation comes with a dialog to either configure the options or comfirm the operation. You dig?

## Resolved Bugs/Features/PRs

- [Issue #612](https://github.com/derailed/k9s/issues/612)
- [Issue #608](https://github.com/derailed/k9s/issues/608)
- [Issue #606](https://github.com/derailed/k9s/issues/606)
- [Issue #237](https://github.com/derailed/k9s/issues/237)
- [PR #607](https://github.com/derailed/k9s/pull/607) ATTA Boy! [Jeff Widman](https://github.com/jeffwidman)
- [PR #570](https://github.com/derailed/k9s/pull/570) Thank you [Ludovico Rosso](https://github.com/ludusrusso)!

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

