### PR TITLE
hugo 0.67.1

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.67.0"
+local version = "0.67.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "520b2e27407d6785ebc0d4313634dfd7c3a21c60dfa17b7bad9523f3cb1b87cd",
+            sha256 = "8ddbc2349225663b039acbedc3894424dc6ddd10e14e0332f896a0c69ead0143",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "49679173372c13886a214c0b61e32a91a511a8460c13f8c4ae1d0cb71afacf00",
+            sha256 = "3076ecd5426f4f1e46a4ca4242bde22c9a137199e5ab93fbbefb0271d25bc52a",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "b43bd173993b07b06aba2f76592fe5e8b3b3147385526ea838d1a380738e9e94",
+            sha256 = "26691df0ec2c09bbe125b77969dd1e3da93b08c1b11b12b192cb38a47e0d8171",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.67.1. 

# Release info 

 

Some minor fixes:

* metrics: Fix --templateMetricsHints [5eadc4c0](https://github.com/gohugoio/hugo/commit/5eadc4c0a8e5c51e72670591c4b7877e79c15e3c) [@bep](https://github.com/bep) [#7048](https://github.com/gohugoio/hugo/issues/7048)
* resources: Add data context to the key in ExecuteAsTemplate [18cb21ff](https://github.com/gohugoio/hugo/commit/18cb21ff2e4a60e7094908e4d6113a9d5a086316) [@bep](https://github.com/bep) [#7046](https://github.com/gohugoio/hugo/issues/7046)
* Improve Tailwind/PostCSS error messages [df298558](https://github.com/gohugoio/hugo/commit/df298558a5a5b747288d9656402af85e0ac75a43) [@bep](https://github.com/bep) [#7041](https://github.com/gohugoio/hugo/issues/7041)[#7042](https://github.com/gohugoio/hugo/issues/7042)
* deps: Update Blackfriday [b1106f87](https://github.com/gohugoio/hugo/commit/b1106f8715cac3544b8ea662b969336fe56fa047) [@bep](https://github.com/bep) [#7039](https://github.com/gohugoio/hugo/issues/7039)
* resources: Try to fix a Go 1.15 go vet error [c0177fe2](https://github.com/gohugoio/hugo/commit/c0177fe2b28eb09d1534e62370849c3f1d70b40f) [@bep](https://github.com/bep) 
* Add languageDirection to language configuration [5914f91b](https://github.com/gohugoio/hugo/commit/5914f91b6c980e42693661d5fd5640e237691df6) [@le0tan](https://github.com/le0tan) [#6550](https://github.com/gohugoio/hugo/issues/6550)




