### PR TITLE
kind 0.8.0

### DIFF
--- a/Food/kind.lua
+++ b/Food/kind.lua
@@ -1,7 +1,7 @@
 local name = "kind"
 local org = "kubernetes-sigs"
-local release = "v0.7.0"
-local version = "0.7.0"
+local release = "v0.8.0"
+local version = "0.8.0"
 food = {
     name = name,
     description = "Kubernetes IN Docker - local clusters for testing Kubernetes",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "11b8a7fda7c9d6230f0f28ffe57831a7227c0655dfb8d38e838e8f03db6612de",
+            sha256 = "d92729517f89a65398e52254ce9f3d6df4f33948e27a96006209f5a2d5559d23",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "0e07d5a9d5b8bf410a1ad8a7c8c9c2ea2a4b19eda50f1c629f1afadb7c80fae7",
+            sha256 = "48b23b191225927bd0a2c5f7a6b4ea3610a0a0cbc6feca1099977d2368f90398",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
-            sha256 = "253b7c330593f89ca904860c0da2b8b229f5515e41fd960e2b73a33d7e4c68e3",
+            sha256 = "5824f01be86df351ea5736f6f25c95acc3134654a7b6451ce43fa429a09c2feb",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package kind to release v0.8.0. 

# Release info 

 `v0.8.0` Most importantly brings persistent clusters that automatically come back
up after `dockerd` / host restarts. It also brings a number of fixes to networking
in general, experimental `podman` backend support, improved failure output, and more.


<h1 id="breaking-changes">Breaking Changes</h1>

- The default node image is a Kubernetes `v1.18.2` image: `kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f`
- **KIND `v0.8.0` requires node images built with `v0.8.0+`**.
  - These new images should be mostly backwards compatible for kind `v0.5.0+`
- **The default docker network for nodes is now `kind` instead of the default docker bridge**
  - This enabled *many* fixes, however if you were running things alongside kind you may need to pass `--net=kind`
  - Your host DNS resolver should just work now :tm: in many cases
  - IPv6 clusters no longer require modifying docker daemon config
  - Docker networks must have a free IPv6 /64 in the [ULA] range, that is you may
  not create other docker networks consuming the entire ULA range. You can work
  around this by precreating the `kind` network with some totally other range if you wish.
- You may need to migrate to the new `featureGates` config field when setting feature gates, this should be easier to use though!

**NOTE**: If you've been experimenting with kind > v0.7.0 installed from `HEAD`, you may need to `docker network rm kind` before
creating IPv6 clusters.

<h1 id="new-features">New Features</h1>

- Clusters should not be broken by dockerd restarts / restarting your host!
- Host DNS should just work :tm:
- IPv6 Clusters no longer require modifying docker daemon settings
- Kubernetes 1.18+ should work on hosts using the iptables nft backend
- `kind delete clusters --all` for deleting all your clusters
- New top level `featureGates` field in Cluster config for enabling feature gates
- Upgraded dependencies broadly, including library packages, go, containerd, CNI, etc...
- `NO_COLOR` ([no-color.org]) support
- _Experimental_ `podman` support
  - These clusters do **not** survive host reboots
  - Requires rootful mode
  - Experimental
- Improved output on failures, including command output without needing to set `-v`
- Experimentally cross-building the base image for AMD64 + ARM by default
- More Documentation! Guide to working with KIND offline, Ingress and more!
- New download host and experimental nightly builds
- Support for Dynamic PV in Kubernetes 1.11.X
- New top level `featureGates` config option for controlling cluster featuregates
- Shiny new WorkGroup-K8s-Infra based infrastructure for Kubernetes CI builds
- Support for `KIND_CLUSTER_NAME` environment variable isntead of `--name`

New Node have been Images for kind `v0.8.0`, please use these **exact** images (IE like `v1.18.2:@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f` including the digest) or build your own as we may need to change the image format again in the future :sweat_smile:

Images built for this release:
  - 1.18: `kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f`
  - 1.17: `kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a`
  - 1.16: `kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765`
  - 1.15: `kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50`
  - 1.14: `kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6`
  - 1.13: `kindest/node:v1.13.12@sha256:214476f1514e47fe3f6f54d0f9e24cfb1e4cda449529791286c7161b7f9c08e7`
  - 1.12: `kindest/node:v1.12.10@sha256:faeb82453af2f9373447bb63f50bae02b8020968e0889c7fa308e19b348916cb`
  - 1.11: `kindest/node:v1.11.10@sha256:74c8740710649a3abb169e7f348312deff88fc97d74cfb874c5095ab3866bb42`


<h1 id="fixes">Fixes</h1>

- Avoid potentially slow `sync` during bootstrap
- Fixed some occasional flakes when exporting logs
- Simple output mode automatically activated on Travis CI to avoid broken PTY behavior
- Fixed image import on ARM
- Fixed abspath resolution in cluster config on Windows
- Fixed DNS resolution on some systems
- Fixed building Kubernetes with Bazel
- Fixed using kind on ZFS / BTRFS backed host docker
- Updated Conformance Certification


<h1 id="contributors">Contributors</h1>

**Thanks again to everyone who contributed to this release! ❤️**

Users whose commits are in this release (alphabetically by user name)

- @aledbf
- @amwat
- @Anuj2512
- @aojea
- @BenTheElder
- @boddumanohar
- @chuckha
- @darkowlzz
- @eightlimbed
- @gurjeet
- @JamesLaverack
- @jroper
- @k8s-ci-robot
- @liggitt
- @longkb
- @maelvls
- @narendrakangralkar
- @oke-py
- @panzhc
- @rajalokan
- @ryanhartje
- @sayboras
- @slimm609
- @stevesloka
- @tao12345666333
- @zegl
- @zhlhahaha

[no-color.org]: https://no-color.org/