### PR TITLE
istioctl 1.6.5

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,5 +1,5 @@
 local name = "istioctl"
-local version = "1.6.4"
+local version = "1.6.5"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "08eb6ff8aadffc0c6544d58733e98e95c17472d79d63ed9824eaf032996b4cf2",
+            sha256 = "c3a0241495d4cb90e45ff5e4c7829039ec94e486e8a6ede9198acbb3842b4488",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "97ce26edad734b4a324b1a3914cead3a38ac70a029dbe09777a483ec192d04df",
+            sha256 = "68e58e8aec544c2b72377f7c334f90f6215bc819f3ed71ac952692cc5c9b73ac",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "fb98e0283432b5c87926635becc163fb7e60f0aa4d697584781d2fe4d7443fde",
+            sha256 = "7e17e0920c12a9d2ee0ed31dbe1cd37f39c02ac059d1c242848afba9f9544db8",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.6.5. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.6.5/)
[Release Notes](https://istio.io/news/announcing-1.6.5/)