### PR TITLE
Update jwt-cli to 3.1.0

### DIFF
--- a/Food/jwt-cli.lua
+++ b/Food/jwt-cli.lua
@@ -1,7 +1,7 @@
 local name = "jwt-cli"
 local org = "mike-engel"
-local release = "3.0.1"
-local version = "3.0.1"
+local release = "3.1.0"
+local version = "3.1.0"
 local executable = "jwt"
 food = {
     name = name,
@@ -14,7 +14,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/mike-engel/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-macOS.tar.gz",
-            sha256 = "f8c2135fcfaad140ba3bd8b4ff0fd3d6fe8f94eaf865c9edea5c534cf517de3e",
+            sha256 = "221fb0d59aadfff8fbfc715a168adb9b76f98ff7f34a052f04a34e52c5661619",
             resources = {
                 {
                     path = executable,
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/mike-engel/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux.tar.gz",
-            sha256 = "2b3fb287177fd9cc74884023eb3e7594dd7f1550241e8dd3d549c26db6b82427",
+            sha256 = "dd6bb19b79cf6ddf30c6e9f1a7091df29cb8d40882fa1772ae0e2cd144990393",
             resources = {
                 {
                     path = "target/release/" .. executable,
@@ -40,7 +40,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/mike-engel/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows.zip",
-            sha256 = "20d0c72b169d2d63349e6389e98475f4f0b67921998d174d948bcc8207db6312",
+            sha256 = "e9158df4e29ee708d52fe89fd72bc1682154707f30cc2f6a2e4183fbdc928eb8",
             resources = {
                 {
                     path = executable .. ".exe",


### PR DESCRIPTION
This updates `jwt-cli` to [3.1.0](https://github.com/mike-engel/jwt-cli/releases/tag/3.1.0)