### PR TITLE
minikube 1.12.1

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,6 @@
 local name = "minikube"
-local org = "kubernetes"
-local release = "v1.12.0"
-local version = "1.12.0"
+local release = "v1.12.1"
+local version = "1.12.1"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "7f6c6eeca19d6b16c9043cfc96a42408bbdec8ba90c01bd025249ca855a1362c",
+            sha256 = "81a69450b8baaa1abbe88d11c58c2a40e552da4d9052d9e123bdbea3e5607146",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +25,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "343592c9d47f03f604b590ae99255b611ecb085ade2c0138f52be9cc5e186f71",
+            sha256 = "b1190dd1ca608560495cead1dc2dd26a8b38aff41ecbd32bfa2871b53075ec10",
             resources = {
                 {
                     path = name,
@@ -39,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "3501b6c2be48183affa9497e7db6d751d92e1536267268b73ad1a936a2977122",
+            sha256 = "a0d8f9d71623e8c66723547fede7df95c12e2a8827fef408b640a6f62bafd57b",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +51,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "c1c4ff25c5514c65b7bc01872228c0775bd981f799e5d59c476b688bc88eff1a",
+            sha256 = "c2230b298932018fc049f38e485363518f91ce59dd7252c2c809a57cfe17400d",
             resources = {
                 {
                     path = name,
@@ -65,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64",
-            sha256 = "a5f8666d762146cc7d85916bcb2d6b7246162e4706f10e5c12a795b9d07ea6c4",
+            sha256 = "db7365266ebb00cd79ae5fc9c854fcf611ad1c6abd152f272727f6691ea8a4ad",
             resources = {
                 {
                     path = name,
@@ -77,7 +76,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "a5f8666d762146cc7d85916bcb2d6b7246162e4706f10e5c12a795b9d07ea6c4",
+            sha256 = "db7365266ebb00cd79ae5fc9c854fcf611ad1c6abd152f272727f6691ea8a4ad",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -89,7 +88,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "980f61b8585eed3b6698807986522c67fb43b7fc1d328047ae0185221eaf17c4",
+            sha256 = "c1d6c7a16a7f2187ba5c5e1e973ddda3e9fcc02d453f68d3b769b786d33e4cdd",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.12.1. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.12.1 - 2020-07-17

Features:
* Add support for Calico CNI (--cni=calico) [#8571](https://github.com/kubernetes/minikube/pull/8571)
* Add support for Cilium CNI (--cni=cilium) [#8573](https://github.com/kubernetes/minikube/pull/8573)


Bug Fixes:
* Fix bugs which prevented upgrades from v1.0+ to v1.12 [#8741](https://github.com/kubernetes/minikube/pull/8741)
* Add KicBaseImage to existing config if missing (fixes v1.9.x upgrade) [#8738](https://github.com/kubernetes/minikube/pull/8738)
* multinode: fix control plane not ready on restart [#8698](https://github.com/kubernetes/minikube/pull/8698)
* none CNI: error if portmap plug-in is required but unavailable [#8684](https://github.com/kubernetes/minikube/pull/8684)

Version Upgrades:
* ingress addon: bump to latest version [#8705](https://github.com/kubernetes/minikube/pull/8705)
* Upgrade go version to 1.14.4 [#8660](https://github.com/kubernetes/minikube/pull/8660)

Huge thank you for this release towards our contributors: 
- Anders F Björklund
- Harsh Modi
- James Lucktaylor
- Medya Ghazizadeh
- Michael Vorburger ⛑️
- Prasad Katti
- Priya Wadhwa
- RA489
- Sharif Elgamal
- Sun-Li Beatteay
- Tam Mach
- Thomas Strömberg
- jinhong.kim

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`8b179f712842f698691f0a9fadfd3de3af32a4475355c6ff69c17ddc8694a32e`