### PR TITLE
saml2aws 2.26.0

### DIFF
--- a/Food/saml2aws.lua
+++ b/Food/saml2aws.lua
@@ -1,7 +1,7 @@
 local name = "saml2aws"
 local org = "Versent"
-local release = "v2.25.0"
-local version = "2.25.0"
+local release = "v2.26.0"
+local version = "2.26.0"
 food = {
     name = name,
     description = "CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "979c2a4897397dd29b99347fe4e4accab9cb8cb697f94f4baf1336dfd59b380c",
+            sha256 = "b22e0c4180d7d9c89c62f4cd5e1bcdebf2bf1065c9ac9cd5e0b050ed8f6413a9",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "f3bb72c53bdd89f53c366daf16297daf5f6b0df60935a80fe190e1026de5b974",
+            sha256 = "7ff7a05f2a7ca624b6a7c83c12d866a3652fe5c2dd861c654f60ad5fcd7a114c",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Versent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.tar.gz",
-            sha256 = "7a640280fb86161aaaadf9d179dba10ff032e7f8074c5c326e7adb62554f1e79",
+            sha256 = "2652e2d3d0d421488fd763f657f1f7b7c4f96d20f7877f2e20638ce1c693ef49",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package saml2aws to release v2.26.0. 

# Release info 

 * [googleapps] Adding fallback when yubikey fails #470 
* fix script's template for fish #472 
* Added support for DUO authorized network bypass #458
* Add support for Yubikey with Onelogin #461 
* fix script's template for powershell #484 
* Get the AWS destination from the Destination, not Audience #481 
* Fixes for okta + govcloud #476 
* Add console flag to present a link instead of opening browser directly #474 
* Fix use of OKTA (Okta verify TOTP) as an MFA provider setting #486 
* add Privileged authentication option in NetIQ #490 