### PR TITLE
aks-engine 0.51.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.50.2"
+local version = "0.51.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "a0be0f9f079f2e6a4bb661727ef257b44d892f289a9e09f169e07724362bfa91",
+            sha256 = "7424df1206f1318cc702cf5f6c12c6f0608ba4d68626473171caca6d879bca0e",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "b6af1a6a4fb44757c1a05bc05999cdc9052538d9cb3f76683005bc70edca4e83",
+            sha256 = "f32fcb10886ad78da3397b3064603a59a702bc8cc3a730b7043ee156208694e0",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "2586d03a0003f434d61114712401d5ec7a53950fe52e78be7dc1f264d9f64393",
+            sha256 = "9a25aacf2f3cd24f88fbf1b0774a76b2a4c228a37b94dbd7e71ce41c8a43020f",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.51.0. 

# Release info 

 <a name="v0.51.0"></a>
# [v0.51.0] - 2020-05-21
### Bug Fixes 🐞
- ensure pod-security-policy is the first addon loaded ([#3313](https://github.com/Azure/aks-engine/issues/3313))
- prevent panic in Windows scale if no tags ([#3308](https://github.com/Azure/aks-engine/issues/3308))
- ensure ERR_K8S_API_SERVER_DNS_LOOKUP_FAIL is returned when DNS check fails ([#3303](https://github.com/Azure/aks-engine/issues/3303))
- addon-manager definition should be under "labels" ([#3302](https://github.com/Azure/aks-engine/issues/3302))
- whitespace trimming in cloud-provider spec is broken ([#3301](https://github.com/Azure/aks-engine/issues/3301))
- increase apiserver connection timeout for private apiserver ([#3293](https://github.com/Azure/aks-engine/issues/3293))
- fix issue provisioning windows nodes with kubenet ([#3300](https://github.com/Azure/aks-engine/issues/3300))
- ensure /mnt is ext4 ([#3297](https://github.com/Azure/aks-engine/issues/3297))
- USER_ASSIGNED_IDENTITY_ID is empty in azure.json ([#3254](https://github.com/Azure/aks-engine/issues/3254))
- update Windows image validate on Azure Stack Hub ([#3260](https://github.com/Azure/aks-engine/issues/3260))
- Add Windows node pool to containerd tests ([#3238](https://github.com/Azure/aks-engine/issues/3238))
- USER_ASSIGNED_IDENTITY_ID is empty in azure.json ([#3232](https://github.com/Azure/aks-engine/issues/3232))
- update Azure Stack Windows binaries component name ([#3231](https://github.com/Azure/aks-engine/issues/3231))
- set Windows defender process exclustion for containerd ([#3215](https://github.com/Azure/aks-engine/issues/3215))
- aad-pod-identity taints foo works in k8s < 1.16 ([#3199](https://github.com/Azure/aks-engine/issues/3199))
- update dcap checksum file ([#3172](https://github.com/Azure/aks-engine/issues/3172))
- added resource limits for networkmonitor daemonset ([#2624](https://github.com/Azure/aks-engine/issues/2624))
- don't hardcode pause image for containerD on Windows ([#3158](https://github.com/Azure/aks-engine/issues/3158))
- Expose error details in Windows CSE ([#3159](https://github.com/Azure/aks-engine/issues/3159))
- correct destination filename for scheduled maintenance addon ([#3142](https://github.com/Azure/aks-engine/issues/3142))
- Correct wrong file name in the logs ([#3138](https://github.com/Azure/aks-engine/issues/3138))

### Code Refactoring 💎
- consolidate pod-security-policy addon spec ([#3284](https://github.com/Azure/aks-engine/issues/3284))
- consolidate cilium addons specs ([#3289](https://github.com/Azure/aks-engine/issues/3289))
- consolidate azure-network-policy addon spec ([#3283](https://github.com/Azure/aks-engine/issues/3283))
- consolidate azure-cloud-provider addon spec ([#3277](https://github.com/Azure/aks-engine/issues/3277))
- move etcd data disk mounting to cloud init  ([#3273](https://github.com/Azure/aks-engine/issues/3273))
- consolidate nvidia-device-plugin addon spec ([#3235](https://github.com/Azure/aks-engine/issues/3235))
- consolidate metrics-server addon spec ([#3211](https://github.com/Azure/aks-engine/issues/3211))
- use newer "az deployment group" CLI syntax ([#3213](https://github.com/Azure/aks-engine/issues/3213))
- consolidate cluster-autoscaler addon spec ([#3198](https://github.com/Azure/aks-engine/issues/3198))
- consolidate azure-cni-networkmonitor addon spec ([#3189](https://github.com/Azure/aks-engine/issues/3189))
- use simpler file names for addons maintenance ([#3187](https://github.com/Azure/aks-engine/issues/3187))
- simplify golangci-lint invocation ([#3182](https://github.com/Azure/aks-engine/issues/3182))
- simplify kubelet systemd service ([#3167](https://github.com/Azure/aks-engine/issues/3167))
- enable generic --register-with-taints and --register-node ([#3155](https://github.com/Azure/aks-engine/issues/3155))

### Continuous Integration 💜
- passing container runtime var when executing new-windows-sku.sh in dev container ([#3242](https://github.com/Azure/aks-engine/issues/3242))
- ensure sku title/summary/longsummary is unique when creating new marketplace skus ([#3239](https://github.com/Azure/aks-engine/issues/3239))
- enable staticcheck linter ([#3191](https://github.com/Azure/aks-engine/issues/3191))
- disable artifact publishing ([#3163](https://github.com/Azure/aks-engine/issues/3163))

### Documentation 📘
- aks-ubuntu-18.04 is default distro ([#3317](https://github.com/Azure/aks-engine/issues/3317))
- fix capitalization ([#3264](https://github.com/Azure/aks-engine/issues/3264))
- AKS-engine (on Stack) considerations around the use of proxy servers ([#3241](https://github.com/Azure/aks-engine/issues/3241))
- remove out of date Calico upgrade note ([#3243](https://github.com/Azure/aks-engine/issues/3243))
- update quickstart.md to add scoop install guide ([#3218](https://github.com/Azure/aks-engine/issues/3218))
- update sgx plugin docs ([#3230](https://github.com/Azure/aks-engine/issues/3230))
- rewrite monitoring topic ([#3205](https://github.com/Azure/aks-engine/issues/3205))
- add missing link to upgrade doc ([#3221](https://github.com/Azure/aks-engine/issues/3221))
- update sgx install instructions to dcv2 vms and newer resource name ([#3214](https://github.com/Azure/aks-engine/issues/3214))
- refresh documentation store ([#3177](https://github.com/Azure/aks-engine/issues/3177))
- remove obsolete api versions documentation ([#3175](https://github.com/Azure/aks-engine/issues/3175))
- document AKS Engine E2E ([#3131](https://github.com/Azure/aks-engine/issues/3131))
- include v0.48.0 in Azure Stack docs ([#3153](https://github.com/Azure/aks-engine/issues/3153))

### Features 🌈
- Updating Windows VHDs to include May patches ([#3263](https://github.com/Azure/aks-engine/issues/3263))
- enable alternate kube-reserved cgroups ([#3201](https://github.com/Azure/aks-engine/issues/3201))
- add support for Kubernetes 1.15.12 ([#3212](https://github.com/Azure/aks-engine/issues/3212))
- add support for Kubernetes 1.19.0-alpha.3 ([#3197](https://github.com/Azure/aks-engine/issues/3197))
- add warning message for empty Location string ([#3174](https://github.com/Azure/aks-engine/issues/3174))
- block imds from VMSS nodes if aad-pod-identity + msi ([#3136](https://github.com/Azure/aks-engine/issues/3136))
- Create Windows containerd VHDs ([#3162](https://github.com/Azure/aks-engine/issues/3162))
- configurable disk caching ([#2863](https://github.com/Azure/aks-engine/issues/2863))
- Kubernetes Dashboard addon v2.0.0 ([#3140](https://github.com/Azure/aks-engine/issues/3140))

### Maintenance 🔧
- remove support for Kubernetes 1.14 ([#3310](https://github.com/Azure/aks-engine/issues/3310))
- make 1.18 the default Kubernetes version ([#3298](https://github.com/Azure/aks-engine/issues/3298))
- disable 18.04 + N series VM node pool ([#3275](https://github.com/Azure/aks-engine/issues/3275))
- don't force create etcd_disk filesystem ([#3276](https://github.com/Azure/aks-engine/issues/3276))
- update Windows pause image ([#3210](https://github.com/Azure/aks-engine/issues/3210))
- rev Linux VHDs to 2020.05.13 ([#3265](https://github.com/Azure/aks-engine/issues/3265))
- remove defunct build-windows-k8s.sh script ([#3248](https://github.com/Azure/aks-engine/issues/3248))
- update zip name for mooncake mirror ([#3237](https://github.com/Azure/aks-engine/issues/3237))
- update Windows VHD to use May 2020 updates ([#3236](https://github.com/Azure/aks-engine/issues/3236))
- updating cni to v1.1.2 ([#3192](https://github.com/Azure/aks-engine/issues/3192))
- update nvidia device plugin ([#3225](https://github.com/Azure/aks-engine/issues/3225))
- bump csi-secrets-store to v0.0.10, keyvault provider to 0.0.5 ([#3233](https://github.com/Azure/aks-engine/issues/3233))
- pull cached Azure Stack Windows binaries from shared SA ([#3223](https://github.com/Azure/aks-engine/issues/3223))
- Updating Azure NPM to v1.1.2 ([#3178](https://github.com/Azure/aks-engine/issues/3178))
- Update Policy addon versions ([#3208](https://github.com/Azure/aks-engine/issues/3208))
- get-logs command on Azure Stack ([#3216](https://github.com/Azure/aks-engine/issues/3216))
- Updating Antrea version to 0.6.0 ([#3204](https://github.com/Azure/aks-engine/issues/3204))
- update Windows VHD build to use mcr.microsoft.com/oss/kubernets/pause:1.3.1 ([#3209](https://github.com/Azure/aks-engine/issues/3209))
- append Azure Stack suffix to custom components images ([#3195](https://github.com/Azure/aks-engine/issues/3195))
- add new M-series SKUs ([#3190](https://github.com/Azure/aks-engine/issues/3190))
- mutex is not necessary now that rand uses local object ([#3048](https://github.com/Azure/aks-engine/issues/3048))
- check all error returns in main code ([#3184](https://github.com/Azure/aks-engine/issues/3184))
- update go-dev image to v1.27.0 ([#3181](https://github.com/Azure/aks-engine/issues/3181))
- check all error returns in tests ([#3183](https://github.com/Azure/aks-engine/issues/3183))
- aad-pod-identity taint ([#3143](https://github.com/Azure/aks-engine/issues/3143))
- add support for Kubernetes 1.17.4 & 1.17.5 on Azure Stack ([#3161](https://github.com/Azure/aks-engine/issues/3161))
- remove //+build !test pragma ([#3169](https://github.com/Azure/aks-engine/issues/3169))
- standardize to {{- for go template expressions ([#3166](https://github.com/Azure/aks-engine/issues/3166))
- remove KUBELET_IMAGE kubelet systemd env var ([#3165](https://github.com/Azure/aks-engine/issues/3165))
- remove deprecated KUBELET_REGISTER_SCHEDULABLE ([#3164](https://github.com/Azure/aks-engine/issues/3164))
- add support for Kubernetes 1.15.11, 1.16.8 & 1.16.9 on Azure Stack ([#3157](https://github.com/Azure/aks-engine/issues/3157))
- update cluster-autoscaler version for k8s 1.19 ([#3133](https://github.com/Azure/aks-engine/issues/3133))

### Testing 💚
- skip azurefile test if using containerd ([#3316](https://github.com/Azure/aks-engine/issues/3316))
- use common timeout for repeat tests ([#3314](https://github.com/Azure/aks-engine/issues/3314))
- add stability test tolerance for calico cluster test configs ([#3287](https://github.com/Azure/aks-engine/issues/3287))
- az deployment group create in E2E runner ([#3249](https://github.com/Azure/aks-engine/issues/3249))
- rationalize "everything" E2E config for coredns autoscaler test ([#3206](https://github.com/Azure/aks-engine/issues/3206))
- reduce node count in E2E "everything" config ([#3200](https://github.com/Azure/aks-engine/issues/3200))
- fix e2e for custom clouds using ADFS ([#3150](https://github.com/Azure/aks-engine/issues/3150))
- rationalize E2E env defaults ([#3132](https://github.com/Azure/aks-engine/issues/3132))
- faster base config test ([#3130](https://github.com/Azure/aks-engine/issues/3130))
- e2e on custom clouds ([#3117](https://github.com/Azure/aks-engine/issues/3117))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.51.0...HEAD
[v0.51.0]: https://github.com/Azure/aks-engine/compare/v0.50.2...v0.51.0