### PR TITLE
brig 1.4.0

### DIFF
--- a/Food/brig.lua
+++ b/Food/brig.lua
@@ -1,5 +1,5 @@
 local name = "brig"
-local version = "1.3.0"
+local version = "1.4.0"
 local baseURL = "https://github.com/Azure/brigade/releases/download"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "b45e0c414f97ea7e9bfd5e949444ea99ac4a290b1cb248985a6d18fa7b2de1cc",
+            sha256 = "03615ead3758fd8768b1c2811be367973db56ec7e6b79e7e133080c0f4c0f984",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "a2ad724573ba5bb9c3ec6652d931e2a5ba72022a33d2e35cf02da7a21290a3a5",
+            sha256 = "e522de1603f6471ff8299cc0fcf34292f03708715f390de5302c1b0690bfbe98",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = baseURL .. "/v" .. version .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "0b624237f28865b7e42b298d543310bc76df413fdfb21009c25a98b2f1d60d14",
+            sha256 = "af9b230c61bdd0f87809c41159787b17e6c3635bf454b64499d2b5c39b87231b",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package brig to release v1.4.0. 

# Release info 

 - minor Makefile improvements 433a1ce2d5d19c435df4eccf86dc56ad4f721b83 (Kent Rancourt)
- small Makefile fix 4702842c5047de059a9bd7c34c2dd779d5eb4ca3 (Kent Rancourt)
- increase lint check timeout 698f7e6e18ef0cfd848fde9bc8a27966a9e887ef (Kent Rancourt)
- account for breaking changes in client-go 46bf3b216530bf18af9ea34c793896276c937d43 (Kent Rancourt)
- corresponding vendor changes 280c8a3c829e7a53a003e294cc52a99454f32362 (Kent Rancourt)
- switch form dep go mod; upgrade critical dependencies 29db8903bc3405e47ce772e12b03cf75cd91edbf (Kent Rancourt)
- upgrade to go 1.14 63eda9ae3fd1b4590674203928c81471248f1d2a (Kent Rancourt)
- chore(brigade-worker): bump mocha; rm minimist resolution (#1071) 64e42e38283f76979a8ef2616094269ca5f335b3 (Vaughn Dice)
- allow worker vcs init container to init git submodules 63d19cf2665a752bedef354a84a6e00cd612ef94 (Kent Rancourt)
- feat(brig): accept inline payload in brig run (#1061) 2c2c03b6d8d100af88e2118b729a0dd9fb5aba74 (Shubham Sharma)
- Updated Docker image to 12.16.2 Node version on Alpine 3.11 1e48c4666d87e48ccf4f39a328696cfe39f4ac9a (veeramarni)
- docker node upgrade 4bd1d96fbdffd2b60bfae30d9e687b88213ba188 (veeramarni)
- fix(brigade.js): add git to e2e job (#1066) e67d00a0b9bc6e459641797346d108f5ef68f798 (Vaughn Dice)
- chore(brigade-worker): fix yarn audit (#1067) aa6deaf27a9d0dcc24de9ea5044f55012d94aaa3 (Vaughn Dice)
- Added emoji's on brig check, unit tests 04f2c18074801cde937dea1d55ad770d4282bf49 (Anthony Foster)
- fix tests broken by dependency upgrades b4c148239acfd2b4cd26d2b0a0d394feb1e71810 (Kent Rancourt)
- corresponding vendor changes af0852bee92f95576cd10a9097cd493b3a0476f8 (Kent Rancourt)
- update relevant k8s libs to 1.17.3 8ae324f438d179e6e4432ab4182c2149c60c3836 (Kent Rancourt)
- chore(brigade.js*): bump brigade-utils; update KindJob usage (#1056) 406bbf28f3567775840c95e0da59d6ec5f564c89 (Vaughn Dice)
- ref(e2e): bump cli versions, add diff platform/arch support, etc. (#1054) 865dfb135d5c75c56f8736f38242341b84a8d50a (Vaughn Dice)