### PR TITLE
helm 3.3.1

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.3.0"
+local version = "3.3.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "3399430b0fdfa8c840e77ddb4410d762ae64f19924663dbdd93bcd0e22704e0b",
+            sha256 = "ab999d5a5e701aa3b75f4b10698d957e75b482cb0fe3c7bb283ac8e1ac602c26",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "ff4ac230b73a15d66770a65a037b07e08ccbce6833fbd03a5b84f06464efea45",
+            sha256 = "81e3974927b4f76e9f679d1f6d6b45748f8c84081a571741d48b2902d816e14c",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "897cb9fe5ca48e53a3acbd9aa8d9948b104d81b4e697a150e9cb8b2d39633d98",
+            sha256 = "72186fa89a47747ba732127bc964ddf839d810a329eebfc7d78a9fed1dfa77be",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.3.1. 

# Release info 

 ## v3.3.1

Helm v3.3.1 is a patch release. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.3.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.3.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-darwin-amd64.tar.gz.sha256sum) / ab999d5a5e701aa3b75f4b10698d957e75b482cb0fe3c7bb283ac8e1ac602c26)
- [Linux amd64](https://get.helm.sh/helm-v3.3.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-amd64.tar.gz.sha256sum) / 81e3974927b4f76e9f679d1f6d6b45748f8c84081a571741d48b2902d816e14c)
- [Linux arm](https://get.helm.sh/helm-v3.3.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-arm.tar.gz.sha256sum) / 8b36dc785d90cad4c45cd49da60d7542a34be9d8e21f700c79df8fb2792416ad)
- [Linux arm64](https://get.helm.sh/helm-v3.3.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-arm64.tar.gz.sha256sum) / 87d302b754b6f702f4308c2aff190280ff23cc21c35660ef93d78c39158d796f)
- [Linux i386](https://get.helm.sh/helm-v3.3.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-386.tar.gz.sha256sum) / 758a459acbef027ab0dcd20ecc4c7ac879225e7c872c66dadfbc91be5b9e99ba)
- [Linux ppc64le](https://get.helm.sh/helm-v3.3.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-ppc64le.tar.gz.sha256sum) / 5bd56525be0199f40743a08b3511945a2cfee204ea23ad2841e9c8382fb2eb0c)
- [Linux s390x](https://get.helm.sh/helm-v3.3.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.1-linux-s390x.tar.gz.sha256sum) / ab999d5a5e701aa3b75f4b10698d957e75b482cb0fe3c7bb283ac8e1ac602c26)
- [Windows amd64](https://get.helm.sh/helm-v3.3.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.3.1-windows-amd64.zip.sha256sum) / ee175565a81d1288769280b00ff1b78a77b225001471d0dd76117f909e707447)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.3.2 will contain only bug fixes.
- 3.4.0 is the next feature release. 

## Changelog

- Fix spelling in completion.go 249e5215cde0c3fa72e27eb7a30e8d55c9696144 (knrt10)
- Fixing linting of templates on Windows 690e2d38d622b258f51bddfba3c9c0ba23065fee (Matt Farina)
- Bump Kubernetes to v0.18.8 + Bump jsonpatch 8943dc288cdab72bc7d7ea46c843d9bd4cf879c3 (Maartje Eyskens)
- Fix Quick Start Guide Link in README.md 800c627556938a0d632ef9d998dc1599f7ccc74c (Tero)
- fix test that modifies the wrong cache data fcb5e7789045cb7e3cad5a7319d56819c7105ceb (Matt Butcher)
- bufix: fix validateNumColons docs 53f68d8b64df51f87f70e0a9f28258bef18752a1 (bellkeyang)
- Fix typo ffc0aff3408e5c4b1973543e05f67e5aefe8ef59 (Martin Hickey)
- Enhance readability by extracting bitwise operation 8e9717cff0ba1e92305e9d10b67dfd3568d92502 (Andrew Melis)
- Make helm ls return only current releases if providing state filter 485262c42b4d79377c7040510504bea84c112eb4 (Andrew Melis)
- fix: Allow building in a path containing spaces 58f61d740ac5e97c66124bd5e69b7874d84cb971 (Chris Wells)
- Alter whitespace in "Update Complete" output 450386c370392f2ee0a92d40240b94d27a01b7ab (Simon Shine)
- Fixing version and spelling errors dbd0a4ee2c526f701a43989dc5b7645036cc297a (Bridget Kromhout)