### PR TITLE
polaris 1.1.1

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,5 +1,5 @@
 local name = "polaris"
-local version = "1.1.0"
+local version = "1.1.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "9b251a51b93ebe74735ab193bf2248e23633add80418b9c0273f485b839bd0f3",
+            sha256 = "ac91e3a3c8e68afd7c91feafbd6670ea150153d1a45f77ee96b1a4644dabd4f6",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "41b188a84df7dac327a1d82728c9a7b5fe966dc91fe863698d6fef7be62c2123",
+            sha256 = "8351df3536ab209283780fcc71fbef69819eeb9bfb7133878fba3b402d2029a2",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 1.1.1. 

# Release info 

 

## Changelog

ca65a446 Bump cloud.google.com/go from 0.58.0 to 0.59.0 (#366)
9ded3269 Bump cloud.google.com/go from 0.59.0 to 0.60.0 (#369)
ed014ecf Bump github.com/prometheus/client_golang from 1.7.0 to 1.7.1 (#365)
2e11c046 Bump google.golang.org/grpc from 1.29.1 to 1.30.0 (#367)
997d4bfb Handle orphaned pods (#371)
4e9aa21c Show controller check results on dashboard (#364)
343e2488 bump to 1.1.1 (#372)


