### PR TITLE
aks-engine 0.52.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.51.0"
+local version = "0.52.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "7424df1206f1318cc702cf5f6c12c6f0608ba4d68626473171caca6d879bca0e",
+            sha256 = "a1ea61f0184066b17ee77b038d41de2d751ae7e18240c5221dd2fdec4fdd7695",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "f32fcb10886ad78da3397b3064603a59a702bc8cc3a730b7043ee156208694e0",
+            sha256 = "bd168e3e2132010ae3df0089c2a4b223680a7a5269466605b9e0849fdf56449a",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "9a25aacf2f3cd24f88fbf1b0774a76b2a4c228a37b94dbd7e71ce41c8a43020f",
+            sha256 = "649455e35275be359d63a8f5b78dc99ed2a5d1cecbecca076784c1349462e079",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.52.0. 

# Release info 

 <a name="v0.52.0"></a>
# [v0.52.0] - 2020-06-04

### Bug Fixes 🐞
- bypass AzurePublicCloud assumption in e2e suite ([#3371](https://github.com/Azure/aks-engine/issues/3371))
- use nvidia drivers version 418.126.02 for 18.04 ([#3366](https://github.com/Azure/aks-engine/issues/3366))
- use right nodeSelector for cluster-autoscaler addon ([#3350](https://github.com/Azure/aks-engine/issues/3350))
- use ctr to remove containerd containers ([#3144](https://github.com/Azure/aks-engine/issues/3144))
### Code Refactoring 💎
- consolidate tiller addon spec ([#3399](https://github.com/Azure/aks-engine/issues/3399))
- consolidate smb-flexvolume addon spec ([#3397](https://github.com/Azure/aks-engine/issues/3397))
- consolidate kube-proxy addon spec ([#3391](https://github.com/Azure/aks-engine/issues/3391))
- consolidate kube-dns addon spec ([#3390](https://github.com/Azure/aks-engine/issues/3390))
- consolidate keyvault-flexvolume addon spec ([#3389](https://github.com/Azure/aks-engine/issues/3389))
- consolidate flannel addon spec ([#3385](https://github.com/Azure/aks-engine/issues/3385))
- drop "beta" from kubernetes.io/os label ([#3369](https://github.com/Azure/aks-engine/issues/3369))
- consolidate aci-connector addon spec ([#3358](https://github.com/Azure/aks-engine/issues/3358))
- consolidate blobfuse-flexvolume addon spec ([#3359](https://github.com/Azure/aks-engine/issues/3359))
- consolidate calico addon spec ([#3361](https://github.com/Azure/aks-engine/issues/3361))
- consolidate cloud-node-manager addon spec ([#3363](https://github.com/Azure/aks-engine/issues/3363))
- consolidate aad-pod-identity addon spec ([#3356](https://github.com/Azure/aks-engine/issues/3356))
- consolidate audit-policy "addon" spec ([#3355](https://github.com/Azure/aks-engine/issues/3355))
- consolidate ip-masq-agent addon spec ([#3347](https://github.com/Azure/aks-engine/issues/3347))
- consolidate kube-rescheduler addon spec ([#3323](https://github.com/Azure/aks-engine/issues/3323))

### Continuous Integration 💜
- updating pub to v0.2.3 ([#3398](https://github.com/Azure/aks-engine/issues/3398))
- add notice file for windows vhd ([#3345](https://github.com/Azure/aks-engine/issues/3345))
- use ginkgo 1.12, run go mod vendor during make coverage ([#3343](https://github.com/Azure/aks-engine/issues/3343))
- enable multiple static resource group exclusions in cleanup script ([#3340](https://github.com/Azure/aks-engine/issues/3340))
- moving windows vhd/image related test configs to westus2 ([#3320](https://github.com/Azure/aks-engine/issues/3320))

### Documentation 📘
- update sgx doc and sgx-test tag ([#3349](https://github.com/Azure/aks-engine/issues/3349))
### Features 🌈
- add "get-versions --azure-env" flag to list custom clouds supported versions ([#3394](https://github.com/Azure/aks-engine/issues/3394))
- configurable calico logging verbosity ([#3396](https://github.com/Azure/aks-engine/issues/3396))
- deprecate heapster addon ([#3387](https://github.com/Azure/aks-engine/issues/3387))
- add support for Kubernetes 1.18.3 ([#3309](https://github.com/Azure/aks-engine/issues/3309))
- add support for Kubernetes 1.16.10 ([#3312](https://github.com/Azure/aks-engine/issues/3312))
- add support for Kubernetes 1.17.6 ([#3311](https://github.com/Azure/aks-engine/issues/3311))
- add support for Kubernetes 1.19.0-beta.0 ([#3299](https://github.com/Azure/aks-engine/issues/3299))
### Maintenance 🔧
- use local kubeconfig if no outbound ([#3410](https://github.com/Azure/aks-engine/issues/3410))
- standardize nodeSelectors ([#3406](https://github.com/Azure/aks-engine/issues/3406))
- rev Windows VHD to 17763.1217.200603 ([#3407](https://github.com/Azure/aks-engine/issues/3407))
- update node-problem-detector to v0.8.2 ([#3365](https://github.com/Azure/aks-engine/issues/3365))
- Add EnableAHUB in WindowsProfile ([#3322](https://github.com/Azure/aks-engine/issues/3322))
- rev AKS Engine VHDs to 2020.06.02 ([#3395](https://github.com/Azure/aks-engine/issues/3395))
- remove unused, deprecated blobfuse spec ([#3384](https://github.com/Azure/aks-engine/issues/3384))
- Bump moby version to 3.0.12 ([#3376](https://github.com/Azure/aks-engine/issues/3376))
- add support for K8s 1.16.10 & 1.17.6 on Azure Stack ([#3377](https://github.com/Azure/aks-engine/issues/3377))
- rev Linux VHDs to 2020.05.29 ([#3378](https://github.com/Azure/aks-engine/issues/3378))
- rev pause image to 1.3.1 ([#3370](https://github.com/Azure/aks-engine/issues/3370))
- get-logs collects vhd-install.complete ([#3372](https://github.com/Azure/aks-engine/issues/3372))
- change MTU only if not Azure CNI on Azure Stack ([#3367](https://github.com/Azure/aks-engine/issues/3367))
- upgrade cni to v1.1.3 ([#3353](https://github.com/Azure/aks-engine/issues/3353))
- remove old labels.yaml file ([#3357](https://github.com/Azure/aks-engine/issues/3357))
- update CNI binary to 0.8.6 ([#3332](https://github.com/Azure/aks-engine/issues/3332))
- k8s v1.17 conformance model for Azure Stack ([#3338](https://github.com/Azure/aks-engine/issues/3338))
- update kube-dashboard addon to v2.0.1 ([#3327](https://github.com/Azure/aks-engine/issues/3327))
- rev coredns to 1.6.9 ([#3328](https://github.com/Azure/aks-engine/issues/3328))
- rev default etcd version to 3.3.22 ([#3325](https://github.com/Azure/aks-engine/issues/3325))

### Testing 💚
- print podsecuritypolicy resources during E2E ([#3386](https://github.com/Azure/aks-engine/issues/3386))
- Add test support for windows server 1909 ([#3379](https://github.com/Azure/aks-engine/issues/3379))
- remove Kubernetes version restrictions from sgx tests ([#3374](https://github.com/Azure/aks-engine/issues/3374))
- run everything E2E config against all cluster versions ([#3348](https://github.com/Azure/aks-engine/issues/3348))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.52.0...HEAD
[v0.52.0]: https://github.com/Azure/aks-engine/compare/v0.51.0...v0.52.0