### PR TITLE
jcli 0.0.30

### DIFF
--- a/Food/jcli.lua
+++ b/Food/jcli.lua
@@ -1,6 +1,6 @@
 local name = "jcli"
-local release = "v0.0.29"
-local version = "0.0.29"
+local release = "v0.0.30"
+local version = "0.0.30"
 food = {
     name = name,
     description = "Jenkins CLI allows you manage your Jenkins as an easy way",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "e5d56a0627df3531f1198335748efcbc034344529546abc423076bba7c7e481e",
+            sha256 = "ca49b17c0223a98682605ace5e9cb0aaf048dc132357541277cac3831b7d5667",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "98bffb1b91ed9961f3359c930453f4761bf3a63515f9244e6e3e40c18e6bfd5d",
+            sha256 = "f9671353e14d58b4fbe08aca23a8e427d3a1426ce2f72a8a82aef9b4d14fa574",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "7ab08382633e7b09bda12b64b716abbef809ba37e8c47593847acca164bc41e5",
+            sha256 = "648f1c644180f3e0221c8f7d60288d858f24dc5e3a6af2fc240627ff40b04cce",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jcli to release v0.0.30. 

# Release info 

 ## What’s Changed

For many uses who want to integrate Jenkins into their own platform, they might meet a problem. How can I get the build ID after I triggered a job?

In order to have a better understanding about it. I guess you need to know the mechanism of Jenkins schedule. If a job was triggered, Jenkins will create a task in the waiting queue, once there is a appropriate agent is ready for it, then Jenkins will schedule it to that agent.

In another word, it's a asynchronous process. So you cannot get the build id immediately, because it has not started.

There's my offer. Install plugin [Pipeline restFul API v0.9](https://plugins.jenkins.io/pipeline-restful-api/) on your Jenkins, upgrade [Jenkins CLI](https://github.com/jenkins-zh/jenkins-cli/releases/tag/v0.0.30) to v0.0.30. Then take the following command:

`jcli job build job/devops/ -b --wait --columns Number --no-headers`

The output is `36`.

## 🚀 Features

* Add self upgrade support (#431) @LinuxSuRen
* Add support to build job after saved it (#429) @LinuxSuRen
* Add man page in homebrew (#391) @LinuxSuRen
* Add support to trigger build and getting the build id (#434) @LinuxSuRen
* Add timeout option for plugin upload command (#428) @LinuxSuRen
* Add timeout option for plugin check command (#422) @LinuxSuRen

## 🐛 Bug Fixes

* Fix cannot connect jnlp agent with http proxy (#420) @LinuxSuRen

## 📝 Documentation updates

* Add gitbook support for jcli document (#426) @LinuxSuRen

## 👻 Maintenance

* Bump github.com/onsi/ginkgo from 1.13.0 to 1.14.0 (#421) @dependabot-preview
* Bump github.com/spf13/pflag from 1.0.3 to 1.0.5 (#432) @dependabot-preview
* Bump github.com/AlecAivazis/survey/v2 from 2.0.7 to 2.0.8 (#427) @dependabot-preview
