### PR TITLE
Added github action for linting only changed Food's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Install gofish
       run: |
-        npm install -yq curl git sudo
         curl -fsSL https://raw.githubusercontent.com/fishworks/gofish/master/scripts/install.sh | bash
         gofish init
     - name: Changed Files Exporter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Running GoFish linter
+
+on:
+  pull_request:
+     branches:
+      - master
+     paths:
+      - '**.lua'
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+    - name: Setup Action
+      uses: actions/checkout@v2
+    - name: Install gofish
+      run: |
+        npm install -yq curl git sudo
+        curl -fsSL https://raw.githubusercontent.com/fishworks/gofish/master/scripts/install.sh | bash
+        gofish init
+    - name: Changed Files Exporter
+      id: files
+      uses: futuratrepadeira/changed-files@v3.0.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run lint check
+      env:
+        FILES: '${{ steps.files.outputs.files_updated }} ${{ steps.files.outputs.files_created }}'
+      run: |
+        echo "The Following files were changed or created:"
+        echo $FILES
+
+        eval $(gofish tank)
+        rm -rf "$GOFISH_DEFAULT_RIG"
+        cp -R . "$GOFISH_DEFAULT_RIG"
+        
+        for i in $FILES; do
+          if [[ $i != *.lua ]]; then
+            echo "Skipping non lua file: $i"
+            continue
+          fi
+          echo "#############################"
+          echo "## $i"
+          echo "#############################"
+          package=$(basename ${i%.*})
+          gofish lint $i
+          gofish install $package
+        done
+


### PR DESCRIPTION
Implements #479 and #777 

This Github Action is based on the existing CircleCI setup.

It will
 - Install newest GoFish from the master branch
 - figure out which fish foods have been changed in the PR, using the `futuratrepadeira/changed-files` action
 - Run the linter on all the updated and new foods

After this PR the `.circleci` can be deleted. 