### PR TITLE
aks-engine 0.50.1

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.50.0"
+local version = "0.50.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "8d467dcfca2e1a8efb8f4ff41f31ae912094d3e1e453df5f12e5b4cf98abe8c2",
+            sha256 = "d83aae202844a9b67d648149493f818540f4c60dc4cf62e2f7fb8b357c1781cc",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "28f3757ae0e3c6b094a9ff18c9e91a8689ba4fb74e05701ee7c77ab99828fbb8",
+            sha256 = "1cb423dbb0f48b232e0d62cb51c369597d76b063dd312487482df0e98a7f995e",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "1d044b265baf5af3f8601a13f462c65e3d59ce799d98ba9d5cb4aefcfe493924",
+            sha256 = "0753f5939389e7e44fecd8060a640dd134ebf94488446e3d5197d0d3998a50ab",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.50.1. 

# Release info 

 <a name="v0.50.1"></a>
# [v0.50.1] - 2020-05-13
### Bug Fixes 🐞
- don't dry-run cluster-init spec ([#3247](https://github.com/Azure/aks-engine/issues/3247))
- custom cloud Azure CNI config for Windows ([#3228](https://github.com/Azure/aks-engine/issues/3228))
- don't validate Windows version in update scenario ([#3226](https://github.com/Azure/aks-engine/issues/3226))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.50.1...HEAD
[v0.50.1]: https://github.com/Azure/aks-engine/compare/v0.50.0...v0.50.1