### PR TITLE
kubeaudit 0.8.0

### DIFF
--- a/Food/kubeaudit.lua
+++ b/Food/kubeaudit.lua
@@ -1,5 +1,5 @@
 local name = "kubeaudit"
-local version = "0.7.0"
+local version = "0.8.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "e920b5f1d486a8ce4dd2fc25063f6fd170ee8a42d78e4cae3090f0635e46d7cc",
+            sha256 = "9223afa2a79aa64e2cd073e0df39d8e54ff4d5f70d2b8f7e5df2d4b5b153c65c",
             resources = {
                 {
                     path = name,
@@ -30,7 +30,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_386.tar.gz",
-            sha256 = "e839f4a729b1f09e7d649425fcc27e171589715d4893a632f93432ae57ff7db1",
+            sha256 = "640156ee3e89633e5af711d072d9fabd4ab570bfbec038c70ca56f7a4a251a7a",
             resources = {
                 {
                     path = name,
@@ -48,7 +48,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "dcd4adf6e1fed851a80adaf96779c1e7edd8b6e71b8fe762345a8f69cc87b7b5",
+            sha256 = "e2b66bb0704658bb4e9f273c8fb3da931c66c66b84214315f24f7a04a23232bf",
             resources = {
                 {
                     path = name,
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_386.tar.gz",
-            sha256 = "8f8a3afe3ac9c80ea0c8aca99a73973a054aeba5bb74df3af7ad8951c4a1190e",
+            sha256 = "a03cfa485258111c0dd0e75032b11020728fbfd96fe704f823540ff7ac449494",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package kubeaudit to release v0.8.0. 

# Release info 

 ## Changelog

58c98c1 import azure auth module for AKS (#268)
9158be4 Log a string representation of the error id (#238)
e8f5a21 Log missing or wrong kubeconfig file (#236)
e8d4f22 Switch travis to Go 1.12 and 1.13 (#237)
8006e92 Replace Shopify/yaml with gopkg.in/yaml.v3 (#227)

