### PR TITLE
mole 1.0.0

### DIFF
--- a/Food/mole.lua
+++ b/Food/mole.lua
@@ -1,7 +1,6 @@
 local name = "mole"
-local version = "0.5.0"
-local release = "v" .. version
-
+local release = "v1.0.0"
+local version = "1.0.0"
 food = {
     name = name,
     description = "cli app to create ssh tunnels",
@@ -13,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".darwin-amd64.tar.gz",
-            sha256 = "618e29266e4fd42bfbbe9c3b9c030a656f1a24344d7148928f3f71b8bdef9ab3",
+            sha256 = "0e9d15f60a189e82fc60df4897e469a9d7b5f006df5d55a4e90b270ce2722e55",
             resources = {
                 {
                     path = name,
@@ -26,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".linux-amd64.tar.gz",
-            sha256 = "3d9398791f00878bb77bfaee9d84dd5c93755f639fbe592b7b655ec4f5889edd",
+            sha256 = "7e98e21a8f450784d9f68bd05135470bffed645d84c7071de0c73a1276f42673",
             resources = {
                 {
                     path = name,
@@ -39,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".windows-amd64.zip",
-            sha256 = "6a1f0f8fabcdeac5d90085788d6871eea67cc805e100c69cd0f8f349c4e41c80",
+            sha256 = "113f0d1ca5afe49f7c2388d6c85f4e098950e5ad8a189d7af57faf51e72d0548",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package mole to release v1.0.0. 

# Release info 

 CHANGELOG

v1.0.0

NEW FEATURE: Complete revamp of CLI user experience [#112]
NEW FEATURE: Support for ssh remote port forwarding tunnel [#114]
NEW FEATURE: Support for authentication ssh session using ssh agent [#102]
NEW FEATURE: Add builds for ARM

v0.5.0

NEW FEATURE: Reconnect to SSH Server if connection drops for any reason (-connection-retries and -retry-wait) [#95]
BUGFIX: SSH config file is required even if all required arguments were provided through CLI [#75]
BUGFIX: Missing port in remote address [#86]
NEW FEATURE: Configurable connection timeout [#92]
BUGFIX: Fix persistence of insecure mode flag (-insecure) [#90]
IMPROVEMENT: Better protecting keys loaded in memory [#78]
NEW FEATURE: Keep idle connection open by sending periodic synthetic packets (-keep-alive-interval flag) [#77]

v0.4.0

NEW FEATURE: Multiple tunnels using the same ssh connection (support for multiple -remote flags) [#72]
INFRA: Project dependencies are now managed by Go modules instead of vendor/ [#69]

v0.3.0

NEW FEATURE: Windows Support! Mole now works on windows (tested on Windows 10) [#65]
INFRA: Using Github Actions for code quality checks (e.g. unit tests, code formatting, etc.)
NEW FEATURE: Users will be prompted to enter the key's password if it is encrypted [#54]
NEW FEATURE: Skip the host key validation by using the -insecure option [#52]
BUGFIX: Server names can contain underscore character [#50]
BUGFIX: Always use the same ssh connection if multiple clients use the same tunnel [#43]
NEW FEATURE: Run mole in background by using the -detach option [#35]
BUGFIX: Return error if required flags are missing [#33]
NEW FEATURE: New -aliases option added to list all configured aliases [#29]
NEW FEATURE: LocalForward option from ssh config file will be used if both -local and -remote are absent [#18]
INFRA: Developers can spawn a small local infra using docker to test their changes

v0.2.0

NEW FEATURE: Aliases can be created to reuse tunnel settings.
Website update

v0.1.0

IP addresses of both local and remote are now optional
Add -version option to display the current version
New website: https://davrodpin.github.io/mole/

v0.0.1

First release. No changes.