### PR TITLE
eksctl 0.21.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.20.0"
+local version = "0.21.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "a96d4b367522461394e7546578bae9113bdd9703e7c8144b5b815a9d329a193a",
+            sha256 = "3cdcbb1792bb131cc0ed944cbfc51dd6f1b2261a480436efc6f8124dea7c8c14",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "069f1980a7942a038e181e7e75d23fa3d8102c2667c1560475cf3bfb570c745a",
+            sha256 = "4573bca35af67fa002fb722b4d41fae2224a27576619ed2f1e269dd7bd15c214",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "fbfc1f4835245245e554e09301620f9126659229137e5d6658dfad2150fe66c9",
+            sha256 = "455f227b1d8b3f588de3efd93b5547674f21cac0a744ba69c8e6159bca17deb6",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.21.0. 

# Release info 

 # Release 0.21.0


## Features

- Ability of changing the node instance name (#1796)
- Lock kubeconfig file before accessing (#2230)
- Use aws-node 1.6.2 (#2288 #2289)

## Improvements

- Use apps/v1 for Deployment for all K8s versions (#2238)
- Propagate SSH_AUTH_SOCK environment variable to git executor (#2083)

## Bug Fixes

- Try to delete nodegroup for any nodegroup state (#2252)
- Fix bug in supporting non-default branches for gitops repos (#2246)
- Don't run extra cluster tasks and nodegroup creation in parallel (#2248)
- Fix update-cluster-endpoints panic when using a cluster config with missing VPC section (#2253)
- Make sure kubeconfig directory exists before locking (#2271 #2272)

## Acknowledgments
Weaveworks would like to sincerely thank:
@aaronjwood,  @danil-smirnov, @hiddeco,  @mikestef9, @rndstr, @rodrigc and @spaghettifunk

