### PR TITLE
buffalo 0.16.12

### DIFF
--- a/Food/buffalo.lua
+++ b/Food/buffalo.lua
@@ -1,5 +1,5 @@
 local name = "buffalo"
-local version = "0.16.11"
+local version = "0.16.12"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Darwin_x86_64.tar.gz",
-            sha256 = "265252e1c52a9325bf327c59ed499e42376d213ae4ba32f7d15a08a85f11a40e",
+            sha256 = "5ef252fa11f60a97bc43e68c322328aad75a4b1bbefbd7eab349f234298b2275",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux_x86_64.tar.gz",
-            sha256 = "64216c8ea9db4ed6b67e2be82e2ee70c0a59073b2983b0b9e6e0dbc3624cd69b",
+            sha256 = "98c2bb227b39f954d5c2639e9c53455aef9e0c787b3b95e1aab85c9b4198e392",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows_x86_64.tar.gz",
-            sha256 = "55e18b8108da06fa1e95030e40466bc5f2bbc3436a441be74e8414a40bf282a6",
+            sha256 = "ad2ef31ae0960352d3ea6037e777656d8ca94391ef6e2cb7844b9ef7ea8b1e6c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package buffalo to release v0.16.12. 

# Release info 

 Fixes an issue where the HTML form binder was not wired correctly.