### PR TITLE
aks-engine 0.50.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.49.0"
+local version = "0.50.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "da456318add621494e887c64f942dd4b1ad3966385db6921688a1343da7672a8",
+            sha256 = "8d467dcfca2e1a8efb8f4ff41f31ae912094d3e1e453df5f12e5b4cf98abe8c2",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "43558ac81d42e3a8fa71f4b144a50c5b94be809b0eed29b32e49460272b2904d",
+            sha256 = "28f3757ae0e3c6b094a9ff18c9e91a8689ba4fb74e05701ee7c77ab99828fbb8",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "37aac602cebd91d2ab2e6f44ccafd518b33245d4e6cd706784809f0702d07c25",
+            sha256 = "1d044b265baf5af3f8601a13f462c65e3d59ce799d98ba9d5cb4aefcfe493924",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.50.0. 

# Release info 

 <a name="v0.50.0"></a>
# [v0.50.0] - 2020-04-22
### Bug Fixes 🐞
- don't hardcode csi enableproxy in kubeclusterconfig.json ([#3127](https://github.com/Azure/aks-engine/issues/3127))
- idempotent systemd + disk mount for etcd ([#3126](https://github.com/Azure/aks-engine/issues/3126))
- use full userAssignedID reference in ARM template ([#3116](https://github.com/Azure/aks-engine/issues/3116))
- add nodeSelector for coredns-autoscaler ([#3109](https://github.com/Azure/aks-engine/issues/3109))
- typos in JSON annotations caught by staticcheck ([#3104](https://github.com/Azure/aks-engine/issues/3104))
- Fixed bug in condition check for dualstack ([#3110](https://github.com/Azure/aks-engine/issues/3110))
- update cluster-proportional-autoscaler path at MCR ([#3091](https://github.com/Azure/aks-engine/issues/3091))
- Update CSI Secrets Store Provider for Azure to 0.0.4 ([#3086](https://github.com/Azure/aks-engine/issues/3086))
- don't skip Windows VMSS node pools during upgrade ([#3083](https://github.com/Azure/aks-engine/issues/3083))
- retry more aggressively when install the gpu deb package. ([#3065](https://github.com/Azure/aks-engine/issues/3065))
### Code Refactoring 💎
- Create signable PS scripts ([#3015](https://github.com/Azure/aks-engine/issues/3015))
- skip sgx driver installation if already exists in OS ([#3062](https://github.com/Azure/aks-engine/issues/3062))
### Code Style 🎶
- override linguist's default language detection ([#3100](https://github.com/Azure/aks-engine/issues/3100))
### Documentation 📘
- join the #aks-engine-users Slack channel (not #provider-azure) ([#3103](https://github.com/Azure/aks-engine/issues/3103))
- remove docker package and choco caveat from release docs ([#3099](https://github.com/Azure/aks-engine/issues/3099))
- get-logs proposal ([#2745](https://github.com/Azure/aks-engine/issues/2745))
### Features 🌈
- add support for Kubernetes 1.19.0-alpha.2 ([#3122](https://github.com/Azure/aks-engine/issues/3122))
- Enable Antrea in NetworkPolicyOnly mode with Azure CNI ([#3027](https://github.com/Azure/aks-engine/issues/3027))
- Enabling SSH on windows nodes by default ([#2759](https://github.com/Azure/aks-engine/issues/2759))
- Updating Windows VHDs with 4B patches ([#3115](https://github.com/Azure/aks-engine/issues/3115))
- modify container runtime data dir ([#3072](https://github.com/Azure/aks-engine/issues/3072))
- enable CSI proxy by default when cloud-controller-manager is enabled on Windows cluster ([#3080](https://github.com/Azure/aks-engine/issues/3080))
- Azure CNI dual stack support ([#2862](https://github.com/Azure/aks-engine/issues/2862))
- enable multiple frontend IPs in Standard LB ([#3085](https://github.com/Azure/aks-engine/issues/3085))
- disable dashboard addon by default ([#3093](https://github.com/Azure/aks-engine/issues/3093))
- coredns-autoscaler ([#3067](https://github.com/Azure/aks-engine/issues/3067))
- add support for Kubernetes 1.17.5 ([#3088](https://github.com/Azure/aks-engine/issues/3088))
- add support for Kubernetes 1.18.2 ([#3089](https://github.com/Azure/aks-engine/issues/3089))
- add support for Kubernetes 1.16.9 ([#3087](https://github.com/Azure/aks-engine/issues/3087))
- disabling windows updates by default ([#3073](https://github.com/Azure/aks-engine/issues/3073))
- "aks-engine get-logs" command ([#2987](https://github.com/Azure/aks-engine/issues/2987))
- give metrics-server system-cluster-critical priority ([#3082](https://github.com/Azure/aks-engine/issues/3082))
- Support Non-Azure Stack Custom Clouds with custom endpoints/root certs/sources.list ([#3063](https://github.com/Azure/aks-engine/issues/3063))
- support cloud-node-manager on Windows clusters ([#3044](https://github.com/Azure/aks-engine/issues/3044))
- proximity placement group support ([#3056](https://github.com/Azure/aks-engine/issues/3056))
- generic cluster-init component ([#3023](https://github.com/Azure/aks-engine/issues/3023))
### Maintenance 🔧
- Use prod repos for containerd. ([#3107](https://github.com/Azure/aks-engine/issues/3107))
- update go compiler to 1.14.2 ([#2839](https://github.com/Azure/aks-engine/issues/2839))
- rev Linux VHDs to 2020.04.21 ([#3123](https://github.com/Azure/aks-engine/issues/3123))
- updating Windows VHD to include April patches ([#3101](https://github.com/Azure/aks-engine/issues/3101))
- remove pre-1.14 addons specs ([#3081](https://github.com/Azure/aks-engine/issues/3081))
- use Ubuntu 18.04-LTS as default ([#3070](https://github.com/Azure/aks-engine/issues/3070))
- remove support for Kubernetes 1.13 ([#3059](https://github.com/Azure/aks-engine/issues/3059))]
- update azure cni version to v1.1.0 ([#3075](https://github.com/Azure/aks-engine/issues/3075))]

### Testing 💚
- really fix bad distro value in everything cluster config ([#3095](https://github.com/Azure/aks-engine/issues/3095))
- fix bad distro value in everything cluster config ([#3094](https://github.com/Azure/aks-engine/issues/3094))
#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.50.0...HEAD
[v0.50.0]: https://github.com/Azure/aks-engine/compare/v0.47.0-aks-gomod-32...v0.50.0