### PR TITLE
polaris 1.0.3

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,7 +1,7 @@
 local name = "polaris"
 local org = "FairwindsOps"
-local release = "1.0.2"
-local version = "1.0.2"
+local release = "1.0.3"
+local version = "1.0.3"
 food = {
     name = name,
     description = "Validation of best practices in your Kubernetes clusters",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "655f1b1a0297ce69f48dfb815f4bb566df39bf505600374b520b33052a12b3d7",
+            sha256 = "24959266d40f6ff69866b8d4060e40a48accd95a5798e2eb374c96f906b9b0e9",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "4339dde5a7cb69a4963d20ee6075d6243bb85962f6507a7c1b44ea8443a79c1f",
+            sha256 = "bd01b1102a229b6401bdf60e324d992114585380a5df8efc7a64a41df1947007",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 1.0.3. 

# Release info 

 

## Changelog

fb98d311 Bump github.com/gobuffalo/mapi from 1.2.0 to 1.2.1 (#316)
deb33bb0 Bump github.com/gogo/protobuf from 1.2.1 to 1.3.1 (#310)
97c81ccf Bump github.com/golang/protobuf from 1.4.0 to 1.4.2 (#315)
e605eef7 Bump github.com/grpc-ecosystem/grpc-gateway from 1.9.0 to 1.14.6 (#306)
217e3563 Bump github.com/imdario/mergo from 0.3.7 to 0.3.9 (#312)
eea4a8e2 Bump google.golang.org/api from 0.5.0 to 0.25.0 (#317)
e9b79fbd Bump k8s.io/klog from 0.3.0 to 0.4.0 (#314)
2cdc4775 bump to 1.0.3 (#325)
af5b86e2 catch cache error (#324)
1021f6b1 fix basepath link (#319)
f657071a fix goreleaser (#326)
33524757 set minor version in polaris tag (#323)
0111b7ec update documentation (#318)


