### PR TITLE
minikube 1.11.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.10.1"
-local version = "1.10.1"
+local release = "v1.11.0"
+local version = "1.11.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "9c51656f6855b4dff9a6f0bf1136255c18bc07c467ff67b32257da921e879246",
+            sha256 = "cc1b8a3327661be6a5d4dc1d6f9891aeeca40f7d9a389aaaffd8d4a1abbe294b",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "0639343ba6076e702550c42315061cfb95a3e99072906fb3ea56e0cb82b08a85",
+            sha256 = "8a6bdeec07cae4b5e9fe1e51492f4c2828cd326d621ddcbee050a56b3c054359",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "acc67ea2ff1ca261269a702a6d998367f65c86d9024c20bbf5ac3922bfca1aaa",
+            sha256 = "0b07a295d5110dc70907e4660429b8f9b3e8c05119e42f73e192b5313695a913",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "c38dabe3d91173bdee8867b257336f1ed699b0ae6594cc0ccc99a58d3bbdc594",
+            sha256 = "8630c05fbbd0e2035ffea0fac8f4a77056696481c9d2e868a7869e4b4e6e386f",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
-            sha256 = "60d4db87a834509a69b70ac253de040eabfb9e96aaf3cee159f73c3d5f37e81a",
+            sha256 = "e94991292f4a0c5b91ef165f826c6a615a122513e8771c8f9ce5b7ec96ab9df0",
             resources = {
                 {
                     path = name,
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "60d4db87a834509a69b70ac253de040eabfb9e96aaf3cee159f73c3d5f37e81a",
+            sha256 = "e94991292f4a0c5b91ef165f826c6a615a122513e8771c8f9ce5b7ec96ab9df0",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -89,7 +89,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "7a68eb0fee88cc4e5df54338c72075a3294149776f7a1e2da4903b51d41e301a",
+            sha256 = "ae99bf82b2f2d73fd5e71bb2ac02ad2440941f5fba9db1007dfee55daec3d250",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.11.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.11.0 - 2020-05-29

Features:

* add 'defaults' sub-command to `minikube config` [#8143](https://github.com/kubernetes/minikube/pull/8143)
* addons: add OLM addon [#8129](https://github.com/kubernetes/minikube/pull/8129)
* addons:: Add Ambassador Ingress controller addon [#8161](https://github.com/kubernetes/minikube/pull/8161)
* bump oldest k8s version supported to 1.13 [#8154](https://github.com/kubernetes/minikube/pull/8154)
* bump default kubernetes version to 1.18.3 [#8307](https://github.com/kubernetes/minikube/pull/8307)
* Bump helm-tiller 2.16.7 and promote tiller ClusterRoleBinding to v1 [#8174](https://github.com/kubernetes/minikube/pull/8174)

Minor Improvements:

* docker/podman drivers: add fall back image in docker hub [#8320](https://github.com/kubernetes/minikube/pull/8320)
* docker/podman drivers: exit with usage when need login to registry [#8225](https://github.com/kubernetes/minikube/pull/8225)
* multinode: copy apiserver certs only to control plane [#8092](https://github.com/kubernetes/minikube/pull/8092)
* docker-env: restart dockerd inside minikube on failure [#8239](https://github.com/kubernetes/minikube/pull/8239)
* wait for kubernetes components on soft start [#8199](https://github.com/kubernetes/minikube/pull/8199)
* improve minikube status display for one node [#8238](https://github.com/kubernetes/minikube/pull/8238)
* improve solution message for wrong kuberentes-version format [#8118](https://github.com/kubernetes/minikube/pull/8118)

Bug fixes:

* fix HTTP_PROXY env not being passed to docker engine [#8198](https://github.com/kubernetes/minikube/pull/8198)
* honor --image-repository even if --image-mirror-country is set [#8249](https://github.com/kubernetes/minikube/pull/8249)
* parallels driver: fix HostIP implementation [#8259](https://github.com/kubernetes/minikube/pull/8259)
* addon registry: avoid getting stuck on registry port 443 [#8208](https://github.com/kubernetes/minikube/pull/8208)
* respect native-ssh param properly [#8290](https://github.com/kubernetes/minikube/pull/8290)
* fixed parsing kubernetes version for keywords "latest" or "stable" [#8230](https://github.com/kubernetes/minikube/pull/8230)
* multinode: make sure multinode clusters survive restarts [#7973](https://github.com/kubernetes/minikube/pull/7973)
* multinode: delete docker volumes when deleting a  node [#8224](https://github.com/kubernetes/minikube/pull/8224)
* multinode: delete worker volumes for docker driver [#8216](https://github.com/kubernetes/minikube/pull/8216)
* multinode: recreate existing control plane node correctly [#8095](https://github.com/kubernetes/minikube/pull/8095)

Huge thank you for this release towards our contributors:

- Anders F Björklund
- Kenta Iso
- Medya Ghazizadeh
- Mikhail Zholobov
- Natale Vinto
- Nicola Ferraro
- Priya Wadhwa
- RA489
- Sharif Elgamal
- Shubham
- kadern0

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`af64ce117799143e647a406f771cf0714761b6a25925b5900778168d41496ca2`