### PR TITLE
helm 3.3.0

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.2.4"
+local version = "3.3.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "603bc2da184b69e6303a15baf037f55f44de7359d0ba84151459ddc7a20851a8",
+            sha256 = "3399430b0fdfa8c840e77ddb4410d762ae64f19924663dbdd93bcd0e22704e0b",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "8eb56cbb7d0da6b73cd8884c6607982d0be8087027b8ded01d6b2759a72e34b1",
+            sha256 = "ff4ac230b73a15d66770a65a037b07e08ccbce6833fbd03a5b84f06464efea45",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "9566f9fa92fce2b3930fe32b173a2f2f015d7c967a879012db3255706057a308",
+            sha256 = "897cb9fe5ca48e53a3acbd9aa8d9948b104d81b4e697a150e9cb8b2d39633d98",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.3.0. 

# Release info 

 ## v3.3.0

Helm v3.3.0 is a feature release. This release, we focused on `helm lint` and general stability/bug fixes. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Notable Changes

- A previously failed release can be upgraded
- New Helm environment variables to set location configuration
- Additional linting checks (e.g. name validation)
- HelmVersion added to Capabilities

## Installation and Upgrading

Download Helm v3.3.0. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.3.0-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-darwin-amd64.tar.gz.sha256sum) / 3399430b0fdfa8c840e77ddb4410d762ae64f19924663dbdd93bcd0e22704e0b)
- [Linux amd64](https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-amd64.tar.gz.sha256sum) / ff4ac230b73a15d66770a65a037b07e08ccbce6833fbd03a5b84f06464efea45)
- [Linux arm](https://get.helm.sh/helm-v3.3.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-arm.tar.gz.sha256sum) / 59d05ba1a8895eb9d0eae569cfc2d38ecd245d2bf3cd0bccd02f933ab0498175)
- [Linux arm64](https://get.helm.sh/helm-v3.3.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-arm64.tar.gz.sha256sum) / 8c64c74e69320ad4364bad29a712d8a737d9df8cae10d1ad08e6a2e513479981)
- [Linux i386](https://get.helm.sh/helm-v3.3.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-386.tar.gz.sha256sum) / 35a89ac6791f4596673f736a2cca551325708a69a27caef17ac6c46fdffff613)
- [Linux ppc64le](https://get.helm.sh/helm-v3.3.0-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-ppc64le.tar.gz.sha256sum) / 93e7e629c65562ed7026e1889cf32428c6a53d39edea42e8f515abe0bfd92b49)
- [Linux s390x](https://get.helm.sh/helm-v3.3.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.0-linux-s390x.tar.gz.sha256sum) / 3399430b0fdfa8c840e77ddb4410d762ae64f19924663dbdd93bcd0e22704e0b)
- [Windows amd64](https://get.helm.sh/helm-v3.3.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.3.0-windows-amd64.zip.sha256sum) / 1bac19768e853ada10b9ee7896678a5a7352cc06546c5ea3d47652fcea1033c3)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.3.1 will contain only bug fixes.
- 3.4.0 is the next feature release.

## Changelog

- Fix issue with install and upgrade running all hooks 8a4aeec08d67a7b84472007529e8097ec3742105 (Matt Farina)
- bump version to v3.3 5c2dfaad847df2ac8f289d278186d048f446c70c (Matthew Fisher)
- fix(template):Issue:helm template with --output-dir (#8156) ceff32d5f8aa173549426625b608137a47981447 (DongGang)
- Adding v4 link 3d05f96b7e505e1f36c3f0f2842d021d879f3231 (Bridget Kromhout)
- Updating for today's actual milestone practices 4ad76e1be278bdf8b842c3775f34301cbed08b72 (Bridget Kromhout)
- fix(cmd): display warnings on stderr 863588ca69209153863f72327fe8c818c963904a (Matthew Fisher)
- Determine chart digest by manifest (#8249) 7e9a83184c32864d3d296f3439bb8ffbc1c0d3a3 (Peter Engelbert)
- Fix some go-lint warnings c6a00e63ef638c14be5560534c339484e35eb7ba (zouyu)
- Fix golint issue 7ec501155d082d2e2cc314d7fd03729b5873f21c (Guangwen Feng)
- feat(comp): Complete revision for rollback command 05beedd671027b227b44968e6a961be5b200a465 (Marc Khouzam)
- fix template command use --show-only flags error in windows environment 4f136861d397ec37b18c92ceee8027333ba1bc24 (ShenXinkang)
- version bump 148d94bcf781bdbf4c735ad0defdee15961389ec (Matthew Fisher)
- remove s390x arch check 569ad27f2bc16b7b407e8a464e70e70cac9a43a8 (vitt-bagal)
- feat(comp): Provide completion for --version flag 561cc4280830af4a40f2e60c5f17fb3ee69b4e39 (Marc Khouzam)
- chore(Makefile): Remove unused variable fd99c9055d3d2bbe2b5a790d5d355f496c4a73f8 (Manuel Rüger)
- Improve the extractor and add tests (#8317) b6bbe4f08bbb98eadd6c9cd726b08a5c639908b3 (Matt Butcher)
- Add HelmVersion to Capabilities 4c9972cb7260e6424890c8d839c53ddb5460a6c5 (Eric Lemieux)
- feat(cmd): Subcommands for the completion command f7c882d55e26958d03c34c9718a964b9a8180da2 (Marc Khouzam)
- fix(chartutil): do not set helpers.tpl filetype for vim aa033196692ea9c4416fbb3859bebf05aded6bef (Adam Reese)
- Add unit test case 9249530b7739a738e16d5e46195c82df63f00127 (ZouYu)
- feat(comp): Move custom completions to Cobra 1.0 88a3d6eaea65971b3e4884b5abbcccc4d7a79f72 (Marc Khouzam)
- fix(doc): generic description for --version/verify e09e8604e6160775890c154b1fb8b6683a8bbb6f (Marc Khouzam)
- Fix description is ignore when installed with upgrade 562767b04015546e53677bb3c8aa5cae12897fa3 (wawa0210)
- Add unit test for man-in-the-middle attack on pull f11e74ee571f6a21ea5fd647513324d7268ff8d3 (Peter Engelbert)
- chore(helm): Avoid confusion in command usage 7dec5dcb8e2857dd14d0ea43f1c68876b5ac8a2d (Marc Khouzam)
- Fix crashing `helm chart list` with large list a0fd1d81f03aaabbd961f0bfd0dfd907493078c6 (Peter Engelbert)
- Show errors when linting for Chart.yaml version and appVersion fields of type non-string 47c38ec23d564fa98d40f90979736b446dc521b9 (Karuppiah Natarajan)
- ref(tests): localize unit test fixtures to package 44a2225035d93ab6e8dc40af7c3ee4ff13452fae (Adam Reese)
- Fix issue with unhandled error on Stat f182ebc11c9ea7a5bf75e35d8e061f3ac68482fd (Matt Farina)
- Removing legacy completions.bash file c56778a8d8c7fe3237bb38f6019d7003d85603d0 (Matt Farina)
- Using flags instead of persistent flags on status 99f277a2f3de395160b473ac7a8cae6c380b6d1c (Matt Farina)
- Removing tiller language dbd001e5326561076e17a62b41ea3a9aa18e069d (Matt Farina)
- Added s390x support 6d49f562bce78c6459f11e82ea8d37e12edb8590 (vitt-bagal)
- add kind_sorter support for SecretList 146e0f9cc3b9c7ca9cb9dd0eba12de2270ae6faf (hzliangbin)
- Fix unit test 5600a2c82d236422e54b6089d5384dea44349900 (Martin Hickey)
- Fix repo cache setting 2ae83f276b60085c550fc81fb6e21b38146e2d9f (Martin Hickey)
- Update the Helm version docs 5840e529e143d3f63539a312b81848f0b25ff6ba (Thomas O'Donnell)
- Revert "group command for easy read" 1a46c3495ab2aa101e31fe9dfbe10802bb7d0a63 (Alan Zhu)
- Catching a potential panic in strval parsing 6857da251edd416454827ac692c85de1ade6b5e6 (Matt Farina)
- Recovering from panic that can occur with make 8f1f0e0db2d96fa3d85c8b7a8e461f6bec7bced9 (Matt Farina)
- Fixing error with strvals parsing bade6478fcdd537957f0ce8a2cc5e06a14940ea0 (Matt Farina)
- ref(pkg/chartutil): use minimal in-memory fixtures 3364265e78274577be049763b54adffb9913d75d (Adam Reese)
- feat: Detect missing selector during lint 118d46eb3e2c8425ecdbb9c8f8270413060eda78 (Matt Butcher)
- Add new line to fix code formatting in doc e6069769151b91c91a107bd4d79ca3a941658518 (Maksim Kochkin)
- fix(comp): Prepare plugin completion for Cobra 1.0 0366f9970f0ff5c0b61b02521d139445bfaeba8f (Marc Khouzam)
- feat(test): Update golangci-lint to 1.27.0 88f6991ffff04c48dd8fd257d238aca48aef80df (Marc Khouzam)
- chore(*): Fix formatting b18e7e201e55ba38fdecbcf81e4da512e55444b4 (Marc Khouzam)
- Fixing PAX Header handling (#8086) 512544b9abbc75418348b76037fee3156ea1d3bd (Matt Farina)
- fix: upgrade using --force shoud not run patch logic (#8000) decab8ea2e6ea4b31560aff50abb2676a67ec8ba (小明同学)
- feat(getter): add timeout option (#7950) ae738d7d87bbd5db7203db7441fb11e32b02df40 (Hidde Beydals)
- fix security mailing list address 2f39854d3f5da2f13cd749ccb08d61982cafef2f (Matthew Fisher)
- bump DefaultCapabilities to 1.18 bfb39c0c68b989eea6a0b648f36aa5c7f930a515 (Matthew Fisher)
- bump to kubernetes 1.18.2 75aa425bfcfdffdbdd285a03fb0fceab8e28c778 (Matthew Fisher)
- scripts: do not use optional 'which' command in get-helm installation (#8048) bf12ae39344aef012927ab391eb26ddd3a30ae30 (Niels de Vos)
- feat: make the linter coalesce the passed-in values before running values tests (#7984) 59eed4e81f840bfa8a5aa69fc6c92471413609eb (Matt Butcher)
- Removed scheme 95e9e18ab585ce3e67c373841efae378886189ee (Juned Memon)
- Fixes repo parsing 8cb9ab7095c885e1f8d9bea3a28229f58ba59a5e (Juned Memon)
- Fixes repo parsing b473f8adec7dab35614f0c20b0738a865830b443 (Juned Memon)
- Set DisableCompression to true to disable unwanted httpclient transformation 93b0eee0dff2849081f16b47f4693fd8b25115bc (Idan Elhalwani)
- Update lint deprecation list e4768e646095204c16a124b8176c2c6542561a08 (Martin Hickey)
- refactor: alter constant `pluginFileName` to `PluginFileName` e1aaf995a6c238f04eb8449f67feb5f2cb95028f (Liu Ming)
- Fixing argument to be lower case be38084eb4d6e0bfb79566083833413947f8bfc8 (Matt Farina)
- docs: fix capitalization in a few help messages bc515991f8fb7c3294e7f7809778fd360751d5cb (Liu Ming)
- bump version to v3.2 8316a403ed16c76c35ce673e163c0ee30b1e8871 (Matt Butcher)
- fix: removed strict template errors in linter (#8017) 08e546f169ff3d5694863f0766c3132da2f095b7 (Matt Butcher)
- Add checking of length of resourceList before creating of deleting 47abe66fd29162a71627ee4c9d26a9c3712e24e1 (Vibhav Bobade)
- fix: use correct regular expression for Kubernetes names (#8013) 524150c662f9c030d2caa9ad8f79d2ff9521c431 (Matt Butcher)
- feat: implement deprecation warnings in helm lint (#7986) bf9d629dc02e759a1ba09ff8f6784dd0fb585cf3 (Matt Butcher)
- added option --insecure-skip-tls-verify for helm install, addresses #7875 8ff7801e0c3d902a5fc4129aaaf60aa97c7ba4fd (Matthias Riegler)
- added option --insecure-skip-tls-verify for helm pull, addresses #7875 918deeef181f20ea640bc562cef69d209493cbab (Matthias Riegler)
- polish to keep the same log style ff3ed53b7c0c07aab2bc8cc59344d18063e8a719 (Liu Ming)
- Fix markdown table in helm command doc fb829c2c843df01ad1dd5ffd13c4e923be4ab9e9 (Lüchinger Dominic)
- feat: lint the names of templated resources (#8011) 6fc93530569813580c1b6554a7154f4ec0fda0b4 (Matt Butcher)
- Adding Helm env vars where XDG exposed 2334195a01a6e47d597940890890a1369f8bcba4 (Matt Farina)
- Fix : Prints empty list in json/yaml is no repositories are present (#7949) cd50d0c3621ad91b3848f14b7ef3a8d6aa29d2c9 (Anshul Verma)
- Updating CONTRIBUTING to match current practice 0a318beba32626997abb6af915ebad9399430103 (Bridget Kromhout)
- Adding PR template from dev-v2 branch f7d1bfd0063a0d43aaef0764222a819fe3472056 (Bridget Kromhout)
- Add unit test for pkg/chart/chart.go 6bc4a948be0ef1e32f6a605b655cc8cd5f0c2f06 (Hu Shuai)
- fix: write index.yaml file atomically (#7954) 984d2ac7676874ae78a7617f7417513a7a9b5ef2 (Raphaël)
- test: add test for bom test data integrity c422e51ca13b9f213d5f7ed42c187d401ffec245 (Thomas FREYSS)
- Fixing docs from version to appVersion (#7975) 54e5088a500bde62a84eeba89d39abd6d7f28daa (Matt Farina)
- Modify Circle config to use Go 1.14 (#7980) 78d57d3d2059de200ed0b1c9c7cb1fb0104630c3 (Josh Dolitsky)
- fix(pkg/cli): ensure correct configuration from kubeconfig file 4a0dfbe53b2191e09a7034ce97e4caf84989d6db (Adam Reese)
- fix(cmd/env): make helm env command respect cli flags (#7978) 9ced0165aba1f0d90990396306d6f7e7a6725a91 (Adam Reese)
- fix(*): remove bom in utf files when loading chart files (#6081) 27ebfa8c561e758b60872b9bb081253036e559ff (Thomas FREYSS)
- Helm upgrades with --reuse-values and nil user values -- with tests (#7959) 6aefbdcf38e14998d0bcb24030061822b1e8888d (David Pait)
- fix(pkg/plugin): copy plugins directly to the data directory (#7962) 1cdd0a20488637c77d92e9a4844e89e8cefd578d (Adam Reese)
- fix linting error with lookup function (#7969) bb47286f09331271e88e6047c51fd6e0ea936506 (Matt Butcher)
- Parse reference templates in predictable order (#7702) d0726e07abed91554f1c62351dc62da4bf21f469 (Andre Sencioles)
- group command for easy read 999e4f266f0c69de023a55858b1284e9d89ee20e (alan)
- fs_test: use os.Getuid() instead user.Current() to determine if a test is executed with root privileges. b83d3d415c8a55ad2af0f2ace0642445b0dbde0c (Predrag Knezevic)
- fix(helm): allow a previously failed release to be upgraded (#7653) 1911870958098b774973c6fe56bfdf4441f61596 (Matthew Morrissette)
- Updating get stripts to skip pre-releases 8e1c34ef045b350c68974f8ca12e2cb6d245d3f3 (Matt Farina)
- Merge remote-tracking branch 'helm/master' a1685b737dd6846bdc35c281bf841b9cc43cb104 (Liu Ming)
- fix(pkg/kube): continue deleting objects when one fails bdf6f48704ed9e09d7fa636f025a3e2d344d42d4 (Adam Reese)
- fix: allow to rollback to previous version even if no deployed releases(#6978) cca68288063d235a4c32ef1ba822dd487317c8dc (liuming216448)
- Add comments about release Version variable de1996e500c75faccbb8aadc1d2e8b788f83ac3b (Andreas Lindhé)
- fixed to mirror master f604105547dc260f4388792de44a6eb9d2a1353f (EItanya)
- removed panic, and replaced with error 640d527190376a8b4945575f767065ebd47a83cb (EItanya)
- fix test 2f534f97424ce4eaa3356e199e453e94bd65b4c6 (EItanya)
- added config file string 17dc43f0547d4fd7205de07428b97fbc4a5276fd (EItanya)
- Fix a typo "update" -> "updates" (#7346) 00769c4512c9c145eafb84f60e8a473de83b0209 (Hu Shuai)
- fix(cmd): Fixes logging on action conf init error (#6909) b7ff1e29327d33b6fe9b44b11d84c182d1adea45 (Jorge I. Gasca)
- Remove duplicated words (#7336) 451e2158ad24594d8c67e2e4a99aefc5ffa84a9f (Nguyen Hai Truong)