### PR TITLE
hugo 0.74.3

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.74.1"
+local version = "0.74.3"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "d2b06c887bde1f60a00ae1c4f67720c1b0d93a396aeb59ee2343316035f48cfc",
+            sha256 = "ae6c6bd919b0c7f6e4577c19b54a43327dc04a155728c5e8c260f3ebb7ff84b4",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "69223e82aeaf1bcf99e85c1139b0c409cd68f140ffb073be050d079e7308f1fe",
+            sha256 = "269482fff497051a7919da213efa29c7f59c000e51cf14c1d207ecf98d87bf33",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "e1811b6ef87c7d40cda399706fa46663f0cb49acb6ea63d571a41182fc6561b6",
+            sha256 = "dc63493ffea9c65c10222678a8472192e8dbc64dc6b50f2513059a946e73706c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.74.3. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* publisher: Collect transition attributes as classes [00e00da2](https://github.com/gohugoio/hugo/commit/00e00da233ab4d643de90bafca00f60ee0bbe785) [@bep](https://github.com/bep) [#7509](https://github.com/gohugoio/hugo/issues/7509)
* Fix Asciidoctor args [45c665d3](https://github.com/gohugoio/hugo/commit/45c665d396ed368261f4a63ceee753c7f6dc5bf9) [@helfper](https://github.com/helfper) [#7493](https://github.com/gohugoio/hugo/issues/7493)
* Fix date format in internal schema template [a06c06a5](https://github.com/gohugoio/hugo/commit/a06c06a5c202de85ff47792b7468bfaeec2fea12) [@jmooring](https://github.com/jmooring) [#7495](https://github.com/gohugoio/hugo/issues/7495)
* resources/js: Add option for setting bundle format [0256959a](https://github.com/gohugoio/hugo/commit/0256959a358bb26b983c9d9496862b0fdf387621) [@bep](https://github.com/bep) [#7503](https://github.com/gohugoio/hugo/issues/7503)
* resources/js: Simplify options handling [eded9ac2](https://github.com/gohugoio/hugo/commit/eded9ac2a05b9a7244c25c70ca8f761b69b33385) [@bep](https://github.com/bep) [#7499](https://github.com/gohugoio/hugo/issues/7499)
* make sure documentation intro text only appears once [8d725128](https://github.com/gohugoio/hugo/commit/8d72512825b4cee12dc1952004f48fd076a3517b) [@TheHippo](https://github.com/TheHippo) 
* resources/js: Add es5 build target [e81aef0a](https://github.com/gohugoio/hugo/commit/e81aef0a954623e4a19062d1534bd8c2af97102a) [@bep](https://github.com/bep) 
* deps: esbuild v0.6.5 [9f919147](https://github.com/gohugoio/hugo/commit/9f9191471ec501f1f957020726f939c9ef48e193) [@bep](https://github.com/bep) 




