### PR TITLE
hugo 0.73.0

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.72.0"
+local version = "0.73.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "4e099a88318ce947c9da0867496340a6304c33b35c72c8e8b8b747eb7578c974",
+            sha256 = "f2346466e2a94a1fc806e182e9a9079544d271349760286a85bb8cd1a761b3c4",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "28353611210d48c681f1f83a64ce36972d010e751f2794122db80f5060fe933d",
+            sha256 = "7238b1b39d50667190020c93370bb2727d9097226cb3147c982d4d40004da09f",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "38e557f084f6b6d42cfa814a72f2b3623d65a63ad487d22deaacf07e1747c644",
+            sha256 = "0b42417310e3528fb775b95730dfac5c73014f11fd64c5c870f450a798692e5f",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.73.0. 

# Release info 

 Again, a release on the small side. Some new features -- one example is that we now support hook templates per section/type, see [#7349](https://github.com/gohugoio/hugo/issues/7349) -- and some important bug fixes.

But the most important part of this release is that we have now finally cleaned up the terms used for the taxonomy page kinds. This has made the taxonomy feature in Hugo harder to understand than it needed to be. The old/new values for these are `taxonomy` => `term` and `taxonomyTerm` => `taxonomy`. We have taken great care to avoid site breakage. See [#6911](https://github.com/gohugoio/hugo/issues/6911) for more information.

This release represents **21 contributions by 9 contributors** to the main Hugo code base.bjorn.erik.pedersen leads the Hugo development with a significant amount of contributions, but also a big shoutout to helfper, moorereason, and onedrawingperday for their ongoing contributions.
And a big thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his relentless work on keeping the themes site in pristine condition and to [@davidsneighbour](https://github.com/davidsneighbour), [@coliff](https://github.com/coliff) and [@kaushalmodi](https://github.com/kaushalmodi) for all the great work on the documentation site.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs), 
which has received **30 contributions by 14 contributors**. A special thanks to christianoliff, bjorn.erik.pedersen, patrick, and hello for their work on the documentation site.


Hugo now has:


* 326+ [themes](http://themes.gohugo.io/)

## Notes

* Rename taxonomy kinds from `taxonomy` to `term`, `taxonomyTerm` to `taxonomy` [#6911](https://github.com/gohugoio/hugo/issues/6911)

## Enhancements

### Templates

* tpl/crypto: Add hmac 

### Other

* Remove some old release notes 
* Create robots.txt in the domain root directory [#5160](https://github.com/gohugoio/hugo/issues/5160)[#4193](https://github.com/gohugoio/hugo/issues/4193)
* Make GroupByParamDate work with string params [#3983](https://github.com/gohugoio/hugo/issues/3983)
* Add GroupByLastmod [#7408](https://github.com/gohugoio/hugo/issues/7408)
* Rename taxonomy kinds from taxonomy to term, taxonomyTerm to taxonomy [#6911](https://github.com/gohugoio/hugo/issues/6911)[#7395](https://github.com/gohugoio/hugo/issues/7395)
* Add genDocsHelper mage target 
* Regenerate templates 
* Beautify HTML generated by pagination template [#7199](https://github.com/gohugoio/hugo/issues/7199)
* Add a nested data dir test 
* Use os.PathError  in RootMappingFs.doLstat 
* Remove credit (#7347) 
* Allow hook template per section/type [#7349](https://github.com/gohugoio/hugo/issues/7349)

## Fixes

### Templates

* Fix bad rounding in NumFmt [#7116](https://github.com/gohugoio/hugo/issues/7116)

### Other

* Fix aliases with path in baseURL 
* Fix server data race/nil pointer in withMaps [#7392](https://github.com/gohugoio/hugo/issues/7392)
* Fix order of GetTerms [#7213](https://github.com/gohugoio/hugo/issues/7213)
* Fix aliases with uglyURLs 
* Fix crash for closing shortcode with no .Inner set [#6857](https://github.com/gohugoio/hugo/issues/6857)[#7330](https://github.com/gohugoio/hugo/issues/7330)
* Fix aliases with relativeURLs 
* Fix URL rewrites vs fast render server mode [#7357](https://github.com/gohugoio/hugo/issues/7357)






