### PR TITLE
minikube 1.10.1

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.10.0"
-local version = "1.10.0"
+local release = "v1.10.1"
+local version = "1.10.1"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "aff7d9e273aff53f8b3ab0e0bc3fdfff76daa19b4a0f5480679ba52fc688eae1",
+            sha256 = "9c51656f6855b4dff9a6f0bf1136255c18bc07c467ff67b32257da921e879246",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "88cd06183d35c1f19352b0c54f3017017cb01ff733112ae72bd2077e8ad1f8ef",
+            sha256 = "0639343ba6076e702550c42315061cfb95a3e99072906fb3ea56e0cb82b08a85",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "9d34cb50bc39f80d39f92d1fb7cb23a271504b519f5e805574894d395ce3e7b3",
+            sha256 = "acc67ea2ff1ca261269a702a6d998367f65c86d9024c20bbf5ac3922bfca1aaa",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "899348ece171b1d7f708f9e10ceda5f742a11a7fcd9c41eec533a5100d8058dc",
+            sha256 = "c38dabe3d91173bdee8867b257336f1ed699b0ae6594cc0ccc99a58d3bbdc594",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
-            sha256 = "9c3410ff03ed0d114e98cbd8cb1b14a3a131e69d92bd964b114ce07fa8385e70",
+            sha256 = "60d4db87a834509a69b70ac253de040eabfb9e96aaf3cee159f73c3d5f37e81a",
             resources = {
                 {
                     path = name,
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "9c3410ff03ed0d114e98cbd8cb1b14a3a131e69d92bd964b114ce07fa8385e70",
+            sha256 = "60d4db87a834509a69b70ac253de040eabfb9e96aaf3cee159f73c3d5f37e81a",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -89,7 +89,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "94fb089f7c88c6e9f4d531a7aad60c992764c3b32e926204f4101b40fc7aa9c9",
+            sha256 = "7a68eb0fee88cc4e5df54338c72075a3294149776f7a1e2da4903b51d41e301a",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.10.1. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.10.1 - 2020-05-12

Bug fixes:

* virtualbox: fix IP address retrieval [#8106](https://github.com/kubernetes/minikube/pull/8106)
* hyperv: fix virtual switch bug [#8103](https://github.com/kubernetes/minikube/pull/8103)
* Bump Default Kubernetes version v1.18.2 and update newest [8099](https://github.com/kubernetes/minikube/pull/8099)

Huge thank you for this release towards our contributors: 

- cprogrammer1994
- Medya Ghazizadeh
- Sharif Elgamal
- Thomas Strömberg

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`7d65c43ca4124e41920317008b43324938eb2fb2835a4e154b5fe4968c71735e`