### PR TITLE
eksctl 0.22.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.21.0"
+local version = "0.22.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "3cdcbb1792bb131cc0ed944cbfc51dd6f1b2261a480436efc6f8124dea7c8c14",
+            sha256 = "4d213cdcd95c6b0edb9065c52ab28fd7af3751c2b4ac50363773c9d92f2e6269",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "4573bca35af67fa002fb722b4d41fae2224a27576619ed2f1e269dd7bd15c214",
+            sha256 = "c2ddc5dbaeb7bf61fbf20100631b586e3d58bc289ec71e222766deff10689727",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "455f227b1d8b3f588de3efd93b5547674f21cac0a744ba69c8e6159bca17deb6",
+            sha256 = "bde26369ee168abbbe633876e60875eadbd661b11417a1bc4fea97bf85237d0a",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.22.0. 

# Release info 

 # Release 0.22.0

## Features

- Increase default volume size to 80G (#2317)
- Add support for App Mesh Preview Environment (#2310)
- Rename update cluster to upgrade cluster (#2303)
- Add KUBECONFIG_USE_SYSTEM_CA env variable to use the system CA instead of the EKS one (#2294)

## Improvements

- Allow StackCollection.DeleteStackByName() to succeed (#2308)
- Do Fargate setup before nodegroup creation (#2304)
- Config schema doc improvements (#2346) (#2342)

## Acknowledgments
Weaveworks would like to sincerely thank:
@rndstr and @stefanprodan

