### PR TITLE
k3d 3.0.1

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "3.0.0"
+local version = "3.0.1"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "83401abd32c562905aca9edf060201db0c8be80dba1a58db142d8bf19e877d63",
+            sha256 = "f9596fe616fa4551602256c0bc6ccc8e147daaf0fdd94c72ffd6af515e9e7867",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "934ad7e08478fa6531b5e66e2153d2922b7db0224a8dc561146f474e7c3dcae8",
+            sha256 = "e773d3a8377b6562d2cf29e7683c89ecc03f5843990c1853b810ca1c656aeb2e",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "698ff370de1c07e48bc50dc87471d53677396a97c08bc4fcc7b09d3b38fc2951",
+            sha256 = "6f5b6c9384ab17ebaf131b86a4410cde6b12b12e926097bd1bb71b953bed2765",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "b93de0bb52c3779c1aadd5a090d343ca39521b82a5137e5d2bd0c003293356b6",
+            sha256 = "75a9ef3e0c67f9d5f950277932f68432424b3d44da1e3939270fdeda34b0ab7d",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "291794bef1af6bea8be2347d34f98ba95846f8c9ed3e63eab5af5b50e3e21b05",
+            sha256 = "a861bf5cab4376706c69836f81688eb24c2d7775a45de40cbb0612e7631e2037",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "eddfd61bce6dea7bb638f45459fd4d0dfe0dbaefe519be4d9f397190526f8353",
+            sha256 = "aaa50b8cdfb97514eb8f1588e20f609534fc5d065fa0df59019b87f2f22fe75a",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v3.0.1. 

# Release info 

 # v3.0.1

## Enhancements

- handle leading `/` in docker container names (#322, @kshelton)
- introduce new node status (#328)
  - can be seen in output of `cluster list` (node columns now: `running/total`) and `node list` (additional column)

## Fixes

- fixed inconsistent behavior of `cluster create --update-default-kubeconfig`/`--switch-context`
- fixed impossible config when mapping port ranges on the loadbalancer (e.g. `cluster create -p 1000-2000@loadbalancer`) (#317)
- fixed hanging forever when trying to start a cluster that's already running (#335)

## Misc

- install script: check for binary in more bashy way (#313, @vandot)

## Docs

- clarify `kubeconfig get/print/show` and `kubeconfig merge/write`