### PR TITLE
helm 3.2.4

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.2.3"
+local version = "3.2.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "3062b35ec858b55810623f105eaa092a13676151d494cc8b1f0798b7354f555f",
+            sha256 = "603bc2da184b69e6303a15baf037f55f44de7359d0ba84151459ddc7a20851a8",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "3156e4fe5f034e5b127cf165d61a8a1c48eb7a73b14689b273de5e6117df6fe2",
+            sha256 = "8eb56cbb7d0da6b73cd8884c6607982d0be8087027b8ded01d6b2759a72e34b1",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "7e7a0640c525f42021126d604220066d5b3de4c2273e9e381d9bfd528890949f",
+            sha256 = "9566f9fa92fce2b3930fe32b173a2f2f015d7c967a879012db3255706057a308",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.2.4. 

# Release info 

 Helm v3.2.4 is the fourth patch release for v3.2, patching a security vulnerability found in Helm's HTTP plugin installer affecting all versions of Helm 3 prior to Helm 3.2.4. Users are encouraged to upgrade to receive the patch.

More information on the security advisory can be found [on the security advisory page](https://github.com/helm/helm/security/advisories/GHSA-qq3j-xp49-j73f).

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.2.4. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.2.4-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-darwin-amd64.tar.gz.sha256sum))
- [Linux amd64](https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz.sha256sum))
- [Linux arm](https://get.helm.sh/helm-v3.2.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-arm.tar.gz.sha256sum))
- [Linux arm64](https://get.helm.sh/helm-v3.2.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-arm64.tar.gz.sha256sum))
- [Linux i386](https://get.helm.sh/helm-v3.2.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-386.tar.gz.sha256sum))
- [Linux ppc64le](https://get.helm.sh/helm-v3.2.4-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-ppc64le.tar.gz.sha256sum))
- [Linux s390x](https://get.helm.sh/helm-v3.2.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.2.4-linux-s390x.tar.gz.sha256sum))
- [Windows amd64](https://get.helm.sh/helm-v3.2.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.2.4-windows-amd64.zip.sha256sum))

This release was signed with `967F 8AC5 E221 6F9F 4FD2 70AD 92AA 783C BAAE 8E3B` and can be found at @bacongobbler's [keybase account](https://keybase.io/bacongobbler). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.3.0 is the next feature release.

## Changelog

- Improve the extractor and add tests b6bbe4f08bbb98eadd6c9cd726b08a5c639908b3 (Matt Butcher)