### PR TITLE
fission 1.9.0

### DIFF
--- a/Food/fission.lua
+++ b/Food/fission.lua
@@ -1,5 +1,5 @@
 local name = "fission"
-local version = "1.8.0"
+local version = "1.9.0"
 local githubReleaseDownloadURL = "https://github.com/fission/fission/releases/download"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = githubReleaseDownloadURL .. "/" .. version .. "/fission-cli-osx",
-            sha256 = "dabd8540d85c171b7f69d9410458efa0e9789e624cdbf36a06ce28d9f1cc5276",
+            sha256 = "04f173b6addf7f09189248e1507a91580914b4108f7f016e6c2cdbe6697720ce",
             resources = {
                 {
                     path = name .. "-cli-osx",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = githubReleaseDownloadURL .. "/" .. version .. "/fission-cli-linux",
-            sha256 = "be83e76bfe964750d8356415cb36de68ca884057d56f98700441dbea090b8a40",
+            sha256 = "acf2078e942c238eca821562171d09a5c89359761aa313fe86daba727efc2c75",
             resources = {
                 {
                     path = name .. "-cli-linux",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = githubReleaseDownloadURL .. "/" .. version .. "/fission-cli-windows.exe",
-            sha256 = "d2a214045ce4316e66ceee8d9f79b0bd7aaa11c43e3b1d7e0df237739219f71a",
+            sha256 = "2306aef705e1f20b5ac77cb4cf80f9239f12e5bbb2c6414dd7597a45d87c5278",
             resources = {
                 {
                     path = name .. "-cli-windows.exe",


### PR DESCRIPTION
Updating package fission to release 1.9.0. 

# Release info 

 Install Guide: https://docs.fission.io/installation/
Release Highlight: https://docs.fission.io/releases/1.9.0/
Full Changelog: https://github.com/fission/fission/blob/master/CHANGELOG.md