### PR TITLE
minikube 1.12.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
-local version = "1.11.0"
-local release = "v" .. version
-
+local org = "kubernetes"
+local release = "v1.12.0"
+local version = "1.12.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "cc1b8a3327661be6a5d4dc1d6f9891aeeca40f7d9a389aaaffd8d4a1abbe294b",
+            sha256 = "7f6c6eeca19d6b16c9043cfc96a42408bbdec8ba90c01bd025249ca855a1362c",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "8a6bdeec07cae4b5e9fe1e51492f4c2828cd326d621ddcbee050a56b3c054359",
+            sha256 = "343592c9d47f03f604b590ae99255b611ecb085ade2c0138f52be9cc5e186f71",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "0b07a295d5110dc70907e4660429b8f9b3e8c05119e42f73e192b5313695a913",
+            sha256 = "3501b6c2be48183affa9497e7db6d751d92e1536267268b73ad1a936a2977122",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "8630c05fbbd0e2035ffea0fac8f4a77056696481c9d2e868a7869e4b4e6e386f",
+            sha256 = "c1c4ff25c5514c65b7bc01872228c0775bd981f799e5d59c476b688bc88eff1a",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
-            sha256 = "e94991292f4a0c5b91ef165f826c6a615a122513e8771c8f9ce5b7ec96ab9df0",
+            sha256 = "a5f8666d762146cc7d85916bcb2d6b7246162e4706f10e5c12a795b9d07ea6c4",
             resources = {
                 {
                     path = name,
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "e94991292f4a0c5b91ef165f826c6a615a122513e8771c8f9ce5b7ec96ab9df0",
+            sha256 = "a5f8666d762146cc7d85916bcb2d6b7246162e4706f10e5c12a795b9d07ea6c4",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -89,7 +89,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "ae99bf82b2f2d73fd5e71bb2ac02ad2440941f5fba9db1007dfee55daec3d250",
+            sha256 = "980f61b8585eed3b6698807986522c67fb43b7fc1d328047ae0185221eaf17c4",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.12.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.12.0 - 2020-07-09

Features:

* new addon : pod-security-policy [#8454](https://github.com/kubernetes/minikube/pull/8454)
* new --extra-config option to config "scheduler" [#8147](https://github.com/kubernetes/minikube/pull/8147)

ISO Changes:

* Upgrade Docker, from 19.03.11 to 19.03.12 [#8643](https://github.com/kubernetes/minikube/pull/8643)
* Upgrade crio to 1.18.2 [#8645](https://github.com/kubernetes/minikube/pull/8645)

Bug fixes:

* none: Fix 'minikube delete' issues when the apiserver is down  [#8664](https://github.com/kubernetes/minikube/pull/8664)

Huge thank you for this release towards our contributors:

- Anders F Björklund
- Ilya Danilkin
- Jani Poikela
- Li Zhijian
- Matt Broberg
- Medya Ghazizadeh
- Priya Wadhwa
- Sharif Elgamal
- Thomas Strömberg
- colvin
- vinu2003

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`8b179f712842f698691f0a9fadfd3de3af32a4475355c6ff69c17ddc8694a32e`