### PR TITLE
k9s 0.18.0

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,7 +1,7 @@
 local name = "k9s"
 local org = "derailed"
-local release = "v0.17.7"
-local version = "0.17.7"
+local release = "v0.18.0"
+local version = "0.18.0"
 food = {
     name = name,
     description = "🐶 Kubernetes CLI To Manage Your Clusters In Style!",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "2fa61e6d14edb5b99b4fd1012610edd64057fde2580348fa2948ef7fde77ba7e",
+            sha256 = "cfebd1c0bca9ac08492c438dae957308446206ccbf846daa974808ea6d924c0c",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "b3330c86046922c1d09a03887fac73408be91378bad1aaaeb1d0086444aa29d1",
+            sha256 = "d35e518e275189cd7ce6ede17dc847741af2908255e175e7c87ca29582daba15",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "a2bdad476932bb4db1e36aa0c8635f4aaf9e67de6d978c1c58bc751cf5553c9b",
+            sha256 = "510feacb3e935f4eadb6fff8787ed46ec4075033008baf6b6ef63e86753a1d68",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.18.0. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.18.0

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better is as ever very much noticed and appreciated!

Also if you dig this tool, please consider sponsoring 👆us or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

---

## GH Sponsors

Big `ThankYou` to the following folks that I've decided to dig in and give back!! 👏🙏🎊
Thank you for your gesture of kindness and for supporting K9s!!

* [Bob Johnson](https://github.com/bbobjohnson)
* [Poundex](https://github.com/Poundex)
* [thllxb](https://github.com/thllxb)

If you've contributed $25 or more please reach out to me on slack with your earth coordinates so I can send you your K9s swags!

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/shirts/k9s_front.png" align="center" width="auto" height="100"/>
<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/shirts/k9s_back.png" align="center" width="auto" height="100"/>

NOTE: I am one not to pressure folks into giving. However, it does make me sad to see postings out there with clear indications that K9s is being used and yet zero mentions of the web site nor this repo. K9s marketing budget relies entirely on word of mouth and is not pimped out by big corps. So if you publish your work and leverage K9s, please give us a shoutout or at the very least reference this repo or website!

---

## AutoSuggestions

K9s command mode now provides for auto complete. Suggestions are pulled from available kubernetes resources and custom aliases. The command mode supports the following keyboard triggers:

| Key                 | Description                              |
|---------------------|------------------------------------------|
| ⬆️ ⬇️               | Navigate up or down thru the suggestions |
| `Ctrl-w`, `Ctrl-u`  | Clear out the command                    |
| `Tab`, `Ctrl-f`, ➡️ | Accept the suggestion                    |

## Logs Revisited

Breaking Change! This drop changes how logs are viewed and configured. The log view now support for pulling logs based on the log timeline current settings are: all, 1m, 5m, 15m and 1h. The following log configuration is in effect as of this drop:

```yaml
# $HOME/.k9s/config.yml
k9s:
  refreshRate: 2
  readOnly: false
  # NOTE: New logger configuration!
  logger:
    tail:          200 # Tail the last 100 lines. Default 100
    buffer:       5000 # Max number of lines displayed in the view. Default 1000
    sinceSeconds:  900 # Displays the last x seconds from the logs timeline. Default 5m
  ...
```

## Resolved Bugs/Features/PRs

* [Issue #628](https://github.com/derailed/k9s/issues/628)
* [Issue #623](https://github.com/derailed/k9s/issues/623)
* [Issue #622](https://github.com/derailed/k9s/issues/622)
* [Issue #565](https://github.com/derailed/k9s/issues/565)

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

