### PR TITLE
crictl 1.18.0

### DIFF
--- a/Food/crictl.lua
+++ b/Food/crictl.lua
@@ -1,5 +1,5 @@
 local name = "crictl"
-local version = "1.17.0"
+local version = "1.18.0"
 local repo = "cri-tools"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "7b72073797f638f099ed19550d52e9b9067672523fc51b746e65d7aa0bafa414",
+            sha256 = "876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "e18150d5546d3ddf6b165bd9aec0f65c18aacf75b94fb28bb26bfc0238f07b28",
+            sha256 = "5045bcc6d8b0e6004be123ab99ea06e5b1b2ae1e586c968fcdf85fccd4d67ae1",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package crictl to release v1.18.0. 

# Release info 

 cri-tools v1.18.0 mainly focuses on bug fixes and stability improvements.

# Main Changes

- [#579](https://github.com/kubernetes-sigs/cri-tools/pull/579) Update Kubernetes to v1.18.0
- [#559](https://github.com/kubernetes-sigs/cri-tools/pull/559) Switch to urfave/cli/v2

# CRI CLI (crictl)

- [#581](https://github.com/kubernetes-sigs/cri-tools/pull/581) Use ContextDialer to fix build
- [#575](https://github.com/kubernetes-sigs/cri-tools/pull/575) Add go-template option for inspect commands
- [#570](https://github.com/kubernetes-sigs/cri-tools/pull/570) Fix invalid `log_path` in docs

# CRI validation testing (critest)

- [#576](https://github.com/kubernetes-sigs/cri-tools/pull/576) Make apparmor failure test more flexible
- [#574](https://github.com/kubernetes-sigs/cri-tools/pull/574) Start container before fetching metrics
- [#567](https://github.com/kubernetes-sigs/cri-tools/pull/567) Cleanup container create test to reduce duplication
- [#566](https://github.com/kubernetes-sigs/cri-tools/pull/566) Add container stats test

## Downloads

| file                                                                                                                                                | sha256                                                           |
| --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [crictl-v1.18.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-386.tar.gz)           | a1aaf482928d0a19aabeb321e406333c5ddecf77a532f7ec8c0bd6ca7014101e |
| [crictl-v1.18.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-amd64.tar.gz)       | 876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a |
| [crictl-v1.18.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-arm.tar.gz)           | d420925d10b47a234b7e51e9cf1039c3c09f2703945a99435549fcdd7487ae3a |
| [crictl-v1.18.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-arm64.tar.gz)       | 95ba32c47ad690b1e3e24f60255273dd7d176e62b1a0b482e5b44a7c31639979 |
| [crictl-v1.18.0-linux-ppc64le.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-ppc64le.tar.gz)   | 53a1fedbcee37f5d6c9480d21a9bb17f1c0214ffe7b640e39231a59927a665ef |
| [crictl-v1.18.0-linux-s390x.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-linux-s390x.tar.gz)       | 114c8885a7eeb43bbe19baaf23c04a5761d06330ba8e7aa39a3a15c2051221f1 |
| [crictl-v1.18.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-windows-386.tar.gz)       | f37e8b5c499fb5a2bd06668782a7dc34e5acf2fda6d1bfe8f0ea9c773359a378 |
| [crictl-v1.18.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/crictl-v1.18.0-windows-amd64.tar.gz)   | 5045bcc6d8b0e6004be123ab99ea06e5b1b2ae1e586c968fcdf85fccd4d67ae1 |
| [critest-v1.18.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-linux-386.tar.gz)         | 484d2e73a76254e3d2f5e682e69fc642c2a0785000fc73c66ae18cde83373c36 |
| [critest-v1.18.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-linux-amd64.tar.gz)     | 23968677bdf5d4055e5118c85449b19b046ee1d8822cae5859b7a4a80c2f1955 |
| [critest-v1.18.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-linux-arm.tar.gz)         | a1b32339a32db39f84869eccf5f2058211c14f12b2085490358aac88a8c3307f |
| [critest-v1.18.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-linux-arm64.tar.gz)     | da5a7590489239754ad35dfa58b0c6f00e6de920fe28a4f63744b1fe1f173d8d |
| [critest-v1.18.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-windows-386.tar.gz)     | 52951f32baa9bcd00c77e45ca54ef13814b89887efdea325b214c4362191c68a |
| [critest-v1.18.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.18.0/critest-v1.18.0-windows-amd64.tar.gz) | 49ba51f9ff8e767a5d4aa7b4c7c0f35cddabfd02700b973685a4fac8855d035c |
