### PR TITLE
jx 2.1.133

### DIFF
--- a/Food/jx.lua
+++ b/Food/jx.lua
@@ -1,5 +1,5 @@
 local name = "jx"
-local version = "2.1.132"
+local version = "2.1.133"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "2fab36aeb4969dca7ba0627cb2ae6527132096ac8493244e31348204cb5339cd",
+            sha256 = "c89230416ae8604ce02dd0268fc7f6d7bb244b3392c52ecd46cabb6e19deed55",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "096638ed437d59d0d36544b719b4020339986bfc29c8f23e6b4b4f6ce1036f91",
+            sha256 = "db9e4a3e11a1ef899a2a96b680529fb8b2cf77ee867c8c9b509fd317a90d5e20",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "86db0a3aacc5fb0ce21cb89c805912c01eb99fca6f1332d0cc4b3c20207043b5",
+            sha256 = "b6345a40348d7b04599b0198100b938938e7b104e76350fd1087f3820d989741",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jx to release v2.1.133. 

# Release info 

 To install jx 2.1.133 see the [install guide](https://jenkins-x.io/getting-started/install/)

### Linux

```shell
curl -L https://github.com/jenkins-x/jx/releases/download/v2.1.133/jx-linux-amd64.tar.gz | tar xzv 
sudo mv jx /usr/local/bin
```

### macOS

```shell
brew tap jenkins-x/jx
brew install jx
```
## Changes

### Bug Fixes

* better defaulting of kaniko flags (James Strachan)
* allow a kaniko flags env var (James Strachan)
* avoid errors if other files need to be added to git (James Strachan)

