### PR TITLE
eksctl 0.26.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.25.0"
+local version = "0.26.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "e232f48e4995f711620ea34c09f582b097e5b006f45fbe82a11fc8955636c9c4",
+            sha256 = "225d718a2be6b286043b7ef83cced281a1564b0953f69974b2791e6d77782238",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "e94e4ec335c036d8f511ea214d5a55dfd097e2053747d7d04d6db49fff107531",
+            sha256 = "a69012e867c9888db3335c91401de6640d1165c155339414b0cf67cc27762a05",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "f72a29060dd9e82d842cffe6b67e9a3d5c0e4bb045a7e6194ea5f68d2ac6619d",
+            sha256 = "f37e2142cb19d4d2d11a7a45b2cc9af7311916a31b141ab21c73ffcee3375da8",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.26.0. 

# Release info 

 # Release 0.26.0

## Features

- Add support for launch templates, custom AMI and more features for managed nodegroups (#2544)
- Add support for ARM (#2535)


## Improvements

- Allow `version: auto` in the config file when creating a cluster (#2505)

## Acknowledgments
Weaveworks would like to sincerely thank all our contributors!

