### PR TITLE
istioctl 1.6.4

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,5 +1,5 @@
 local name = "istioctl"
-local version = "1.6.3"
+local version = "1.6.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "65c4da38ca076ff9ff45bdbef9a576575657c651488c50ba0e41c509da04b86e",
+            sha256 = "08eb6ff8aadffc0c6544d58733e98e95c17472d79d63ed9824eaf032996b4cf2",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "a50671068a2e80dd7300d6d9df082da16c82553090f53837527574c979754204",
+            sha256 = "97ce26edad734b4a324b1a3914cead3a38ac70a029dbe09777a483ec192d04df",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "afca191c681336cd5385461273bddfb92264dadd04d6e5527f3bf2d22879743f",
+            sha256 = "fb98e0283432b5c87926635becc163fb7e60f0aa4d697584781d2fe4d7443fde",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.6.4. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.6.4/)
[Release Notes](https://istio.io/news/announcing-1.6.4/)