### PR TITLE
helmfile 0.118.1

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.118.0"
+local version = "0.118.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "8894ae6bd611a8caf35cf86c9355ae77d01186c14a1c83614100f6300cabb538",
+            sha256 = "3e3046e67100ef9b08e4e3b738297e684dd83ffde02b90a7895b5664b6678224",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "1bff4358c80669d6340e8b70e183387b30959103a60cbcd652dd8712d36322b4",
+            sha256 = "67a800cbb7923f7181b97ea313af2d23db495a4336023f0edd5508fb965a6fa9",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "176edb78abbf76c8020d8f7dc7af9176396cf02013902dadb08fb7f5a151c324",
+            sha256 = "3694bfe70a504a6b99d7fc73a4953e9cafe26008ca03b1e55d6396c8d65e13a8",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "aa98911ead593538f25de2e7bb97ff3831a00d8c51f40dc9c55c62d059d0e113",
+            sha256 = "0f35bb344cc1e43eb7a349803f380f554059904caf7b3de3249e49f0d01b3a5b",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "260508517046e7e8a81e56afe159ddd8627fe7cb9cb85eea39bdff94b89e1c4b",
+            sha256 = "fd89ac5e647b3daabdd59b3b782d849e27b7f3acc7bdc42f12b5ab5b13609a89",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "19eb4314f3505cac04a16b69ec21303400b7e94bbce11b6dcbe22c29a9c773bc",
+            sha256 = "e7f356e17b8725294d86a5e1ce9be8855c503fd5ef2fd0f7fb5b8142c9b2e296",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.118.1. 

# Release info 

 930f91a (HEAD, tag: v0.118.1, origin/master, origin/HEAD, master) Merge pull request #1273 from roboll/fix-chartify
1cfce32 (origin/fix-chartify) Add documentation for releases[].{strategicMergePatches,jsonPatches}
29fdb57 fix: Support for kustomization as chart
68432b1 fix: Do not skip passing values files when adhocDependencies/jsonPatches/jsonPatches exist 
### [Build Info](https://circleci.com/gh/roboll/helmfile/5173)