### PR TITLE
aks-engine 0.53.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.52.0"
+local version = "0.53.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "a1ea61f0184066b17ee77b038d41de2d751ae7e18240c5221dd2fdec4fdd7695",
+            sha256 = "9753ae612760d1572fb77e12c5c365202aa18d98a1c8c6dd433b911f4a3fa320",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "bd168e3e2132010ae3df0089c2a4b223680a7a5269466605b9e0849fdf56449a",
+            sha256 = "bb4fcaa2884cae88ed715dcceab3f2f6c4f93f8ba723d2e898388e72cb6b62a6",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "649455e35275be359d63a8f5b78dc99ed2a5d1cecbecca076784c1349462e079",
+            sha256 = "97f728d14fae32b2fd07bcc42cd3c515424ce5f41d429a09e1d69b16669cfac7",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.53.0. 

# Release info 

 <a name="v0.53.0"></a>
# [v0.53.0] - 2020-06-29
### Bug Fixes 🐞
- remove v1.17 support on Azure Stack ([#3544](https://github.com/Azure/aks-engine/issues/3544))
- downgrade blobfuse to 1.1.1 since there is breaking change on 1.2.3 ([#3540](https://github.com/Azure/aks-engine/issues/3540))
- always use /var/run/reboot-required ([#3536](https://github.com/Azure/aks-engine/issues/3536))
- updating hotfix packages used for windows to include hyperkube a… ([#3539](https://github.com/Azure/aks-engine/issues/3539))
- use kube-proxy image instead of hyperkube for 1.16 ([#3532](https://github.com/Azure/aks-engine/issues/3532))
- add windows hotfix overrides for 1.18.2, 1.16.10, 1.15.12 for AKS ([#3528](https://github.com/Azure/aks-engine/issues/3528))
- add validation for enableVMSSNodePublicIP + Basic LB ([#3524](https://github.com/Azure/aks-engine/issues/3524))
- ensure cron systemd job restarts ([#3523](https://github.com/Azure/aks-engine/issues/3523))
- use hotfix Windows builds for 1.18.4, 1.17.7, and 1.16.11 ([#3510](https://github.com/Azure/aks-engine/issues/3510))
- addons bootstrapping errata ([#3481](https://github.com/Azure/aks-engine/issues/3481))
- scale + AvailabilitySet errata ([#3490](https://github.com/Azure/aks-engine/issues/3490))
- make security context configs more restrictive ([#3454](https://github.com/Azure/aks-engine/issues/3454))
- validate that --upgrade-version is semver-compatible during upgrade ([#3442](https://github.com/Azure/aks-engine/issues/3442))
- Use mirror in China for AzureChinaCloud ([#3433](https://github.com/Azure/aks-engine/issues/3433))
- VolumePluginDir issue on Windows ([#3426](https://github.com/Azure/aks-engine/issues/3426))
- disable apiserver insecure-port ([#3422](https://github.com/Azure/aks-engine/issues/3422))
- only schedule mic on Linux nodes ([#3420](https://github.com/Azure/aks-engine/issues/3420))
- Enable e2e to install ginko if required ([#3330](https://github.com/Azure/aks-engine/issues/3330))

### Documentation 📘
- update throttling doc ([#3545](https://github.com/Azure/aks-engine/issues/3545))
- add Azure API throttling doc ([#3534](https://github.com/Azure/aks-engine/issues/3534))
- update azure-stack documentation ([#3479](https://github.com/Azure/aks-engine/issues/3479))
- supported versions for Azure Stacks using VHD 2020.05.13 ([#3457](https://github.com/Azure/aks-engine/issues/3457))
- remove references to "whitelist" ([#3428](https://github.com/Azure/aks-engine/issues/3428))
### Features 🌈
- add support for Kubernetes 1.18.4 ([#3500](https://github.com/Azure/aks-engine/issues/3500))
- add support for Kubernetes 1.17.7 ([#3499](https://github.com/Azure/aks-engine/issues/3499))
- add support for Kubernetes 1.16.11 ([#3496](https://github.com/Azure/aks-engine/issues/3496))
- enable configurable usageReportingEnabled in calico addon ([#3493](https://github.com/Azure/aks-engine/issues/3493))
- ensure all AKS required ports on api-server are exposed ([#3488](https://github.com/Azure/aks-engine/issues/3488))
- enable windows daemonset in container monitoring addon ([#3466](https://github.com/Azure/aks-engine/issues/3466))
- add support for Kubernetes v1.19.0-beta.2 ([#3471](https://github.com/Azure/aks-engine/issues/3471))
- Dualstack support for Windows containers ([#3415](https://github.com/Azure/aks-engine/issues/3415))
- flatcar nodes ([#3380](https://github.com/Azure/aks-engine/issues/3380))
- enable configurable apiserver --anonymous-auth ([#3430](https://github.com/Azure/aks-engine/issues/3430))
- Update container monitoring addon for may omsagent release  ([#3403](https://github.com/Azure/aks-engine/issues/3403))
- add support for Kubernetes 1.19.0-beta.1 ([#3408](https://github.com/Azure/aks-engine/issues/3408))

### Maintenance 🔧
- rev Linux VHDs to 2020.06.25 ([#3558](https://github.com/Azure/aks-engine/issues/3558))
- updating windows VHD used by aks-engine to include June k8s packages ([#3550](https://github.com/Azure/aks-engine/issues/3550))
- get-logs collects audit logs ([#3537](https://github.com/Azure/aks-engine/issues/3537))
- add support for K8s 1.16.11 on Azure Stack ([#3535](https://github.com/Azure/aks-engine/issues/3535))
- Adding 1.15.12, 1.16.10, 1.18.2 hotfix packages for windows ([#3525](https://github.com/Azure/aks-engine/issues/3525))
- bump moby to 3.0.13 ([#3404](https://github.com/Azure/aks-engine/issues/3404))
- improve vmss validation now that vmss is default ([#3526](https://github.com/Azure/aks-engine/issues/3526))
- rev Linux VHDs to 2020.06.22 ([#3527](https://github.com/Azure/aks-engine/issues/3527))
- increase default cloud provider's rate limits on Azure Stack ([#3515](https://github.com/Azure/aks-engine/issues/3515))
- Updates the pause image to 1.4.0 ([#3516](https://github.com/Azure/aks-engine/issues/3516))
- add 1.16.11, 1.17.7, 1.18.4 hotfix packages to Windows VHD ([#3506](https://github.com/Azure/aks-engine/issues/3506))
- add support for K8s 1.17.7 on Azure Stack ([#3509](https://github.com/Azure/aks-engine/issues/3509))
- Support to change LicenseType for Windows ([#3485](https://github.com/Azure/aks-engine/issues/3485))
- triage "k8s-master" references for eventual removal ([#3474](https://github.com/Azure/aks-engine/issues/3474))
- add csi windows related images ([#3448](https://github.com/Azure/aks-engine/issues/3448))
- update metrics-server to v0.3.6 ([#3463](https://github.com/Azure/aks-engine/issues/3463))
- rev azure-sdk-for-go to v43.0.0 ([#3467](https://github.com/Azure/aks-engine/issues/3467))
- Add June Windows Patches ([#3468](https://github.com/Azure/aks-engine/issues/3468))
- update pause image to v1.3.2 ([#3461](https://github.com/Azure/aks-engine/issues/3461))
- update Azure NPM to v1.1.4 ([#3452](https://github.com/Azure/aks-engine/issues/3452))
- June 2020 windows patches ([#3439](https://github.com/Azure/aks-engine/issues/3439))
- standardize nodeSelector declarations in addons ([#3419](https://github.com/Azure/aks-engine/issues/3419))
- bump csi-secrets-store image versions ([#3424](https://github.com/Azure/aks-engine/issues/3424))
- update aad-pod-identity manifest and version ([#3423](https://github.com/Azure/aks-engine/issues/3423))
- update addon-manager to v9.1.1 ([#3409](https://github.com/Azure/aks-engine/issues/3409))

### Testing 💚
- enable CustomKubeProxyImage override ([#3538](https://github.com/Azure/aks-engine/issues/3538))
- fix UT ([#3548](https://github.com/Azure/aks-engine/issues/3548))
- Add Windows SAC 2004 e2e ([#3518](https://github.com/Azure/aks-engine/issues/3518))
- pointing Windows containerd binaries to nightly builds for e2e test passes ([#3511](https://github.com/Azure/aks-engine/issues/3511))
- fix validation for windows + containerd ([#3508](https://github.com/Azure/aks-engine/issues/3508))
- fix validation for windows + containerd ([#3508](https://github.com/Azure/aks-engine/issues/3508))
- skip stability tests for "everything" E2E cluster config ([#3498](https://github.com/Azure/aks-engine/issues/3498))
- use regular timeout for functional DNS test ([#3487](https://github.com/Azure/aks-engine/issues/3487))
- retry pod scheduling attempts ([#3486](https://github.com/Azure/aks-engine/issues/3486))
- use full toleration for testing scheduling to control plane ([#3483](https://github.com/Azure/aks-engine/issues/3483))
- basic pods Running E2E tests for all addons ([#3482](https://github.com/Azure/aks-engine/issues/3482))
- assign default stability iterations in cluster.sh ([#3475](https://github.com/Azure/aks-engine/issues/3475))
- don't perform stability tests on long-running cluster configs ([#3464](https://github.com/Azure/aks-engine/issues/3464))
- test Azure NetworkPolicy against all Kubernetes versions ([#3455](https://github.com/Azure/aks-engine/issues/3455))
- generic async top nodes interface for E2E ([#3444](https://github.com/Azure/aks-engine/issues/3444))
- Disable failing kubnet tests ([#3436](https://github.com/Azure/aks-engine/issues/3436))
- improve coredns autoscaler E2E validation ([#3438](https://github.com/Azure/aks-engine/issues/3438))
- e2e tests download of larger files ([#3412](https://github.com/Azure/aks-engine/issues/3412))
#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.53.0...HEAD
[v0.53.0]: https://github.com/Azure/aks-engine/compare/v0.52.0...v0.53.0