### PR TITLE
aks-engine 0.48.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.47.0"
+local version = "0.48.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "34ee90e14ab35343a7a7e7f88a6b741f899b53331524e25b8af8fddbe5dec2ab",
+            sha256 = "21648ccfb0083f2025e3281659be89bf1844b88b051300771625aa5d6b781b5b",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "2f61400cad9c25f5a2c0e62bb47bc6fcdcaaa8301342d28f1a5be8498c227fd1",
+            sha256 = "c8c1095543702b3f3872dfe6af275fd2ac3ab88c75c72aaae9b6248d37a85847",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "064be8ec4fa3e26de3e358d59e7f39aa6ef89d50dadb55305c0c7800d4eed966",
+            sha256 = "caf6c60cb82fc61954e274d5b58881165ea1cc02c010f82b0cf3cf734576a016",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.48.0. 

# Release info 

 <a name="v0.48.0"></a>
# [v0.48.0] - 2020-03-20
### Bug Fixes 🐞
- $ERR_SYSTEMCTL_STOP_FAIL VHD CI errata ([#2934](https://github.com/Azure/aks-engine/issues/2934))
- use ntp instead of systemd-timesyncd in 18.04 ([#2815](https://github.com/Azure/aks-engine/issues/2815))
- use explicit kubeconfig in label-nodes.sh ([#2929](https://github.com/Azure/aks-engine/issues/2929))
- check network from node to k8s api server in CSE ([#2919](https://github.com/Azure/aks-engine/issues/2919))
- parse SGX driver url and compare checksum ([#2914](https://github.com/Azure/aks-engine/issues/2914))
- do not remove VMAS resources from template when adding a VMAS pool ([#2907](https://github.com/Azure/aks-engine/issues/2907))
- scale cannot find VM index for the VMAS+VHD+Linux case ([#2906](https://github.com/Azure/aks-engine/issues/2906))
- honor custom{component}Image fields ([#2886](https://github.com/Azure/aks-engine/issues/2886))
- apply_network_config: false for 18.04-LTS ([#2908](https://github.com/Azure/aks-engine/issues/2908))
- ensure label-nodes systemd service can be enabled ([#2915](https://github.com/Azure/aks-engine/issues/2915))
- add validation for new AKS engine Windows Version ([#2896](https://github.com/Azure/aks-engine/issues/2896))
- fixing nssm logging in windows CSE ([#2890](https://github.com/Azure/aks-engine/issues/2890))
- Windows no outbound fixes ([#2883](https://github.com/Azure/aks-engine/issues/2883))
- Do not remove patched hyperkube image in cleanUpContainerImages ([#2878](https://github.com/Azure/aks-engine/issues/2878))
- make master availabilityProfile an optional field for Azure Stack ([#2866](https://github.com/Azure/aks-engine/issues/2866))
- install cracklib-runtime on ubuntu ([#2871](https://github.com/Azure/aks-engine/issues/2871))
- address containerd errata ([#2865](https://github.com/Azure/aks-engine/issues/2865))
- update EncryptionConfiguration to latest ([#2856](https://github.com/Azure/aks-engine/issues/2856))
- explicitly set kubeconfig when using KUBECTL in CSE ([#2847](https://github.com/Azure/aks-engine/issues/2847))
- update sgx driver download urls ([#2807](https://github.com/Azure/aks-engine/issues/2807))
- update yaml.v2 and golangci-lint for go 1.14 compatibility ([#2824](https://github.com/Azure/aks-engine/issues/2824))
- fix the CNI temp file URL parsing in CSE ([#2817](https://github.com/Azure/aks-engine/issues/2817))
- override components image config during upgrade ([#2814](https://github.com/Azure/aks-engine/issues/2814))
- kube-proxy uses custom hyperkube on Azure Stack ([#2806](https://github.com/Azure/aks-engine/issues/2806))
- use non-reserved exit codes for bcc/bpf install ([#2785](https://github.com/Azure/aks-engine/issues/2785))
- components works with Azure Stack ([#2775](https://github.com/Azure/aks-engine/issues/2775))
- apiserver broken due to incorrect kms cachesize ([#2769](https://github.com/Azure/aks-engine/issues/2769))
- only configAddons if addons enabled ([#2774](https://github.com/Azure/aks-engine/issues/2774))
- support Azure containerd install in Debian ([#2766](https://github.com/Azure/aks-engine/issues/2766))
- Set vnetCidr by the address space of the vnet ([#2725](https://github.com/Azure/aks-engine/issues/2725))
- init Azure clients consistently ([#2739](https://github.com/Azure/aks-engine/issues/2739))
- update apiserver encryption provider config flag ([#2727](https://github.com/Azure/aks-engine/issues/2727))
- Adding skuLongSummary to sku template publishing file to unblock publishing pipeline ([#2729](https://github.com/Azure/aks-engine/issues/2729))
- remove requirement for ldflags or make test ([#2724](https://github.com/Azure/aks-engine/issues/2724))
- Set WindowsSku and ImageVersion by publisher and offer in creating ([#2689](https://github.com/Azure/aks-engine/issues/2689))
- update to use single omsagent yaml for all k8s versions to avoid any manual errors and easy maintainbility ([#2692](https://github.com/Azure/aks-engine/issues/2692))
- raising dynamic port range for windows to better support clusters with 200+ services ([#2688](https://github.com/Azure/aks-engine/issues/2688))
- unknown ostype when getting an index should probably create an error ([#2681](https://github.com/Azure/aks-engine/issues/2681))

### Build 🏭
- Publish junit test results to pipeline ([#2664](https://github.com/Azure/aks-engine/issues/2664))
- fetch k8s Windows .zip from kubernetesartifacts storage ([#2655](https://github.com/Azure/aks-engine/issues/2655))

### Code Refactoring 💎
- add KubernetesImageBaseType ([#2711](https://github.com/Azure/aks-engine/issues/2711))
- user-configurable components ([#2540](https://github.com/Azure/aks-engine/issues/2540))
- put Azure DC/OS SKUs list in a separate source file ([#2706](https://github.com/Azure/aks-engine/issues/2706))
- put Azure locations list in a separate source file ([#2705](https://github.com/Azure/aks-engine/issues/2705))

### Continuous Integration 💜
- stop testing k8s 1.13 ([#2749](https://github.com/Azure/aks-engine/issues/2749))

### Documentation 📘
- ubuntu-18.04-gen2 distro ([#2917](https://github.com/Azure/aks-engine/issues/2917))
- fixed large clusters doc page ([#2826](https://github.com/Azure/aks-engine/issues/2826))
- add CSE example in upgrade do-not-dos ([#2795](https://github.com/Azure/aks-engine/issues/2795))
- adding Kalya to OWNERS ([#2793](https://github.com/Azure/aks-engine/issues/2793))
- add data collection (telemetry) notice to readme ([#2674](https://github.com/Azure/aks-engine/issues/2674))
- proposal for Azure locations + SKUs automation ([#2694](https://github.com/Azure/aks-engine/issues/2694))

### Features 🌈
- installing csi-proxy for windows at node deployment time ([#2930](https://github.com/Azure/aks-engine/issues/2930))
- add UltraSSD support ([#2905](https://github.com/Azure/aks-engine/issues/2905))
- add support for Kubernetes 1.17.4 ([#2899](https://github.com/Azure/aks-engine/issues/2899))
- add support for Kubernetes 1.15.11 ([#2897](https://github.com/Azure/aks-engine/issues/2897))
- add support for Kubernetes 1.16.8 ([#2898](https://github.com/Azure/aks-engine/issues/2898))
- configurable sysctl.d configuration ([#2880](https://github.com/Azure/aks-engine/issues/2880))
- upgrade control plane only ([#2635](https://github.com/Azure/aks-engine/issues/2635))
- allow iptables mode for dualstack 1.18+ ([#2882](https://github.com/Azure/aks-engine/issues/2882))
- update containermonitoring addon for february 2020 release ([#2850](https://github.com/Azure/aks-engine/issues/2850))
- collect Windows CSE logs during log collection ([#2858](https://github.com/Azure/aks-engine/issues/2858))
- add support for single stack IPv6 ([#2781](https://github.com/Azure/aks-engine/issues/2781))
- Experimental support for Windows+ContainerD ([#1322](https://github.com/Azure/aks-engine/issues/1322))
- add support for Kubernetes 1.15.10, 1.16.6 & 1.16.7 on Azure Stack ([#2834](https://github.com/Azure/aks-engine/issues/2834))
- release Windows VHD with 2C updates ([#2809](https://github.com/Azure/aks-engine/issues/2809))
- Add IsCredentialAutoGenerated for WindowsProfile ([#2804](https://github.com/Azure/aks-engine/issues/2804))
- "aks-engine get-locations" command ([#2771](https://github.com/Azure/aks-engine/issues/2771))
- add support for Kubernetes 1.18.0-beta.1 ([#2791](https://github.com/Azure/aks-engine/issues/2791))
- feb windows updated ([#2786](https://github.com/Azure/aks-engine/issues/2786))
- update pause image to 1.3.0 (includes 1903 and 1909 support) ([#2757](https://github.com/Azure/aks-engine/issues/2757))
- add support for Kubernetes 1.18.0-alpha.5 ([#2748](https://github.com/Azure/aks-engine/issues/2748))
- enable MCR KubernetesImageBaseType ([#2722](https://github.com/Azure/aks-engine/issues/2722))
- add support for Kubernetes 1.18.0-alpha.3 ([#2682](https://github.com/Azure/aks-engine/issues/2682))
- add template/options for using Shared Image Gallery ([#2687](https://github.com/Azure/aks-engine/issues/2687))
- Adding WindowsNodeReset.ps1 script to reset/cleanup state for nodes ([#2457](https://github.com/Azure/aks-engine/issues/2457))
- install bcc tools by default ([#2683](https://github.com/Azure/aks-engine/issues/2683))
- updating windows VHD for Feb k8s versions ([#2731](https://github.com/Azure/aks-engine/issues/2731))
- add support for Kubernetes 1.15.10 ([#2709](https://github.com/Azure/aks-engine/issues/2709))
- add support for Kubernetes 1.16.7 ([#2710](https://github.com/Azure/aks-engine/issues/2710))
- add support for Kubernetes 1.17.3 ([#2707](https://github.com/Azure/aks-engine/issues/2707))
- abort/warn if apimodel contains properties not supported by Azure Stack ([#2717](https://github.com/Azure/aks-engine/issues/2717))
- adding mcr.microsoft.com/oss/kubernetes/pause:1.3.0 to windows VHD ([#2702](https://github.com/Azure/aks-engine/issues/2702))
- read vm size from instance metadata service for windows cse telemetry ([#2663](https://github.com/Azure/aks-engine/issues/2663))
- multi AI telemetry keys ([#2606](https://github.com/Azure/aks-engine/issues/2606))

### Maintenance 🔧
- rev Linux VHDs to 2020.03.19 ([#2939](https://github.com/Azure/aks-engine/issues/2939))
- improve --client-id flag validation message ([#2935](https://github.com/Azure/aks-engine/issues/2935))
- rev default Kubernetes version to 1.15 ([#2932](https://github.com/Azure/aks-engine/issues/2932))
- new Kubernetes versions for Linux VHDs ([#2894](https://github.com/Azure/aks-engine/issues/2894))
- updating windows VHD to include 3B patches + march k8s packages ([#2902](https://github.com/Azure/aks-engine/issues/2902))
- update cluster-autoscaler for k8s 1.18 ([#2901](https://github.com/Azure/aks-engine/issues/2901))
- optimize CSE payload ([#2891](https://github.com/Azure/aks-engine/issues/2891))
- pre-install the version of apmz in CSE ([#2889](https://github.com/Azure/aks-engine/issues/2889))
- Bump moby to 3.0.11 ([#2887](https://github.com/Azure/aks-engine/issues/2887))
- don't re-run provision.sh if already called.  ([#2843](https://github.com/Azure/aks-engine/issues/2843))
- update default to recommended cluster settings on Azure Stack ([#2861](https://github.com/Azure/aks-engine/issues/2861))
- don't require azure.json on node vms ([#2849](https://github.com/Azure/aks-engine/issues/2849))
- update cni-plugins to v0.8.5 ([#2841](https://github.com/Azure/aks-engine/issues/2841))
- default to large cluster settings on Azure Stack ([#2832](https://github.com/Azure/aks-engine/issues/2832))
- update Azure CNI to v1.0.33 ([#2825](https://github.com/Azure/aks-engine/issues/2825))
- force image base to MCR if target cloud is Azure Stack ([#2802](https://github.com/Azure/aks-engine/issues/2802))
- update node-problem-detector to v0.8.1 ([#2808](https://github.com/Azure/aks-engine/issues/2808))
- pre-pull addon images hosted in MCR ([#2800](https://github.com/Azure/aks-engine/issues/2800))
- Update the containerd config ([#2780](https://github.com/Azure/aks-engine/issues/2780))
- Adding 2C patches to windows VHD which addresses some networking issues ([#2796](https://github.com/Azure/aks-engine/issues/2796))
- adding azure-cni v1.0.33 artifacts to VHDs ([#2790](https://github.com/Azure/aks-engine/issues/2790))
- rationalize AKS Engine VHD config ([#2755](https://github.com/Azure/aks-engine/issues/2755))
- update coredns to 1.6.7 ([#2783](https://github.com/Azure/aks-engine/issues/2783))
- update cluster-autoscaler for 1.15 and 1.16 ([#2776](https://github.com/Azure/aks-engine/issues/2776))
- bump keyvault-flexvol to v0.0.16 ([#2760](https://github.com/Azure/aks-engine/issues/2760))
- use MCR URI to validate outbound connectivity ([#2761](https://github.com/Azure/aks-engine/issues/2761))
- use azure containerd packages ([#2649](https://github.com/Azure/aks-engine/issues/2649))
- installing Docker EE 19.03.5 by default in Windows VHD ([#2751](https://github.com/Azure/aks-engine/issues/2751))
- update image base for windows vhd ([#2742](https://github.com/Azure/aks-engine/issues/2742))
- cse cleanup ([#2746](https://github.com/Azure/aks-engine/issues/2746))
- apply large ipv3 neigh GC settings to nodes of all sizes ([#2732](https://github.com/Azure/aks-engine/issues/2732))
- update cluster-autoscaler to 1.17.1 ([#2730](https://github.com/Azure/aks-engine/issues/2730))
- use k8s 1.17 for e2e tests in windows vhd pipeline ([#2719](https://github.com/Azure/aks-engine/issues/2719))
- gofmt to avoid lint errors ([#2699](https://github.com/Azure/aks-engine/issues/2699))
- Add ProgressPreference=SilentlyContinue to disable progress bar ([#2693](https://github.com/Azure/aks-engine/issues/2693))
### Testing 💚
- simplified availabilityset E2E cluster config ([#2926](https://github.com/Azure/aks-engine/issues/2926))
- skip node ready test after scale down ([#2921](https://github.com/Azure/aks-engine/issues/2921))
- better skip test implementation ([#2924](https://github.com/Azure/aks-engine/issues/2924))
- only use 1 node per pool in no outbound test ([#2922](https://github.com/Azure/aks-engine/issues/2922))
- create functions in network policy specific file and let tests call it. ([#2904](https://github.com/Azure/aks-engine/issues/2904))
- add test config to use gen2 images for agent pools ([#2893](https://github.com/Azure/aks-engine/issues/2893))
- working Windows containerd URLs ([#2885](https://github.com/Azure/aks-engine/issues/2885))
- Add default deny egress test for net work policy. ([#2872](https://github.com/Azure/aks-engine/issues/2872))
- don't count nodes, just look for labels ([#2884](https://github.com/Azure/aks-engine/issues/2884))
- run node labels test later ([#2876](https://github.com/Azure/aks-engine/issues/2876))
- remove apiserver from master test ([#2875](https://github.com/Azure/aks-engine/issues/2875))
- improved master/agent pod validation ([#2797](https://github.com/Azure/aks-engine/issues/2797))
- reorder E2E tests ([#2784](https://github.com/Azure/aks-engine/issues/2784))
- get pod network info if dns validation fails ([#2778](https://github.com/Azure/aks-engine/issues/2778))
- add deployment stability tests ([#2767](https://github.com/Azure/aks-engine/issues/2767))
- configurable CONTAINER_RUNTIME via E2E ([#2753](https://github.com/Azure/aks-engine/issues/2753))
- remove non-working SGX E2E cluster config ([#2744](https://github.com/Azure/aks-engine/issues/2744))
- add LB_TEST_TIMEOUT default ([#2703](https://github.com/Azure/aks-engine/issues/2703))
- enable configurable LoadBalancer test timeout ([#2700](https://github.com/Azure/aks-engine/issues/2700))
- curl as a stability test client ([#2697](https://github.com/Azure/aks-engine/issues/2697))
- don't get vms before resource group exists ([#2696](https://github.com/Azure/aks-engine/issues/2696))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.48.0...HEAD
[v0.48.0]: https://github.com/Azure/aks-engine/compare/v0.47.0...v0.48.0