### PR TITLE
istioctl 1.5.1

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,7 +1,7 @@
 local name = "istioctl"
 local org = "istio"
-local release = "1.5.0"
-local version = "1.5.0"
+local release = "1.5.1"
+local version = "1.5.1"
 food = {
     name = name,
     description = "Connect, secure, control, and observe services.",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "0955bdb68ac77ebe550bc26e39586f7831988c47ad24539b46602ca21a0ca149",
+            sha256 = "df6d05201186b8ff831d3a4b6796bc5144e11f030b46bef7757437d79df23b21",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-linux.tar.gz",
-            sha256 = "fba603390074b1b9da9b3bd1492a278740fe725ac8ff07b8ec54fb7d66e03c33",
+            sha256 = "cbaf9c76a75e2585bd3444e96bf64c29b31165981a4dc4a24faf7a34d9f9de01",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "e468cd757130f1f204294699ab130db04fe958158d00b258bc49b0c0d7fc0285",
+            sha256 = "02e03413ec6e70569d37390ee063580d65d97de186d6da039eccc9a35c470549",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.5.1. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.5.1/)
[Release Notes](https://istio.io/news/announcing-1.5.1/)