### PR TITLE
kubebuilder 2.3.1

### DIFF
--- a/Food/kubebuilder.lua
+++ b/Food/kubebuilder.lua
@@ -1,7 +1,7 @@
 local name = "kubebuilder"
 local org = "kubernetes-sigs"
-local release = "v2.3.0"
-local version = "2.3.0"
+local release = "v2.3.1"
+local version = "2.3.1"
 food = {
     name = name,
     description = "Kubebuilder - SDK for building Kubernetes APIs using CRDs",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "b44f6c7ba1edf0046354ff29abffee3410d156fabae6eb3fa62da806988aa8bd",
+            sha256 = "39314d45053b6c31eb17e35c9b8d923f8a38277a9a136448345dd4b7f0f308f4",
             resources = {
                 {
                     path = name .. "_" .. version .. "_darwin_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "a8ffea619f8d6e6c9fab2df8543cf0912420568e3979f44340a7613de5944141",
+            sha256 = "ff496970f209706763f2aba2bdcefc2de8d00085b3b972b5790117b59ea4ed10",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,


### PR DESCRIPTION
Updating package kubebuilder to release v2.3.1. 

# Release info 

 ## Changelog

39a45e32 :book: document how to udpate kubebuilder book
18fb3514 :book: note multiversion kubectl behavior
46e9db0d Add Adirio as a reviewer
60deebbd Add logos to book
8b726b00 Added explanatory note about the index
ec671a54 Clarifying a sentence re: backwards compatability
b2a1f45e Delegate config checks to the config model
43c42a56 Include the missing envtest import.
7d747cf2 add mock testdata for plugins with --pattern=addon
6c89111f bump kube-rbac-proxy to v0.5.0
5c754a31 declarative pattern: Support cluster scoped types
231408ea fix pattern addon template
095ce7bc fix: master branch broken ci - update testdata
b70e9ca4 improvements for contributors
3e39118a internal/config/config.go: use DefaultVersion instead of version string directly
