### PR TITLE
crictl 1.19.0

### DIFF
--- a/Food/crictl.lua
+++ b/Food/crictl.lua
@@ -1,5 +1,5 @@
 local name = "crictl"
-local version = "1.18.0"
+local version = "1.19.0"
 local repo = "cri-tools"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "876dd2b3d0d1c2590371f940fb1bf1fbd5f15aebfbe456703ee465d959700f4a",
+            sha256 = "87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "5045bcc6d8b0e6004be123ab99ea06e5b1b2ae1e586c968fcdf85fccd4d67ae1",
+            sha256 = "df60ff65ab71c5cf1d8c38f51db6f05e3d60a45d3a3293c3248c925c25375921",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package crictl to release v1.19.0. 

# Release info 

 cri-tools v1.19.0 mainly focuses on bug fixes and stability improvements.

This includes:
- a number of bug fixes to the CLI and critest
- CI testing for dockershim (now standalone not built into kubelet), crio, and containerd
- stability and usability improvements to the CLI including the ability to automatically connect to default configurations of dockershim, containerd, and crio; and many more.
- a refresh to the crictl CLI help output and the [crictl docs](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md)

### Main Changes

- [#651](https://github.com/kubernetes-sigs/cri-tools/pull/651) Removed the darwin/386 release binaries because of go1.15

### CRI CLI (crictl)

- [#627](https://github.com/kubernetes-sigs/cri-tools/pull/627) Added config and switches to manage pull-image for create/run commands
- [#615](https://github.com/kubernetes-sigs/cri-tools/pull/615) Make config write maintain comments
- [#606](https://github.com/kubernetes-sigs/cri-tools/pull/606) Fix server connection timeout
- [#604](https://github.com/kubernetes-sigs/cri-tools/pull/604) Update set configuration command
- [#603](https://github.com/kubernetes-sigs/cri-tools/pull/603) Allow -s for --state when listing containers
- [#600](https://github.com/kubernetes-sigs/cri-tools/pull/600) Add Runtime column for RuntimeHandler
- [#599](https://github.com/kubernetes-sigs/cri-tools/pull/599) Update the default CRI server
- [#583](https://github.com/kubernetes-sigs/cri-tools/pull/583) Allow to remove pod sandoxes in parallel

### CRI validation testing (critest)

- [#624](https://github.com/kubernetes-sigs/cri-tools/pull/624) Added waits for creations/modifications of timing-sensitive files
- [#618](https://github.com/kubernetes-sigs/cri-tools/pull/618) Use CRI-validation-friendly version of nginx image
- [#611](https://github.com/kubernetes-sigs/cri-tools/pull/611) Update dockershim critest
- [#594](https://github.com/kubernetes-sigs/cri-tools/pull/594) Enable critest to use CRI server configuration file
- [#590](https://github.com/kubernetes-sigs/cri-tools/pull/590) Update SELinux testing for MCS

### Downloads

| file                                                                                                                                                | sha256                                                           |
| --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [crictl-v1.19.0-darwin-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-darwin-amd64.tar.gz)     | 83f3c232c0958d836330fb04ff94a53d93abcc710e4f7a93a17a710e04421b60 |
| [crictl-v1.19.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-386.tar.gz)           | fd0247b81a46adeca69ef3b7bbcf7d0e776df63195918236887243773b98a0c0 |
| [crictl-v1.19.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-amd64.tar.gz)       | 87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae |
| [crictl-v1.19.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-arm64.tar.gz)       | ec040d14ca03e8e4e504a85dae5353e04b5d9d8aea3df68699258992c0eb8d88 |
| [crictl-v1.19.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-arm.tar.gz)           | b72fd3c4b35f60f5db2cfcd8e932f6000cf9c2978b54adfcf60ee5e2d452e92f |
| [crictl-v1.19.0-linux-ppc64le.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-ppc64le.tar.gz)   | 72107c58960ee9405829c3366dbfcd86f163a990ea2102f3ed63a709096bc7ba |
| [crictl-v1.19.0-linux-s390x.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-linux-s390x.tar.gz)       | 20ec106c307c9d56c2ecae1560b244f8ac26450b9704682f24bfb5f468b06776 |
| [crictl-v1.19.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-windows-386.tar.gz)       | 3b7a41b556e3eae1fb56d17edc990ccd4839c8ab554249a8991155ee266dac4b |
| [crictl-v1.19.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/crictl-v1.19.0-windows-amd64.tar.gz)   | df60ff65ab71c5cf1d8c38f51db6f05e3d60a45d3a3293c3248c925c25375921 |
| [critest-v1.19.0-darwin-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-darwin-amd64.tar.gz)   | 5301afe7078345d6a56d192af921be0d0e4dda59554edadb00b3ad915bfceaea |
| [critest-v1.19.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-linux-386.tar.gz)         | e17048ce006e95e710c6677b9a11f83afdf5bfe6ebf74d8fc35521544933031d |
| [critest-v1.19.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-linux-amd64.tar.gz)     | 85116040ec93c0b8db8264410d4b1465a8fe064b055a22034aa20bd602bf2695 |
| [critest-v1.19.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-linux-arm64.tar.gz)     | 0a83f29c706027ecd610f0ed7470b7b6c6d227a54e336bf8664bc9a82547d103 |
| [critest-v1.19.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-linux-arm.tar.gz)         | dbc3d252206e7769a73642c340a8926045fc837811be70bc1da1f0e42384892c |
| [critest-v1.19.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-windows-386.tar.gz)     | 8a78f0278c3f634139225eda1b18a539ab790ae31f49a60de0d1c368bb9f9623 |
| [critest-v1.19.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.19.0/critest-v1.19.0-windows-amd64.tar.gz) | 1146b37e540695740d5c7bca85b106fdfc69e094e6759b6a568d6e71624c8576 |
