### PR TITLE
hugo 0.69.2

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.69.0"
+local version = "0.69.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "4ce9f62c7395559dec4bdc24ea5f971db3e548268d1d0ea23805c52ad3dba161",
+            sha256 = "f58e9312ee292c082c5833a128e751c1d07c5fb0da1b7584c09131f18e2ccf52",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "4a11fbce51cfabaa26a244d75e84ff16c7f9fd47c315e6f11f3f39612d82ba46",
+            sha256 = "167d8fb2db1728c0b24914030bab498e38d8ae1dcb01f792672b8a0085903ddf",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "4d38f92792fa4188882aa5985853c8f2b5c66ca25d7eb86db6b70fc0f47fdbc4",
+            sha256 = "d2335fe3835aa8586184a07b8070eae11457d14cdf87f74948e3ba8161301833",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.69.2. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* Fix IsAncestor and IsDescendant when the same page is passed [8d5766d4](https://github.com/gohugoio/hugo/commit/8d5766d417d6564a1aa1cbe8f9a29ab9bba22371) [@tekezo](https://github.com/tekezo) 
* deps: Update goldmark-highlighting [5c41f41a](https://github.com/gohugoio/hugo/commit/5c41f41ad4b14e48aea64687a7600f5ad231e879) [@satotake](https://github.com/satotake) [#7027](https://github.com/gohugoio/hugo/issues/7027)[#6596](https://github.com/gohugoio/hugo/issues/6596)
* Fix IsAncestor and IsDescendant under subsection [27a4c441](https://github.com/gohugoio/hugo/commit/27a4c4410cd9592249925fb14b32605fb961c597) [@tekezo](https://github.com/tekezo) 




