### PR TITLE
buffalo 0.16.4

### DIFF
--- a/Food/buffalo.lua
+++ b/Food/buffalo.lua
@@ -1,7 +1,7 @@
 local name = "buffalo"
 local org = "gobuffalo"
-local release = "v0.16.2"
-local version = "0.16.2"
+local release = "v0.16.4"
+local version = "0.16.4"
 food = {
     name = name,
     description = "Rapid Web Development w/ Go",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Darwin_x86_64.tar.gz",
-            sha256 = "82c2e97a02216979153008b0846319ee698a38decbc01a0af3f713ca042406f9",
+            sha256 = "c9f07a6210f20b4fec4cc16fee758e00a64797fc46f011bb56d9bc9a8072947f",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux_x86_64.tar.gz",
-            sha256 = "32bf359f8fa0cd2558827124f6fb17ee13c0d24162cdf4f3fd180a50b1e756c4",
+            sha256 = "5eb4320068ccd9d3861cae2c99c7c080acb994b9cfd4e3ccbf312a7f2843559e",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows_x86_64.tar.gz",
-            sha256 = "0185a30db26e49049c4e6ec2498f9f81f02930167295c8d4448ca26188c880b2",
+            sha256 = "a1cadcab6b9cd13572ec9c149c962e8d6a0eec751871ab4cec29b5bd6a7c83b5",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package buffalo to release v0.16.4. 

# Release info 

 Minor tweaks.

* Updates codeclimate config file. Thanks @boskiv
* Fixes a path issue for Auto in Windows. Thanks @daHaimi
* Allows to pass -timeout to the test command. Reported by @kiambogo
* c.Error now logs the error code. Reported by  @stnguyen90

