### PR TITLE
helmfile 0.108.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.106.3"
+local version = "0.108.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "1c6fc33bc99eea34b0194820f362cea11a2da7f203323b1f7f6b1ecde9c91db2",
+            sha256 = "8de1030f9ed5f5ddb848acea7984a10c951f8fa897941a0bf39223c51c15bb3c",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "0a79c98314d2e3abee98f6ea41075e739f0bc652d13e5c8851b272d55765a2fc",
+            sha256 = "65f3811b6d876cecaa021bbcd0b7516a808fdb359019694720cdb15b4874c2a3",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "1a61d9d8d4075866b1e263b6f9cc7715b278c932b88f7c13f1c6adc5dd223b0f",
+            sha256 = "d1432b2d7a44fb738dd52ba6caceae10cac167b91e74c8073dbdfcd0867db989",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "cea2e6c5b0c9de90df4e03c56a01535f1f334b114202d3bcde6be765a54e1d99",
+            sha256 = "06c63f3f551cc7b8fa1b5b741ff9ab1a91b612f3093d98651fe702333cbdcfb7",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "40a3f678e8dfc238326371efb77f5d8e5a040477cc4aee467743185258523dc9",
+            sha256 = "4e78386f23771f74b398bae76825928b43ad699a018f13f271a2c013490299ad",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "4e4fc5b473c4b1f5a66ed08f60894f7ffe03a81cfa93522c4e2c287bc0426ac9",
+            sha256 = "c82ad08ccbabfc7a01a51e96a42edb3e75c02cce16d81238edc96e0a91c81fce",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.108.0. 

# Release info 

 71635ca (HEAD, tag: v0.108.0, origin/master, origin/HEAD, master) feat: add option `--include-tests` for diff and apply command (#1179)
486be09 Bump vals to 0.3.0 (#1175) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/4514)