### PR TITLE
istioctl 1.6.2

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,7 +1,7 @@
 local name = "istioctl"
 local org = "istio"
-local release = "1.6.1"
-local version = "1.6.1"
+local release = "1.6.2"
+local version = "1.6.2"
 food = {
     name = name,
     description = "Connect, secure, control, and observe services.",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "616cf30294a563b743833369c1435ae27244603d42c15818329f1ead25c0065a",
+            sha256 = "e9a1912e554ef31308bb78a96ab7c43281c7be6f7892337c21dab462fdf97b3e",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "5ac280f72515b328ce1b5779f0f00df742bbb3be142fafa935da58b25a2c1caf",
+            sha256 = "9e6c7f5cc52663a4177d6f275c500b4de5c59f075384c7084e3a7412921c310d",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. release .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "439eb4e4bf4695b1236581b0b7ed57b6620bfdf96915b033e3ae0d2d330c9b27",
+            sha256 = "734dcb1426c1604e261fe2333f6888581b688ab3b4f491e5cd2034740da0468b",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.6.2. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.6.2/)
[Release Notes](https://istio.io/news/announcing-1.6.2/)