### PR TITLE
helmfile 0.115.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.114.0"
+local version = "0.115.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "e683539afbe59987a16d9892e611b93b95c30011ee166dd3854c19e2ab93ccc7",
+            sha256 = "980c79b6976369f43b9b2100c62eacd269b351121304e952164f542385435674",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "bcb84a808ce9bc3499b4d5c76cbbaa4c9a5ca96f7f096a138e0d41c802c01ca0",
+            sha256 = "d13a82cf2cf3b0f8ef8787ef6adf75f535b48fbfb3ae6e99020c5ec9763f2eb5",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "dd074934188ac11275109a01f98eb0651d49c1566ddf3141dc71236e96b31535",
+            sha256 = "132a8b343fbb503e5d185580f53880d4849dcd0b0c61a6074880dc46416f0c6f",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "cdb9cabb613117b8a7cb6164adb95c7f81ca8f625d9095a2aec89d6ae156e80a",
+            sha256 = "04410e8de3a6ee772ea5265fe4d8bd0a1d877ce5a814c1079a28a64ff26f927a",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "87ca8379015d80a9ef1c76c6c770d46547af397906b41e75eb4e521922c392c4",
+            sha256 = "932c1ea4a7516badf9e7da1165d2a258f7bfd9a6294699925ebaec487694cb3d",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "c488c7b139f8f23922075f60527e30db96e5389f51c248d9ec2c310880009150",
+            sha256 = "c4d12e16d647b67af308d2caef1a9103ccce18b00f3e746618d01cbfeb1e0262",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.115.0. 

# Release info 

 9e4bc6e (HEAD, tag: v0.115.0, origin/master, origin/HEAD, master) chore: Add retries for downloading kubectl in docker builds
ef2d885 README: Add note about environment variable types (#1251)
66f3458 feat: Add global `--debug` flag for passing `--debug` to helm (#1236)
6d5f8c7 Allow skipping chart-related operations when `installed: false` (#1233)
23be9af Show executed command when errors occurred (#1252)
1e9e228 Dockerfile: Upgrade to Helm v3.2.1. (#1253)
c72cab8 Bump variantdev/vals for Vault AppRole support (#1239)
923bd54 Use namespace for release unicity with helm3 (#1213) (#1235)
a0e30c5 Correct ordering between releases and sub-helmfiles on destroy/delete (#1234)
daf8c2f Upgrade helm to v3.2.0 (#1231) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/5046)