### PR TITLE
fluxctl 1.20.1

### DIFF
--- a/Food/fluxctl.lua
+++ b/Food/fluxctl.lua
@@ -1,7 +1,7 @@
 local name = "fluxctl"
 local org = "fluxcd"
-local release = "1.20.0"
-local version = "1.20.0"
+local release = "1.20.1"
+local version = "1.20.1"
 food = {
     name = name,
     description = "The GitOps Kubernetes operator",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_darwin_amd64",
-            sha256 = "dd34cb8bd2c07f0a8ab77fa9306b57618686df2884a32ffca11f31a02b2b5f28",
+            sha256 = "6e617f7dab10c6d1bf3d030a8e9590dfabb91d0e1ec1b7d49b7a841194b561a0",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_linux_amd64",
-            sha256 = "790450b7fb3cbb5decc060223e489bce3459753b5e77e7bac1adeee8db41eb21",
+            sha256 = "0b44c95acf9b08fee6f975bf13a93c71a766d0a342f0e9af1470ebaa1b1a98bc",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_windows_amd64",
-            sha256 = "092ecc238065030dcda7ddbdcb9ba4a48afdbdd476a8b00831af4a4500066b84",
+            sha256 = "43a4880dfdddfe644a74eeb936e73aa9d22c3397e90ee672ed15a387421760e2",
             resources = {
                 {
                     path = name .. "_windows_amd64",


### PR DESCRIPTION
Updating package fluxctl to release 1.20.1. 

# Release info 

 ## 1.20.1 (2020-08-05)

This patch release has some fixes for faults in improvements in 1.20.0.

### Fixes

- Do not return error when failed to load last-synced resources [fluxcd/flux#3223][]
- Dockerfile: Include /sbin dir in PATH [fluxcd/flux#3211][]
- Put notice re gitops-engine at top of README [fluxcd/flux#3197][]
- Avoid panic when directory does not exist [fluxcd/flux#3193][]
- Put git messages into tmp files [fluxcd/flux#3179][]

### Maintenance and documentation

- Give advice on percent-encoding creds using in URL [fluxcd/flux#3204][]
- Get shellcheck from new URL [fluxcd/flux#3224][]
- Add Sngular as Flux user [fluxcd/flux#3212][]
- Add rebase GitHub action [fluxcd/flux#3190][]

### Thanks

Thanks to @alex-shpak, @mmorejon, @ordovicia, @ricardo-larosa, @squaremo and @stefanprodan for their contributions to this release.

[fluxcd/flux#3224]: https://github.com/fluxcd/flux/pull/3224
[fluxcd/flux#3223]: https://github.com/fluxcd/flux/pull/3223
[fluxcd/flux#3212]: https://github.com/fluxcd/flux/pull/3212
[fluxcd/flux#3211]: https://github.com/fluxcd/flux/pull/3211
[fluxcd/flux#3204]: https://github.com/fluxcd/flux/pull/3204
[fluxcd/flux#3197]: https://github.com/fluxcd/flux/pull/3197
[fluxcd/flux#3193]: https://github.com/fluxcd/flux/pull/3193
[fluxcd/flux#3190]: https://github.com/fluxcd/flux/pull/3190
[fluxcd/flux#3179]: https://github.com/fluxcd/flux/pull/3179
[fluxcd/flux#3178]: https://github.com/fluxcd/flux/pull/3178
