### PR TITLE
jx 2.1.138

### DIFF
--- a/Food/jx.lua
+++ b/Food/jx.lua
@@ -1,5 +1,5 @@
 local name = "jx"
-local version = "2.1.132"
+local version = "2.1.138"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "2fab36aeb4969dca7ba0627cb2ae6527132096ac8493244e31348204cb5339cd",
+            sha256 = "344270547157249965e5e20eb21a9ef292658da40b8777143bb4921f29c9c138",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "096638ed437d59d0d36544b719b4020339986bfc29c8f23e6b4b4f6ce1036f91",
+            sha256 = "167fcaaf215c534bad5c21e178cbbe3dc72948c23b6a2f4227a91098c2468b6d",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "86db0a3aacc5fb0ce21cb89c805912c01eb99fca6f1332d0cc4b3c20207043b5",
+            sha256 = "47b92f485dcf4501d4d15188e00acc103ab4fb893aa5568fb61813eeb53cf927",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jx to release v2.1.138. 

# Release info 

 To install jx 2.1.138 see the [install guide](https://jenkins-x.io/getting-started/install/)

### Linux

```shell
curl -L https://github.com/jenkins-x/jx/releases/download/v2.1.138/jx-linux-amd64.tar.gz | tar xzv 
sudo mv jx /usr/local/bin
```

### macOS

```shell
brew tap jenkins-x/jx
brew install jx
```
## Changes

### Bug Fixes

* jx step tag can edit the wrong chart file (Aurélien Lambert) [#7417](https://github.com/jenkins-x/jx/issues/7417) 

### Issues

* [#7417](https://github.com/jenkins-x/jx/issues/7417) jx step tag can edit the wrong chart file ([aure-olli](https://github.com/aure-olli))

