### PR TITLE
aks-engine 0.49.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.48.0"
+local version = "0.49.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "21648ccfb0083f2025e3281659be89bf1844b88b051300771625aa5d6b781b5b",
+            sha256 = "da456318add621494e887c64f942dd4b1ad3966385db6921688a1343da7672a8",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "c8c1095543702b3f3872dfe6af275fd2ac3ab88c75c72aaae9b6248d37a85847",
+            sha256 = "43558ac81d42e3a8fa71f4b144a50c5b94be809b0eed29b32e49460272b2904d",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "caf6c60cb82fc61954e274d5b58881165ea1cc02c010f82b0cf3cf734576a016",
+            sha256 = "37aac602cebd91d2ab2e6f44ccafd518b33245d4e6cd706784809f0702d07c25",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.49.0. 

# Release info 

 <a name="v0.49.0"></a>
# [v0.49.0] - 2020-04-11
### Bug Fixes 🐞
- make sure nvidia utility and compute bins can be mounted into co… ([#3029](https://github.com/Azure/aks-engine/issues/3029))
- the os disk size restriction is changed in azure. ([#3043](https://github.com/Azure/aks-engine/issues/3043))
- remove unnecessary apt lock waits ([#3049](https://github.com/Azure/aks-engine/issues/3049))
- In case of api server connection error, still complete script ([#3022](https://github.com/Azure/aks-engine/issues/3022))
- disable unattended upgrades during CSE execution ([#1681](https://github.com/Azure/aks-engine/issues/1681))
- don't download collectlogs.ps1 if it exists ([#3006](https://github.com/Azure/aks-engine/issues/3006))
- add node selector for csi-secrets-store ds ([#3007](https://github.com/Azure/aks-engine/issues/3007))
- check dns status before connection ([#3002](https://github.com/Azure/aks-engine/issues/3002))
- make build with go 1.14 ([#3005](https://github.com/Azure/aks-engine/issues/3005))
- change gatekeeper namespace in azure-policy addon ([#2991](https://github.com/Azure/aks-engine/issues/2991))
- each apiserver process listens on its own IP address ([#2953](https://github.com/Azure/aks-engine/issues/2953))
- use same cluster-autoscaler version in MCR ([#2981](https://github.com/Azure/aks-engine/issues/2981))
- use upstreamartifacts CDN URL for apmz ([#2962](https://github.com/Azure/aks-engine/issues/2962))
- add NVv3 series to NVidia driver install list ([#2959](https://github.com/Azure/aks-engine/issues/2959))
- check network to k8s api for vmss ([#2938](https://github.com/Azure/aks-engine/issues/2938))
- Get WindowsVersion from registry instead of calling Get-ComputerInfo ([#2954](https://github.com/Azure/aks-engine/issues/2954))

### Code Refactoring 💎
- retry nvidia drivers installation ([#3031](https://github.com/Azure/aks-engine/issues/3031))
- cse_install.sh for VHD reqs ([#3016](https://github.com/Azure/aks-engine/issues/3016))
- store CSE exit codes in code ([#3012](https://github.com/Azure/aks-engine/issues/3012))
- Parse sgx dcap version file, enable checksum ([#2942](https://github.com/Azure/aks-engine/issues/2942))

### Code Style 🎶
- format CSE scripts consistently ([#3020](https://github.com/Azure/aks-engine/issues/3020))

### Continuous Integration 💜
- new VHD pipeline definition for Ubuntu + gen2 images ([#2958](https://github.com/Azure/aks-engine/issues/2958))
### Documentation 📘
- update `aks-engine deploy` example output ([#3019](https://github.com/Azure/aks-engine/issues/3019))
- include Basic LB SKU limitations in Azure Stack page ([#2988](https://github.com/Azure/aks-engine/issues/2988))
- update examples location for zh docs ([#2920](https://github.com/Azure/aks-engine/issues/2920))

### Features 🌈
- Allow specifying Distro and ImageRef at the same time ([#3052](https://github.com/Azure/aks-engine/issues/3052))
- default to MCR for Kubernetes images ([#3046](https://github.com/Azure/aks-engine/issues/3046))
- add support for Kubernetes 1.18.1 ([#3045](https://github.com/Azure/aks-engine/issues/3045))
- EncryptionAtHost support ([#3041](https://github.com/Azure/aks-engine/issues/3041))
- allow mixed mode Availability Zone configuration ([#3032](https://github.com/Azure/aks-engine/issues/3032))
- "aks-engine get-skus" command ([#2772](https://github.com/Azure/aks-engine/issues/2772))
- disable unneeded message-of-the-day sections ([#3000](https://github.com/Azure/aks-engine/issues/3000))
- deprecate kata-containers ([#3014](https://github.com/Azure/aks-engine/issues/3014))
- adding kubelet and csi-proxy-server as windows defender excluded processes ([#2967](https://github.com/Azure/aks-engine/issues/2967))
- add ability to use pre-existing user assigned MSI ([#2960](https://github.com/Azure/aks-engine/issues/2960))
- etcd metrics URL ([#2989](https://github.com/Azure/aks-engine/issues/2989))
- add csi-secrets-store addon ([#2936](https://github.com/Azure/aks-engine/issues/2936))
- Windows azure-cni with containerd ([#2864](https://github.com/Azure/aks-engine/issues/2864))
- add support for Kubernetes 1.19.0-alpha.1 ([#2982](https://github.com/Azure/aks-engine/issues/2982))
- add support for Kubernetes 1.18.0 ([#2957](https://github.com/Azure/aks-engine/issues/2957))
- deprecate CoreOS support ([#2945](https://github.com/Azure/aks-engine/issues/2945))

### Maintenance 🔧
- Updating AKS to use April 2020 Windows VHDs by default ([#3060](https://github.com/Azure/aks-engine/issues/3060))
- rev Linux VHDs to 2020.04.09 ([#3058](https://github.com/Azure/aks-engine/issues/3058))
- update Antrea version to v0.5.1 ([#2970](https://github.com/Azure/aks-engine/issues/2970))
- SinglePlacementGroup=false if VMSS + SLB ([#3054](https://github.com/Azure/aks-engine/issues/3054))
- ensure upgraded clusters use MCR images ([#3053](https://github.com/Azure/aks-engine/issues/3053))
- update cluster-autoscaler versions ([#3024](https://github.com/Azure/aks-engine/issues/3024))
- reduce CSE by optimizing var/func names ([#3034](https://github.com/Azure/aks-engine/issues/3034))
- upgrade to azure-sdk v41.0.0 ([#3035](https://github.com/Azure/aks-engine/issues/3035))
- updated network monitor to latest version 0.0.8 ([#3026](https://github.com/Azure/aks-engine/issues/3026))
- use Standard LoadBalancer as default ([#2998](https://github.com/Azure/aks-engine/issues/2998))
- change csi-proxy binary name ([#3003](https://github.com/Azure/aks-engine/issues/3003))
- return distinct CSE err for GPU drivers runtime configuration ([#2941](https://github.com/Azure/aks-engine/issues/2941))
- remove mlocate if auditd disabled ([#2999](https://github.com/Azure/aks-engine/issues/2999))
- switch dev image to go 1.13 version ([#2976](https://github.com/Azure/aks-engine/issues/2976))
- force Basic LB SKU on Azure Stack ([#2974](https://github.com/Azure/aks-engine/issues/2974))
- optimize apt_get_purge CSE func ([#2931](https://github.com/Azure/aks-engine/issues/2931))
- update etcd to 3.3.19 ([#2944](https://github.com/Azure/aks-engine/issues/2944))
- update azure-policy addon versions ([#2903](https://github.com/Azure/aks-engine/issues/2903))

### Testing 💚
- fail fast for cluster.sh test workflows ([#3009](https://github.com/Azure/aks-engine/issues/3009))
- UT for addons ip-masq-agent image override ([#2997](https://github.com/Azure/aks-engine/issues/2997))
- use 1.17 for E2E ([#2980](https://github.com/Azure/aks-engine/issues/2980))
- reduce PR E2E cluster jobs ([#2975](https://github.com/Azure/aks-engine/issues/2975))
- promote --failFast to an e2e flag, defaulting to false ([#2964](https://github.com/Azure/aks-engine/issues/2964))
- don't grab ps logs during E2E operation ([#2966](https://github.com/Azure/aks-engine/issues/2966))
- add egress tests which target pod and namespace. ([#2925](https://github.com/Azure/aks-engine/issues/2925))
- don't test version if customWindowsPackageURL ([#2951](https://github.com/Azure/aks-engine/issues/2951))
#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.49.0...HEAD
[v0.49.0]: https://github.com/Azure/aks-engine/compare/v0.48.0...v0.49.0