### PR TITLE
k3d 3.0.0

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "1.7.0"
+local version = "3.0.0"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "c24add17c29c95c239efba277977cb1ecdfb77255d57ade004059cb04bf28250",
+            sha256 = "83401abd32c562905aca9edf060201db0c8be80dba1a58db142d8bf19e877d63",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "da9ff31bcf4377fadfb065f4998d347f19de1168a5a553ce2c23b763ee1f6098",
+            sha256 = "934ad7e08478fa6531b5e66e2153d2922b7db0224a8dc561146f474e7c3dcae8",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "d42d3128ab9f0586187b4fe977b1560b86b7fe787f0d0de40e70c971b90e17b4",
+            sha256 = "698ff370de1c07e48bc50dc87471d53677396a97c08bc4fcc7b09d3b38fc2951",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "d922dc3c6df0cb9c7a92a3d1f1a96efd4126208596b06f522d6270289dcfadd5",
+            sha256 = "b93de0bb52c3779c1aadd5a090d343ca39521b82a5137e5d2bd0c003293356b6",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "2d08ee5434fa6a9f6d8abf420cb3ebb075af320262ecbac82175e33442163587",
+            sha256 = "291794bef1af6bea8be2347d34f98ba95846f8c9ed3e63eab5af5b50e3e21b05",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "1f8e8515f281a8439bea5605c122ac4f45192c3f043f315f22250bd23f36e661",
+            sha256 = "eddfd61bce6dea7bb638f45459fd4d0dfe0dbaefe519be4d9f397190526f8353",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v3.0.0. 

# Release info 

 # :tada: `FROM scratch` - Re-Written k3d

We've spent quite some ~days~ ~weeks~ months on completely re-writing k3d from scratch. New concepts, new architecture, new setup, new syntax, new everything.

**Why v3?** Because v2 is too mainstream.. :trollface: 
The real reason is that v3 is not just the next step in k3d's "evolution", but rather a complete rewrite, including new concepts and structures. At first it was planned to drop a v2.0.0 release in between v1.x and v3.0.0, but due to the changes over time, this is not going to happen anymore.
Also, "k3d v3" just sounds sooo good :feelsgood: :grin: 

## :house: New Home & New Logo

[![k3d logo](https://k3d.io/static/img/k3d_logo_black_blue.svg)](https://k3d.io/)
We now have a real homepage up with documentation, examples, etc ... and our very own logo :partying_face: 

### https://k3d.io/

## :computer: Installation

Please checkout the installation instructions here: https://k3d.io/#installation
The page is build from the `docs/` directory using [`mkdocs`](https://www.mkdocs.org/).

## :exclamation: Important Notes & Breaking Changes

#### New Syntax

By far the largest breaking change for you as a k3d user is the change of the CLI syntax.
  - in k3d v1.x (and v3.0.0 up to rc.6), we used to have the `VERB NOUN` syntax, similar to how `kubectl` and `kind` have it
    - e.g. `k3d create -n mycluster` (v1.x) or `k3d create cluster mycluster` (v3.0.0-rc.6)
  - **NEW**: Now we decided to follow the route of other major cloud CLIs (like gcloud, awscli, az, etc.) and roll with `NOUN VERB` syntax, which makes the CLI cleaner and easier to develop
  - e.g. `k3d cluster create`, `k3d kubeconfig get`, ...
  - Please checkout `k3d help` or the [command tree on the website](https://k3d.io/usage/commands/#command-tree) as a reference

#### Inclusive Terminology

To be as inclusive to the community as possible, we decided to get rid of all occurrences of `master` and `worker` in our code. Here is what changed:

- `master` (node role) -> `server` (similar to k3s)
  - e.g. `k3d cluster create multi-server --servers 3`
- `worker` (node role) -> `agent` (similar to k3s)
  - e.g. `k3d cluster create multi-agent --agents 2`
  - **Important**: Due to this renaming, the short-hand flag `k3d cluster create -a` now stands for `--agents` and not anymore for `--api-port` (which does not have a short-hand flag anymore)
- `master` (branch) -> `main`

#### Cluster Setup

By default, every cluster you create will now spawn at least 2 containers: 1 server node + 1 server load balancer (disable via `--no-lb`) used as the main access point to the Kubernetes API.

## :new: New Features (Selection)

- creating multi-server clusters (using k3s' embedded datastore): `k3d cluster create --servers 3`
- updating existing kubeconfigs: `k3d kubeconfig merge mycluster --output /my/kubeconfig.yaml`
  - **IMPORTANT**: By default, k3d will now update your default kubeconfig upon cluster creation to use the new cluster/context!
- attaching new clusters to existing networks: `k3d create cluster --network this-other-network`
- handling nodes independently from clusters: `k3d node create/start/stop/delete mynode`
- multiarch images for `k3d-proxy` and `k3d-tools` containers: linux w/ amd64/arm/arm64
- leaving out `--api-port` upon cluster creation will randomly assign a port to expose the API on the host
- `--wait` flag set by default for all important commands where once could want to wait for cluster/node initialization before returning
- proper support to be used as a Go Module: exported functions, constants, etc.
- shell completion
-  revamped CI via Drone

Checkout all commands provided by the CLI here: https://k3d.io/usage/commands/

## :soon: Missing Features

There are some features of v1.x that haven't made it into this release yet.
Probably the most prominent one is the registries feature (`--enable-registry`) and related options.
Please checkout the [feature comparison page on the website](https://k3d.io/faq/v1vsv3-comparison) to see what's implemented, what's missing, what has been dropped and what is planned to land in v3.x.