### PR TITLE
polaris 1.1.0

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,5 +1,5 @@
 local name = "polaris"
-local version = "1.0.3"
+local version = "1.1.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "24959266d40f6ff69866b8d4060e40a48accd95a5798e2eb374c96f906b9b0e9",
+            sha256 = "9b251a51b93ebe74735ab193bf2248e23633add80418b9c0273f485b839bd0f3",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "bd01b1102a229b6401bdf60e324d992114585380a5df8efc7a64a41df1947007",
+            sha256 = "41b188a84df7dac327a1d82728c9a7b5fe966dc91fe863698d6fef7be62c2123",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 1.1.0. 

# Release info 

 

## Changelog

eb21b030 Add filters javascript
29642809 Add namespace filters section
b4e3d40f Add priority class check, some test infra (#342)
0a0720a2 Adds option to exempt an entire controller from checks via config file (#350)
aada33f0 Bump cloud.google.com/go from 0.56.0 to 0.58.0 (#347)
ededabf0 Bump contrib.go.opencensus.io/exporter/ocagent from 0.4.12 to 0.7.0 (#335)
ded260ee Bump github.com/json-iterator/go from 1.1.9 to 1.1.10 (#346)
ab7eeccf Bump github.com/prometheus/client_golang from 1.6.0 to 1.7.0 (#356)
97f25cd7 Bump github.com/prometheus/procfs from 0.0.11 to 0.1.0 (#331)
7b88c48a Bump github.com/prometheus/procfs from 0.1.0 to 0.1.3 (#345)
a90c3b0f Bump github.com/stretchr/testify from 1.5.1 to 1.6.1 (#333)
4020000d Bump go.opencensus.io from 0.22.3 to 0.22.4 (#354)
cea0ca7f Bump golang.org/x/text from 0.3.2 to 0.3.3 (#355)
3df9d35c Bump google.golang.org/api from 0.25.0 to 0.26.0 (#334)
78a16fa0 Bump google.golang.org/api from 0.26.0 to 0.28.0 (#357)
d19b0769 Bump gopkg.in/yaml.v2 from 2.2.8 to 2.3.0 (#332)
bf6e4156 Don't assume all objects have pods. (#329)
3061756a Filter by namespaces in query, style expandable filter section, check checkboxes on page load
03331147 Merge pull request #320 from FairwindsOps/jd/search-filter
b26c4be8 Support audit files which use \r or \r\n as newline character (#343)
5b173cf4 Support read yaml contents of workload from stdin (#353)
d44138be Update filter section styles
fa3504c3 add custom checks to config (#340)
69bed16e don't error out when resolving parent resource (#358)
3e9c270a fix zero-state (#341)
5705f819 throw error when severity isn't set for custom check (#360)
80662bd2 update to version 1.1.0 (#362)


