### PR TITLE
helm 3.2.1

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.2.0"
+local version = "3.2.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "1d456ebcba589b9f39e5a6120d3a437a78ddcef074805bb95cbeb84c198d2bde",
+            sha256 = "983c4f167060b3892a42f353c7891cabac36ec49f6042eae1046bd8a258b8a14",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "4c3fd562e64005786ac8f18e7334054a24da34ec04bbd769c206b03b8ed6e457",
+            sha256 = "018f9908cb950701a5d59e757653a790c66d8eda288625dbb185354ca6f41f6b",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "3866887a54b96c45aa5cfbe6f704e0a1c2ae312c786cd4db93ecc6783e384194",
+            sha256 = "f1a058d7469003cd2605c8b76f328863bdfa17e176910adac9cbbcac2da4ca93",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.2.1. 

# Release info 

 Helm v3.2.1 is the first patch release for Helm 3.2 and it includes several bug fixes. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.2.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.2.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-darwin-amd64.tar.gz.sha256sum) / 983c4f167060b3892a42f353c7891cabac36ec49f6042eae1046bd8a258b8a14)
- [Linux amd64](https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz.sha256sum) / 018f9908cb950701a5d59e757653a790c66d8eda288625dbb185354ca6f41f6b)
- [Linux arm](https://get.helm.sh/helm-v3.2.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-arm.tar.gz.sha256sum) / b84708ac114669b2a6d81c84f43793268811f19c279b355d6ef00e5e208a9e9d)
- [Linux arm64](https://get.helm.sh/helm-v3.2.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-arm64.tar.gz.sha256sum) / 7200fb4582345f521d56daed56112d667fef25c48569f574fab3f9cb04c5b176)
- [Linux i386](https://get.helm.sh/helm-v3.2.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-386.tar.gz.sha256sum) / f62bd14ea97d78ac00708c5c51f065d5bb9ae25119a7a780f79d3ba45ba531c6)
- [Linux ppc64le](https://get.helm.sh/helm-v3.2.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-ppc64le.tar.gz.sha256sum) / 324466498e6f6300643ddfff2b9e3c796e731cccf442850868c317025cdb71f5)
- [Linux s390x](https://get.helm.sh/helm-v3.2.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.1-linux-s390x.tar.gz.sha256sum) / 983c4f167060b3892a42f353c7891cabac36ec49f6042eae1046bd8a258b8a14)
- [Windows amd64](https://get.helm.sh/helm-v3.2.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.2.1-windows-amd64.zip.sha256sum) / dbd30c03f5ba110348a20ffb5ed8770080757937c157987cce59287507af79dd)

This release was signed with `6EA5 D759 8529 A53E` and can be found at @hickeyma [keybase](https://keybase.io/hickeyma) account. Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.3.0 is the next feature release and will have environment variable and linter improvements
- 3.2.2 is the next patch release and will contain bug fixes

## Changelog

- Add checking of length of resourceList before creating of deleting fe51cd1e31e6a202cba7dead9552a6d418ded79a (Vibhav Bobade)
- docs: fix capitalization in a few help messages 9036e17fb6bca6609721385cc224acdf39b28ec9 (Liu Ming)
- polish to keep the same log style 07255156767ecc6e53c84d6dcd4c2fda79d8a440 (Liu Ming)
- Fix markdown table in helm command doc 8635a19660e8d79da5e70a64de64c2b18f1fde73 (Lüchinger Dominic)
- Add unit test for pkg/chart/chart.go 03a4c06a0410a1c7763b761ff7fc00a09efe103a (Hu Shuai)
- Fixing docs from version to appVersion (#7975) 209974ad97ccd38c0dff58c41789e3333f25ef97 (Matt Farina)
- Helm upgrades with --reuse-values and nil user values -- with tests (#7959) efad407154c80eeb11edc3572b047cd4f2c8c24a (David Pait)
- fix(pkg/plugin): copy plugins directly to the data directory (#7962) 48d09a26d2a7e5d9693e0d4f145287961b612020 (Adam Reese)
- fs_test: use os.Getuid() instead user.Current() to determine if a test is executed with root privileges. b98b7d064fc654ffec7f76c2396b992f35cc253d (Predrag Knezevic)
- fix(helm): allow a previously failed release to be upgraded (#7653) 56ef9ab386c771d827dc502f5f8e12929fc5ee1f (Matthew Morrissette)
- fix: write index.yaml file atomically (#7954) cb7189f6ce0ba3ce73ba564e81c379a446261216 (Raphaël)