### PR TITLE
eksctl 0.14.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.13.0"
+local version = "0.14.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "b2aa450e2285d79e0631ba8410c709970585b2d34c7a7e7ee17ba38de221f01e",
+            sha256 = "6bb64d9514793eea4788fd1a219223466047e5d1f02c661e9a7bc46c661bd223",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "73328372c14e8c0fb0571882a0497ee2e33d9c3d0e3d4987f035f07e4c4cd4a6",
+            sha256 = "7c670d460e7b23c55c589056b9ed034952233d65b293035cc46a706233620ce8",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "41b025473df428b934710c056a798566a2c2800a937ac2b9acd9a328dcb09d70",
+            sha256 = "3da0d3e5fbb173186b3ac8863fa0dcd2a3b96cd974050bdb305968f563c2e2be",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.14.0. 

# Release info 

 # Release 0.14.0

## Features


- Default to SSM Parameter for AMI resolution (#1814)
- Upgrade CNI version to 1.6.0 (#1824)
- Update Flux Helm operator to 1.0.0-rc9 (#1815)
- Update to core-dns:1.6.6 (#1729)
- Add NodeRole for managed group (#1747)
- Update Flux packages and migrate to Helm v3 (#1761)
- Add eksctl version tag in cloudformation (#1757)
- Support spot instances with only one instance type (#1772)
- Add tags flag in create nodegroup CLI (#1760)
- Add support for permissions Boundary (#1638)
- Added the ability to override the kube config cluster server (#1746)
- Support public/private API endpoints settings from file (#1693)

## Improvements

- Deprecate latest_release tag (#1809)
- Add integration tests for Fargate (#1792)
- Improve linting rules (#1786)
- Add example of using labels for forcing pods to run on desired node groups (#1804)
- Improve the error when resource is not known (#1776)
- Update README.md (#1794)
- Create Fargate role only if there is --fargate (#1749)
- Fix missing tags in nodegroup after scaling (#1836)

## Bug Fixes

- Fix bug in update-cluster-endpoint #1820 (#1821)
- Fix duplicate listing of subnets (#1477)
-  Fix null pointer dereference in cluster access validation (#1852)

## Acknowledgments
Weaveworks would like to sincerely thank:
@ajayk, @allanchua101,  @dholbach,   @ota42y, @paulbes, @ryotarai, @sayboras, @stefanprodan and @treacher

