### PR TITLE
aks-engine 0.54.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.53.0"
+local version = "0.54.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "9753ae612760d1572fb77e12c5c365202aa18d98a1c8c6dd433b911f4a3fa320",
+            sha256 = "5bd66cbf96ab59b7abe8ed187146f484718ff6606df978553ea601fea8f2a4dc",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "bb4fcaa2884cae88ed715dcceab3f2f6c4f93f8ba723d2e898388e72cb6b62a6",
+            sha256 = "154268fc08e7135cf35a227a54bc5907bddd57f866f3ec7432ef56c5304b8a8e",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "97f728d14fae32b2fd07bcc42cd3c515424ce5f41d429a09e1d69b16669cfac7",
+            sha256 = "9d52987da63af31cb3e5af8563a9715085ed909ca3f5dcb78e43d7c5b52adad8",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.54.0. 

# Release info 

 <a name="v0.54.0"></a>
# [v0.54.0] - 2020-07-30
### Bug Fixes 🐞
- only remove CRI if re-installing ([#3654](https://github.com/Azure/aks-engine/issues/3654))
- reinforce MCR migration during upgrade for older clusters ([#3625](https://github.com/Azure/aks-engine/issues/3625))
- updating hotfix packages used for windows inlcuding CVE and metric ([#3599](https://github.com/Azure/aks-engine/issues/3599))
- use correct VMSS name comparison during Windows scale ([#3590](https://github.com/Azure/aks-engine/issues/3590))
- always extract kubelet and kubectl from a custom URL if defined ([#3574](https://github.com/Azure/aks-engine/issues/3574))
- use mcr.azk8s.cn for Azure CNI in China cloud ([#3587](https://github.com/Azure/aks-engine/issues/3587))
- update akse upgrade and scale in the e2e test to include identity ([#3582](https://github.com/Azure/aks-engine/issues/3582))
- validate signed powershell packages in Azure and China Cloud ([#3579](https://github.com/Azure/aks-engine/issues/3579))
- kube-proxy upgrade from v1.15 to v1.16 ([#3570](https://github.com/Azure/aks-engine/issues/3570))
- change addons image pull policy to IfNotPresent ([#3562](https://github.com/Azure/aks-engine/issues/3562))

### Documentation 📘
- fix incorrect calico addons section heading ([#3565](https://github.com/Azure/aks-engine/issues/3565))

### Features 🌈
- add support for Kubernetes 1.16.13 ([#3602](https://github.com/Azure/aks-engine/issues/3602))
- Support configurable Windows PauseImage ([#3594](https://github.com/Azure/aks-engine/issues/3594))
- add support for Kubernetes 1.17.9 ([#3603](https://github.com/Azure/aks-engine/issues/3603))
- add support for Kubernetes 1.18.6 ([#3604](https://github.com/Azure/aks-engine/issues/3604))
- etcdStorageLimitGB for configurable etcd storage limit ([#3583](https://github.com/Azure/aks-engine/issues/3583))
- add hosts config agent support for Windows nodes ([#3572](https://github.com/Azure/aks-engine/issues/3572))
- Consume signed powershell scripts ([#3441](https://github.com/Azure/aks-engine/issues/3441))
- enable /etc/hosts config agent for AKS private cluster BYO DNS ([#3556](https://github.com/Azure/aks-engine/issues/3556))
- add support for Kubernetes v1.16.12 ([#3551](https://github.com/Azure/aks-engine/issues/3551))
- add support for Kubernetes v1.17.8 ([#3552](https://github.com/Azure/aks-engine/issues/3552))
- add support for Kubernetes v1.18.5 ([#3553](https://github.com/Azure/aks-engine/issues/3553))

### Maintenance 🔧
- rev Linux VHDs to 2020.07.24 ([#3649](https://github.com/Azure/aks-engine/issues/3649))
- bump cloud-controller-manager and cloud-node-manager to v0.5.1 ([#3636](https://github.com/Azure/aks-engine/issues/3636))
- update Windows default VHD for July ([#3619](https://github.com/Azure/aks-engine/issues/3619))
- add support for k8s v1.17.9 on Azure Stack ([#3612](https://github.com/Azure/aks-engine/issues/3612))
- add support for K8s v1.16.13 on Azure Stack ([#3613](https://github.com/Azure/aks-engine/issues/3613))
- update CoreDNS to v1.7.0 ([#3608](https://github.com/Azure/aks-engine/issues/3608))
- update Dashboard addon to v2.0.3 ([#3606](https://github.com/Azure/aks-engine/issues/3606))
- July 2020 windows patches ([#3598](https://github.com/Azure/aks-engine/issues/3598))
- update go toolchain to 1.14.4 ([#3596](https://github.com/Azure/aks-engine/issues/3596))
- Use moby 19.03.x packages ([#3549](https://github.com/Azure/aks-engine/issues/3549))
- upgrades force azure-cnms update strategy ([#3571](https://github.com/Azure/aks-engine/issues/3571))

### Revert Change ◀️
- "feat: install Windows csi proxy during cluster creation ([#2854](https://github.com/Azure/aks-engine/issues/2854))"

### Testing 💚
- move E2E global vars out of "not block ssh port" conditional block ([#3635](https://github.com/Azure/aks-engine/issues/3635))
- run pod schedule tests first ([#3627](https://github.com/Azure/aks-engine/issues/3627))
- set default IDENTITY_SYSTEM ([#3591](https://github.com/Azure/aks-engine/issues/3591))
- don't return from GetAllRunningByLabelWithRetry until we have pods ([#3588](https://github.com/Azure/aks-engine/issues/3588))
- testing the recommended flow of sgx-device-plugin ([#3560](https://github.com/Azure/aks-engine/issues/3560))
- ensure all resource creation attempts are retried ([#3566](https://github.com/Azure/aks-engine/issues/3566))
- enable daemonset E2E test conveniences ([#3564](https://github.com/Azure/aks-engine/issues/3564))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.54.0...HEAD
[v0.54.0]: https://github.com/Azure/aks-engine/compare/v0.53.0...v0.54.0