### PR TITLE
helm 3.2.2

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.2.1"
+local version = "3.2.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "983c4f167060b3892a42f353c7891cabac36ec49f6042eae1046bd8a258b8a14",
+            sha256 = "8815169407011ef989a4b1b95d83f58353ae3dbe17f39d3b927ec95b57fc4aa3",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "018f9908cb950701a5d59e757653a790c66d8eda288625dbb185354ca6f41f6b",
+            sha256 = "305cc92bc21c902a5337a9e1a63316ef67f6e06000d878cf22eb504c6750745c",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "f1a058d7469003cd2605c8b76f328863bdfa17e176910adac9cbbcac2da4ca93",
+            sha256 = "a94e0e894b7018b74f26a0fffd7e4d9ebdf7e121f9b5b3cf6a746e38c507fb50",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.2.2. 

# Release info 

 This release is marked as a security release due to a nuance with the Go module proxy. During the last release, a Git tag was accidentally created, then deleted, and then re-created correctly. In that time, the Go proxy cached the wrong version. Even now, a month later, the Google-run proxy has an invalid SHA. Thus, when a build from source occurs, in some rare cases the user may get a security error directly from the Go toolchain.

There is no actual security vulnerability here. Both SHAs (the real one and the one in Go proxy) pull safe-to-build versions of the source code. However, only the tag's current SHA is the correct SHA for Helm. See [issue 8246](https://github.com/helm/helm/issues/8246). And thanks to Scott Gregory for bringing this to our attention.

Helm v3.2.2 is the second patch release for Helm 3.2 and it includes several bug fixes. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.2.2. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.2.2-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-darwin-amd64.tar.gz.sha256sum) / 8815169407011ef989a4b1b95d83f58353ae3dbe17f39d3b927ec95b57fc4aa3)
- [Linux amd64](https://get.helm.sh/helm-v3.2.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-amd64.tar.gz.sha256sum) / 305cc92bc21c902a5337a9e1a63316ef67f6e06000d878cf22eb504c6750745c)
- [Linux arm](https://get.helm.sh/helm-v3.2.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-arm.tar.gz.sha256sum) / 5ea04e597ee786747b22df951ed8894ebb3e1f90d5da48703452d7a766b0f09a)
- [Linux arm64](https://get.helm.sh/helm-v3.2.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-arm64.tar.gz.sha256sum) / 72ed5d860972a6ee52f3777baf96229dd218dae92c342cbe159333051ee30e81)
- [Linux i386](https://get.helm.sh/helm-v3.2.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-386.tar.gz.sha256sum) / 50afdeae6cf309993ffd3e36e771179803646123eb697fab4919e74efe255fe9)
- [Linux ppc64le](https://get.helm.sh/helm-v3.2.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-ppc64le.tar.gz.sha256sum) / 6b1e5377c5665c6908f014523f622d8db365f639274bfcea30f674de531dc286)
- [Linux s390x](https://get.helm.sh/helm-v3.2.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.2-linux-s390x.tar.gz.sha256sum) / 8815169407011ef989a4b1b95d83f58353ae3dbe17f39d3b927ec95b57fc4aa3)
- [Windows amd64](https://get.helm.sh/helm-v3.2.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.2.2-windows-amd64.zip.sha256sum) / 8b28feea08d6b480419b088ba38242ce2dbc23e9a880d012ab32371e256fdd00)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.2.3 will contain only bug fixes.
- 3.3.0 is the next feature release. This release will focus on linting, OCI updates, and more

## Changelog

- Fixing per gofmt a6ea66349ae3015618da4f547677a14b9ecc09b3 (Matt Farina)
- Fix issue with unhandled error on Stat 1da74ed1bb60b200340db95e672f2c20f7dc5596 (Matt Farina)
- chore(helm): Avoid confusion in command usage 120c25353c7b4f26f646345e22820bd3cae81026 (Marc Khouzam)
- Fix unit test 564044c7d0250b3ace563ca7001097f2f8cee979 (Martin Hickey)
- Fix repo cache setting 4cdc98264bb5a0817075c7287f9af609f232a514 (Martin Hickey)
- Fixing PAX Header handling (#8086) cd29dd34019b5a79e6124df8cf4005cbcdec66e5 (Matt Farina)
- fix: upgrade using --force shoud not run patch logic (#8000) 4b91e1639745fdead179d1ddef394a657c501ed1 (小明同学)
- Set DisableCompression to true to disable unwanted httpclient transformation a8f6ae5bd5de92069e3d9a3d4d53e1dd0912675d (Idan Elhalwani)