### PR TITLE
jx 2.1.121

### DIFF
--- a/Food/jx.lua
+++ b/Food/jx.lua
@@ -1,5 +1,5 @@
 local name = "jx"
-local version = "2.1.101"
+local version = "2.1.121"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "5fb0f9fd9aa12c83bee7215a301ea42502006bd7d3812e162695e2e33854475e",
+            sha256 = "3b6532b5a193bd4c237d22145f86b2cfd8bf4a664477de73d4a99a1ca240ba18",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "e4790b929d4c0ef7b3a58167311dc0a1051999d1cfe246e281a1355cc1a960fc",
+            sha256 = "65065b8dac52f7e6199153f6c9f5765adaca04bef0b7deb599d31d0202355992",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "2e21648348ee3b2606b67904a03c54520439959823306f842a6b8bdaab695ff6",
+            sha256 = "16231df16ada47feea6b4f9bb6a05f5d44b9de86d2ff36b87d9537939b4f2c33",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jx to release v2.1.121. 

# Release info 

 To install jx 2.1.121 see the [install guide](https://jenkins-x.io/getting-started/install/)

### Linux

```shell
curl -L https://github.com/jenkins-x/jx/releases/download/v2.1.121/jx-linux-amd64.tar.gz | tar xzv 
sudo mv jx /usr/local/bin
```

### macOS

```shell
brew tap jenkins-x/jx
brew install jx
```
## Changes

### Chores

* Make the linter happy by using an interface (Andrew Bayer)
* add "make mod" target for Lighthouse to call (Andrew Bayer)
* Switch to lighthouse.git for lighthouse config pkg (Andrew Bayer)

