### PR TITLE
polaris 1.2.0

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,5 +1,5 @@
 local name = "polaris"
-local version = "1.1.1"
+local version = "1.2.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "ac91e3a3c8e68afd7c91feafbd6670ea150153d1a45f77ee96b1a4644dabd4f6",
+            sha256 = "34ee76aeea51ce6d27f3266e86e010cd0780a44b39fd4e9a61d4b663bf6ae655",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "8351df3536ab209283780fcc71fbef69819eeb9bfb7133878fba3b402d2029a2",
+            sha256 = "75a9b5a3e0b0534af9f371be0411e302d8e2b2c8ba78f204449fbd78fc8b8856",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 1.2.0. 

# Release info 

 

## Changelog

6060cf24 Bump cloud.google.com/go from 0.60.0 to 0.61.0 (#375)
b3d323d7 Bump github.com/imdario/mergo from 0.3.9 to 0.3.10 (#376)
f6a4bffe Bump google.golang.org/api from 0.28.0 to 0.29.0 (#373)
e044a540 Fix CLI flags documentation. (#374)
4e290e19 Update config.yaml (#378)
47150155 add ability to audit a single workload (#368)
8d562f24 fix for parent tree climbing (#379)
7b1f0465 update version (#380)


