### PR TITLE
minikube 1.9.1

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.9.0"
-local version = "1.9.0"
+local release = "v1.9.1"
+local version = "1.9.1"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "2a074b0d842e3d9272444990374c6ffc51878c2d11c0434f54e15269b59593f9",
+            sha256 = "ac8855ea54e798fa6f00e8c251b55c3d2a54e3b80e896162958a5ac7b0e3f60b",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "81d77d1babe63be393e0a3204aac7825eb35e0fdf58ffefd9f66508a43864866",
+            sha256 = "7174c881289a7302a05d477c67cc1ef5b48153e825089d6c0d0bcfaebe33d42a",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "d11a957704c23670eac453a47897449a2aaab13b7dcd6424307f8932ac9f81bb",
+            sha256 = "91d15b2ef8f357aa463ae16de59f6e018120398f492ba4e35cd77f21acb27d5c",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package minikube to release v1.9.1. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.9.1 - 2020-04-02

Improvements:

* add delete-on-failure flag [#7345](https://github.com/kubernetes/minikube/pull/7345)
* Run dashboard with internal kubectl if not in path [#7299](https://github.com/kubernetes/minikube/pull/7299)
* Implement options for the minikube version command [#7325](https://github.com/kubernetes/minikube/pull/7325)
* service list cmd: display target port and name  [#6879](https://github.com/kubernetes/minikube/pull/6879)
* Add rejection reason to 'unable to find driver' error [#7379](https://github.com/kubernetes/minikube/pull/7379)
* Update Japanese translations [#7359](https://github.com/kubernetes/minikube/pull/7359)

Bug fixes:

* Make eviction and image GC settings consistent across kubeadm API versions [#7364](https://github.com/kubernetes/minikube/pull/7364)
* Move errors and warnings to output to stderr [#7382](https://github.com/kubernetes/minikube/pull/7382)
* Correct assumptions for forwarded hostname & IP handling [#7360](https://github.com/kubernetes/minikube/pull/7360)
* Extend maximum stop retry from 30s to 120s [#7363](https://github.com/kubernetes/minikube/pull/7363)
* Use kubectl version --short if --output=json fails [#7356](https://github.com/kubernetes/minikube/pull/7356)
* Fix embed certs by updating kubeconfig after certs are populated [#7309](https://github.com/kubernetes/minikube/pull/7309)
* none: Use LookPath to verify conntrack install [#7305](https://github.com/kubernetes/minikube/pull/7305)
* Show all global flags in options command [#7292](https://github.com/kubernetes/minikube/pull/7292)
* Fix null deref in start host err [#7278](https://github.com/kubernetes/minikube/pull/7278)
* Increase Docker "slow" timeouts to 15s [#7268](https://github.com/kubernetes/minikube/pull/7268)
* none: check for docker and root uid [#7388](https://github.com/kubernetes/minikube/pull/7388)

Thank you to our contributors for this release!

- Anders F Björklund
- Dan Lorenc
- Eberhard Wolff
- John Laswell
- Marcin Niemira
- Medya Ghazizadeh
- Prasad Katti
- Priya Wadhwa
- Sharif Elgamal
- Thomas Strömberg
- Vincent Link
- anencore94
- priyawadhwa
- re;i
- tomocy

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`c161e8ffdbc8d7cc92c2f57809bf846ff73996f06bc6a757bef518b3acce5b47`