### PR TITLE
k9s 0.20.2

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,7 +1,7 @@
 local name = "k9s"
 local org = "derailed"
-local release = "v0.19.7"
-local version = "0.19.7"
+local release = "v0.20.2"
+local version = "0.20.2"
 food = {
     name = name,
     description = "🐶 Kubernetes CLI To Manage Your Clusters In Style!",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "970e6d483af6713eb533b682926237197d14c91cb9245dd35af76d028fd8cad6",
+            sha256 = "4b4a12ff5cb89f61ce3044417bccbd2a9568cb65ca23775cf69d1491f6d01c52",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "d550594356f34bbcdbe2327ae2ac4144d0ce8f720707cf3228e57fe9df0d8d4a",
+            sha256 = "c51be2299ba36a31cbc5ed69ad50d8b4ba8bbf4143c7104da53e2e447fee5c2b",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "2d399d7fd4291bc9e16030743bf81f0a78fb7719544712b8f4645f41d99dcc0c",
+            sha256 = "485ef75ccf8c4e5bac5f4595590816b9d3fc60cfb90fbf37c38a1847e28145ce",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.20.2. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.20.2

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better is as ever very much noticed and appreciated!

Also if you dig this tool, consider joining our [sponsorhip program](https://github.com/sponsors/derailed) and/or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

---

## Maintenance Release!

Fixing a few issues in the v0.20 aftermath ;(
Thank you all for reporting these issues and for your patience!

## Selection Marker

In this drop, we're adding the ability to set row mark ranges. There are situations where you've filtered a resource and need to delete part or all of the rows. In previous releases, you had to mark each rows one by one. Now you have the ability to select the beginning and end range and all rows in between will now be marked! To mark a single row, you can use `space`. To select rows between your initial mark to the current selection use `Ctrl-space`. To nuke all marked rows use `Ctrl-\`. All credits and ATTA BOY! goes to [Ryan Richard](https://github.com/cfryanr) for suggesting this feature! Thank you Ryan!!

## Logs Got Some TLC!

Per [Raman Gupta](https://github.com/rocketraman) excellent suggestion, we've added a way to add a separator to your chatty logs to easily see the latest incoming logs. While in log view, you can now press `m` for mark to add the separator to the log stream. If you don't care about the log history and just want to see the latest incoming logs, pressing `c` will clear out the log viewer.

## Resolved Bugs/Features/PRs

- [Issue #741](https://github.com/derailed/k9s/issues/741)
- [Issue #740](https://github.com/derailed/k9s/issues/740)
- [Issue #739](https://github.com/derailed/k9s/issues/739)
- [Issue #727](https://github.com/derailed/k9s/issues/727)
- [Issue #723](https://github.com/derailed/k9s/issues/723)
- [PR #725](https://github.com/derailed/k9s/pull/725) Big Thanks To [Soupyt](https://github.com/soupyt)!!

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

