### PR TITLE
minikube 1.10.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.9.2"
-local version = "1.9.2"
+local release = "v1.10.0"
+local version = "1.10.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "f27016246850b3145e1509e98f7ed060fd9575ac4d455c7bdc15277734372e85",
+            sha256 = "aff7d9e273aff53f8b3ab0e0bc3fdfff76daa19b4a0f5480679ba52fc688eae1",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -23,10 +23,23 @@ food = {
             }
         },
         {
+            os = "darwin",
+            arch = "amd64",
+            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
+            sha256 = "88cd06183d35c1f19352b0c54f3017017cb01ff733112ae72bd2077e8ad1f8ef",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "3121f933bf8d608befb24628a045ce536658738c14618504ba46c92e656ea6b5",
+            sha256 = "9d34cb50bc39f80d39f92d1fb7cb23a271504b519f5e805574894d395ce3e7b3",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -36,13 +49,50 @@ food = {
             }
         },
         {
+            os = "linux",
+            arch = "amd64",
+            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
+            sha256 = "899348ece171b1d7f708f9e10ceda5f742a11a7fcd9c41eec533a5100d8058dc",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
+            sha256 = "9c3410ff03ed0d114e98cbd8cb1b14a3a131e69d92bd964b114ce07fa8385e70",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        },
+        {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "426586f33d88a484fdc5a3b326b0651d57860e9305a4f9d4180640e3beccaf6b",
+            sha256 = "9c3410ff03ed0d114e98cbd8cb1b14a3a131e69d92bd964b114ce07fa8385e70",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
+            sha256 = "94fb089f7c88c6e9f4d531a7aad60c992764c3b32e926204f4101b40fc7aa9c9",
+            resources = {
+                {
+                    path = name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }


### PR DESCRIPTION
Updating package minikube to release v1.10.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.10.0 - 2020-05-11

Features:

* Add new env variable `MINIKUBE_FORCE_SYSTEMD` to configure force-systemd [#8010](https://github.com/kubernetes/minikube/pull/8010)
* docker/podman: add alternative repository for base image in github packages [#7943](https://github.com/kubernetes/minikube/pull/7943)


Improvements:

* tunnel: change to clean up by default [#7946](https://github.com/kubernetes/minikube/pull/7946)
* docker/podman warn about non-amd64 archs [#8053](https://github.com/kubernetes/minikube/pull/8053)
* docker: Detect windows container and exit with instructions [#7984](https://github.com/kubernetes/minikube/pull/7984)
* make `minikube help` output consistent [#8036](https://github.com/kubernetes/minikube/pull/8036)
* podman: Use noninteractive sudo when running podman [#7959](https://github.com/kubernetes/minikube/pull/7959)
* podman: Wrap the start command with cgroup manager too [#8001](https://github.com/kubernetes/minikube/pull/8001)
* podman: implement copy for podman-remote [#8060](https://github.com/kubernetes/minikube/pull/8060)
* podman: Don't run the extraction tar container for podman [#8057](https://github.com/kubernetes/minikube/pull/8057)
* podman: disable selinux labels when extracting the tarball (permissions error) [#8017](https://github.com/kubernetes/minikube/pull/8017)
* podman: Get the gateway by inspecting container network [#7962](https://github.com/kubernetes/minikube/pull/7962)
* podman-env: add PointToHost function for podman driver [#8062](https://github.com/kubernetes/minikube/pull/8062)
* virtualbox: Quiet initial ssh timeout warning [#8027](https://github.com/kubernetes/minikube/pull/8027)
* update ingress-nginx addon version [#7997](https://github.com/kubernetes/minikube/pull/7997)
* config: Add base image to the cluster config [#7985](https://github.com/kubernetes/minikube/pull/7985)

Bug Fixes:

* wait to add aliases to /etc/hosts before starting kubelet [#8035](https://github.com/kubernetes/minikube/pull/8035)
* fix missing node name in minikube stop output [#8023](https://github.com/kubernetes/minikube/pull/8023)
* addons: fix initial retry delay, double maximum limit [#7999](https://github.com/kubernetes/minikube/pull/7999)
* restart: validate configs with new hostname, add logging [#8022](https://github.com/kubernetes/minikube/pull/8022)
* assign proper internal IPs for nodes [#8018](https://github.com/kubernetes/minikube/pull/8018)
* use the correct binary for unpacking the preload [#7961](https://github.com/kubernetes/minikube/pull/7961)

Huge thank you for this release towards our contributors:

- Anders F Björklund
- Giacomo Mr. Wolf Furlan
- Kenta Iso
- Manuel Alejandro de Brito Fontes
- Medya Ghazizadeh
- Noah Spahn
- Priya Wadhwa
- Sharif Elgamal
- Thomas Strömberg
- anencore94

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`7d65c43ca4124e41920317008b43324938eb2fb2835a4e154b5fe4968c71735e`