### PR TITLE
helmfile 0.118.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.116.0"
+local version = "0.118.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "d7cef1951a3489d6434b14b7890655ca279d29fd230d7769a001a0b5734cc983",
+            sha256 = "8894ae6bd611a8caf35cf86c9355ae77d01186c14a1c83614100f6300cabb538",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "ecbf4117241bb8081b50e199619ae3d201c0e9c493a1e6f3589e299c452d4c20",
+            sha256 = "1bff4358c80669d6340e8b70e183387b30959103a60cbcd652dd8712d36322b4",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "0d45e0d57a46134c7a0342e184f43aaa420b1ed6479052ef89152a56b30b45ef",
+            sha256 = "176edb78abbf76c8020d8f7dc7af9176396cf02013902dadb08fb7f5a151c324",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "67c5f90a88b5bf6c77ef1d1be6f19ebbb1b3270443828f03a23f887771e49b6a",
+            sha256 = "aa98911ead593538f25de2e7bb97ff3831a00d8c51f40dc9c55c62d059d0e113",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "7488150c0844949f9438030d4b248fb740463d6163c3c9c71ac626de74d53568",
+            sha256 = "260508517046e7e8a81e56afe159ddd8627fe7cb9cb85eea39bdff94b89e1c4b",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "a978115f31784339e6625293d954248db1644fd46c6d807909415c03d4d2f992",
+            sha256 = "19eb4314f3505cac04a16b69ec21303400b7e94bbce11b6dcbe22c29a9c773bc",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.118.0. 

# Release info 

 16288df (HEAD, tag: v0.118.0, origin/master, origin/HEAD, master) feat: GA of Kustomize and K8s manifests support (#1172) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/5142)