### PR TITLE
istioctl 1.6.3

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,5 +1,5 @@
 local name = "istioctl"
-local version = "1.6.2"
+local version = "1.6.3"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "e9a1912e554ef31308bb78a96ab7c43281c7be6f7892337c21dab462fdf97b3e",
+            sha256 = "65c4da38ca076ff9ff45bdbef9a576575657c651488c50ba0e41c509da04b86e",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "9e6c7f5cc52663a4177d6f275c500b4de5c59f075384c7084e3a7412921c310d",
+            sha256 = "a50671068a2e80dd7300d6d9df082da16c82553090f53837527574c979754204",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "734dcb1426c1604e261fe2333f6888581b688ab3b4f491e5cd2034740da0468b",
+            sha256 = "afca191c681336cd5385461273bddfb92264dadd04d6e5527f3bf2d22879743f",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.6.3. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.6.3/)
[Release Notes](https://istio.io/news/announcing-1.6.3/)