### PR TITLE
eksctl 0.20.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.19.0"
+local version = "0.20.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "442b2b20097422ea6cdfe8a3fbfcfc3d3c864abd56bcf45dd2236702a222f5c0",
+            sha256 = "a96d4b367522461394e7546578bae9113bdd9703e7c8144b5b815a9d329a193a",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "054bc9231eaf12efb9f30a93edbd90cfd4c52ce68d2138cdaff5d5e53002eb11",
+            sha256 = "069f1980a7942a038e181e7e75d23fa3d8102c2667c1560475cf3bfb570c745a",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "13d975a5172205116ba4f9647fdfb744e9c6d0adea87a73d0a264fe2f461d141",
+            sha256 = "fbfc1f4835245245e554e09301620f9126659229137e5d6658dfad2150fe66c9",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.20.0. 

# Release info 

 # Release 0.20.0

## Features

- Add support for GovCloud regions (#2190)
- Add nodes-min and nodes-max flags in ng scale (#2022)
- Make Kubernetes 1.16 the default version (#2204 #2199)
- Add support for setting up Gitops during cluster creation (#2212)
- Install neuron plugin for inf1 instances (#2162)


## Improvements

- Add name argument for delete iamserviceaccount (#2165)
- List supported k8s versions (#2126)
- Add IAM permissions required by AWS ALB Ingress to use WAFv2 and Shield (#2213)

## Bug Fixes

- Fix Fargate on Kubernetes 1.16 (#2183)
- Fix flags issue in version cli (#2187)
- Filter only kops ec2 resource with type ec2.ResourceTypeSubnet (#1752)
- Fix timeouts in gitops operations on Fargate (#2232)

## Acknowledgments
Weaveworks would like to sincerely thank:
@agbanagba,  @justinclayton,  @polanfong, @rimaulana, @sayboras and @smrutiranjantripathy

