### PR TITLE
eksctl 0.25.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.23.0"
+local version = "0.25.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "3ae86bae13a08d9b7abcae29890f824becc07575aeafd1ab47ee47c6712d5848",
+            sha256 = "e232f48e4995f711620ea34c09f582b097e5b006f45fbe82a11fc8955636c9c4",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "85885e026026e31952a8ee31b16a68a21321d9eb1d6e37acdc8fea1c29f0565e",
+            sha256 = "e94e4ec335c036d8f511ea214d5a55dfd097e2053747d7d04d6db49fff107531",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "9655ac1dcd0bf804f649b5af7f88b44b8ad3612889074bda36f5a4e76f17cb3f",
+            sha256 = "f72a29060dd9e82d842cffe6b67e9a3d5c0e4bb045a7e6194ea5f68d2ac6619d",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.25.0. 

# Release info 

 # Release 0.25.0

## Features

- Add disableIMDSv1 config option (#2460)
- Make 1.17 default (#2444)
- Add support for Milan (eu-south-1) and Cape Town (af-south-1) regions (#2495)

## Improvements

- Cleanup ALBs created by AWS ALB Ingress Controller (#2465)
- Don't replace service account with update-aws-node (#2459)
- Updated default kubelet reserved memory calculation to match the calculation used by amazon-eks-ami (#2443)
- Don't attach unnecessary policy to cluster IAM role (#2451)

## Bug Fixes

- Restore "auto" version for upgrade cluster (#2464)
- Allow service role some actions necessary for ELB (#2492)

## Acknowledgments
Weaveworks would like to sincerely thank:
@agbanagba, @brianpursley,  @ismailyenigul, @lloydchang, @mfykmn,  @morancj, @nckturner and @programmer04

