### PR TITLE
aks-engine 0.55.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.54.1"
+local version = "0.55.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "b84e871fe00317e71762084136e66901da414c6db5e549b78639b72b8f4f7c6a",
+            sha256 = "500d476374d0db11a3ec1d459481e8b06e3a08672ee7bf57c97fe6f6e954a4fe",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "bb8cf47803c47bc63ed27c025e7c007dae9a77524017b51b7275f03c5ebbe8f2",
+            sha256 = "d8071cb607738849bd95aca0fcb0a1b2fa68633f1ed5f3222311b811f48497ed",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "d3480969a0b09ba8e52f9bb472f90a4a2b7e756c9a4877ac1f41b665ba2b9e9b",
+            sha256 = "b2b3a734be7b65557121f69acacea078a49f5c4786c8ccb6e075c281636da627",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.55.0. 

# Release info 

 <a name="v0.55.0"></a>
# [v0.55.0] - 2020-08-27
### Bug Fixes 🐞
- fix issue where installing a different version of containerd vs what was pre-installed on VHD failed silently ([#3743](https://github.com/Azure/aks-engine/issues/3743))
- add missing 1.16.14 kube-proxy image to the vhd dependencies ([#3736](https://github.com/Azure/aks-engine/issues/3736))
- do not restart addon-manager if a reboot is required ([#3721](https://github.com/Azure/aks-engine/issues/3721))
- add rbac rules for nodes/status in cloud-node-manager.yaml ([#3699](https://github.com/Azure/aks-engine/issues/3699))
- use new Windows VHD image version ([#3701](https://github.com/Azure/aks-engine/issues/3701))
- don't wait for pod-security-policy spec if disabled ([#3673](https://github.com/Azure/aks-engine/issues/3673))
- metrics-server upgrade from v1.15 to v1.16 ([#3691](https://github.com/Azure/aks-engine/issues/3691))
- validate "basic" LB and fix related unit tests ([#3690](https://github.com/Azure/aks-engine/issues/3690))

### Continuous Integration 💜
- use 1.4.0 containerd release for windows in CI ([#3742](https://github.com/Azure/aks-engine/issues/3742))
- clarify apt packages installed during VHD CI ([#3674](https://github.com/Azure/aks-engine/issues/3674))

### Documentation 📘
- update limitations in dualstack docs ([#3727](https://github.com/Azure/aks-engine/issues/3727))
- adding James to OWNERS ([#3706](https://github.com/Azure/aks-engine/issues/3706))
- fix misleading sysctldConfig examples ([#3682](https://github.com/Azure/aks-engine/issues/3682))
- update the SGX DCAP version mentioned in the sgx instructions ([#3684](https://github.com/Azure/aks-engine/issues/3684))
- update stale Istio page and example ([#3639](https://github.com/Azure/aks-engine/issues/3639))

### Features 🌈
- variable upgrade timeout based on num nodes ([#3752](https://github.com/Azure/aks-engine/issues/3752))
- collect hyperv logs ([#3737](https://github.com/Azure/aks-engine/issues/3737))
- Patch v1.15.11, v1.15.12, v1.16.10, v1.16.13, v1.17.7, v1.17.9, v1.18.4 v1.18.6 for Windows ([#3725](https://github.com/Azure/aks-engine/issues/3725))
- add support for K8s v1.17.11 on Azure Stack ([#3702](https://github.com/Azure/aks-engine/issues/3702))
- add support for K8s v1.16.14 on Azure Stack ([#3704](https://github.com/Azure/aks-engine/issues/3704))
- add support for Kubernetes v1.17.11 ([#3696](https://github.com/Azure/aks-engine/issues/3696))
- add support for Kubernetes v1.18.8 ([#3697](https://github.com/Azure/aks-engine/issues/3697))
- configurable microsoft apt repository ([#3698](https://github.com/Azure/aks-engine/issues/3698))
- add support for Kubernetes v1.16.14 ([#3695](https://github.com/Azure/aks-engine/issues/3695))
- cluster upgrade operations upgrade pause image ([#3689](https://github.com/Azure/aks-engine/issues/3689))
- add support for Kubernetes 1.19.0-rc.4 ([#3666](https://github.com/Azure/aks-engine/issues/3666))
- azure arc addon ([#3634](https://github.com/Azure/aks-engine/issues/3634))

### Maintenance 🔧
- rev Linux VHDs to 2020.08.24 ([#3750](https://github.com/Azure/aks-engine/issues/3750))
- add new Azure VM SKUs ([#3744](https://github.com/Azure/aks-engine/issues/3744))
- update windows default VHD for August ([#3730](https://github.com/Azure/aks-engine/issues/3730))
- update csi-secrets-store addon manifest and images ([#3728](https://github.com/Azure/aks-engine/issues/3728))
- upgrade metrics-server to v0.3.7 ([#3669](https://github.com/Azure/aks-engine/issues/3669))
- force delete addon manager when addon manager pods get stuck on terminating state ([#3685](https://github.com/Azure/aks-engine/issues/3685))
- Hyperv and upstream Containerd package support ([#3688](https://github.com/Azure/aks-engine/issues/3688))
- update Windows VHD to include 8B patches ([#3692](https://github.com/Azure/aks-engine/issues/3692))
- Update  docker version to fix log rotation issue ([#3693](https://github.com/Azure/aks-engine/issues/3693))
- update cluster-autoscaler to latest patch versions ([#3683](https://github.com/Azure/aks-engine/issues/3683))
- update cluster-autoscaler to latest patch versions ([#3650](https://github.com/Azure/aks-engine/issues/3650))

### Testing 💚
- disable azure-arc-onboarding addon in everything cluster config ([#3756](https://github.com/Azure/aks-engine/issues/3756))
- update kubernetes e2e to use GINKGO_FAIL_FAST parameter value ([#3660](https://github.com/Azure/aks-engine/issues/3660))
- fix ginkgo failFast ([#3738](https://github.com/Azure/aks-engine/issues/3738))
- don't run kubelet restart test if ssh is blocked ([#3638](https://github.com/Azure/aks-engine/issues/3638))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.55.0...HEAD
[v0.55.0]: https://github.com/Azure/aks-engine/compare/v0.54.1...v0.55.0