### PR TITLE
hugo 0.71.1

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.71.0"
+local version = "0.71.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "f5db68d264b2724f072d02b6dfad40afaf9bb9082cf4c1bdf239408d1e1c31d8",
+            sha256 = "6a96f99b1e18938cb2c1cd6e6a4940eea43972de2eafc4bb48360be4d73465d3",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "7da50efc00ca59e5fda06468751045271bbdc3b5f504a3824e3af2d5e04fb7cd",
+            sha256 = "18d95148464b15ff16d94de600b26edb565fbe84723650ea8974ffb670873b14",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "b84abcc4fcd5b990dab8399198eedefdf5b560aad09ece7a25c1fd806d53b2a4",
+            sha256 = "1d0705cd8976e65ac762d116e363ecbf235f2e623c3fa33819daa6b010281f9e",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.71.1. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* Add some more date test cases [81f56332](https://github.com/gohugoio/hugo/commit/81f5633245bf123fbe7ad78eec51ae7b4e6c177a) [@bep](https://github.com/bep) [#7310](https://github.com/gohugoio/hugo/issues/7310)
* Fix RenderString vs render hooks [9698b0da](https://github.com/gohugoio/hugo/commit/9698b0dab11f52d52145e85ff71311d2f103cb4e) [@bep](https://github.com/bep) [#7265](https://github.com/gohugoio/hugo/issues/7265)
* Prevent WARNINGs in RenderString [32344fe3](https://github.com/gohugoio/hugo/commit/32344fe3db862584e3f926d63bdf33b7fa7d22f7) [@bep](https://github.com/bep) 
* Fix IsAncestor/IsDescendant for taxonomies [4d7fa9f1](https://github.com/gohugoio/hugo/commit/4d7fa9f114c62ae2ec12257203ed21b0e4d69a04) [@bep](https://github.com/bep) [#7305](https://github.com/gohugoio/hugo/issues/7305)
* Fix GetPage on section/bundle name overlaps [a985efce](https://github.com/gohugoio/hugo/commit/a985efcecf44afe1d252690ec0a00cf077974f44) [@bep](https://github.com/bep) [#7301](https://github.com/gohugoio/hugo/issues/7301)
* Fix Go template script escaping [6c3c6686](https://github.com/gohugoio/hugo/commit/6c3c6686f5d3c7155e2d455b07ac8ab70f42cb88) [@bep](https://github.com/bep) [#6695](https://github.com/gohugoio/hugo/issues/6695)
* Add a test helper [c34bf485](https://github.com/gohugoio/hugo/commit/c34bf48560c91c8a2fa106867af7b08a569609b5) [@bep](https://github.com/bep) 




