### PR TITLE
jx 2.1.131

### DIFF
--- a/Food/jx.lua
+++ b/Food/jx.lua
@@ -1,5 +1,5 @@
 local name = "jx"
-local version = "2.1.121"
+local version = "2.1.131"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "3b6532b5a193bd4c237d22145f86b2cfd8bf4a664477de73d4a99a1ca240ba18",
+            sha256 = "b8107de13199226087db8e5c1f91b848256093dce7f6606ce4661a1997efe25e",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "65065b8dac52f7e6199153f6c9f5765adaca04bef0b7deb599d31d0202355992",
+            sha256 = "e169dec6635f1d68c718b0201f48783b07575812a220c75691c5cfaf6c68b063",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "16231df16ada47feea6b4f9bb6a05f5d44b9de86d2ff36b87d9537939b4f2c33",
+            sha256 = "89da1ea3e21e3c65e5328dda8d44ad2607995c5377eb2b98798b63674eace2e9",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jx to release v2.1.131. 

# Release info 

 To install jx 2.1.131 see the [install guide](https://jenkins-x.io/getting-started/install/)

### Linux

```shell
curl -L https://github.com/jenkins-x/jx/releases/download/v2.1.131/jx-linux-amd64.tar.gz | tar xzv 
sudo mv jx /usr/local/bin
```

### macOS

```shell
brew tap jenkins-x/jx
brew install jx
```
## Changes

### Documentation

* refactor issue template and add discourse link to readme ([ankitm123](https://github.com/ankitm123))

