### PR TITLE
gomplate 3.8.0

### DIFF
--- a/Food/gomplate.lua
+++ b/Food/gomplate.lua
@@ -1,9 +1,9 @@
 local name = "gomplate"
-local version = "3.7.0"
-
+local release = "v3.8.0"
+local version = "3.8.0"
 food = {
     name = name,
-    description = "A versatile Go template processor",
+    description = "A flexible commandline tool for template rendering. Supports lots of local and remote datasources.",
     license = "MIT",
     homepage = "https://gomplate.ca",
     version = version,
@@ -11,9 +11,8 @@ food = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin-amd64-slim",
-            -- shasum of the release archive
-            sha256 = "e574ccecbae40b90ea6ab590deb1c1e7697961d0782638b0104a73947cd529b3",
+            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_darwin-amd64-slim",
+            sha256 = "60217c40bdf65c781a0f5933fe5cba04d93005bf15e2e479e694895481d11b1b",
             resources = {
                 {
                     path = name .. "_darwin-amd64-slim",
@@ -25,9 +24,8 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux-amd64-slim",
-            -- shasum of the release archive
-            sha256 = "edeafbade658f4cf8dde853b7b2d8b8441936587bded5d32444efee3d3be9b87",
+            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_linux-amd64-slim",
+            sha256 = "847f7d9fc0dc74c33188c2b0d0e9e4ed9204f67c36da5aacbab324f8bfbf29c9",
             resources = {
                 {
                     path = name .. "_linux-amd64-slim",
@@ -39,13 +37,12 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows-amd64-slim" .. ".exe",
-            -- shasum of the release archive
-            sha256 = "505e98480cd9355c570780496b0e93b18dbe5020db2e4ce07125168b1b6e985e",
+            url = "https://github.com/hairyhenderson/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_windows-amd64-slim.exe",
+            sha256 = "77e907bddd6c6474ca1137b51a22eb1ec72d8a113bc3aa92e4825b993399069c",
             resources = {
                 {
-                    path = name .. "_windows-amd64-slim" .. ".exe",
-                    installpath = "bin\\" .. name .. ".exe",
+                    path = name .. "_windows-amd64-slim.exe",
+                    installpath = "bin\\" .. name .. ".exe"
                 }
             }
         }


### PR DESCRIPTION
Updating package gomplate to release v3.8.0. 

# Release info 

 It's time for another gomplate release, and this time we have a good number of bug fixes, new functions, and updated dependencies.

Thanks to [@surki](https://github.com/surki) and [@jen20](https://github.com/jen20) for their contributions to this release!

Of particular note is the new [**experimental mode**](https://docs.gomplate.ca/config/#experimental) which you can use to try out some new functionality that isn't ready to be "locked in" just yet.

In particular, there are now some new **RSA Encryption/Decryption** functions, including [`crypto.RSAGenerateKey`](https://docs.gomplate.ca/functions/crypto/#crypto-rsageneratekey-experimental), which gives you a way to quickly generate an RSA encryption key pair! The reason these are experimental is because I'm not sure about the UX yet, and the function names may change in a future release.

Be sure to check out the multi-platform Docker images available at [`hairyhenderson/gomplate`](https://hub.docker.com/r/hairyhenderson/gomplate).

_If you've gained value out of gomplate and want to find a way to encourage development, please consider [sponsoring me](https://github.com/sponsors/hairyhenderson)!_

## [v3.8.0](https://github.com/hairyhenderson/gomplate/tree/v3.8.0) (2020-08-29)
[Full Changelog](https://github.com/hairyhenderson/gomplate/compare/v3.7.0...v3.8.0)

### Release Notes

#### New features and changes

- [\#919](https://github.com/hairyhenderson/gomplate/pull/919) New [experimental mode](https://docs.gomplate.ca/config/#experimental)!
    - Some functions and features will be provided for early feedback behind the `experimental` configuration option. These features may change before being permanently enabled, and [feedback](https://github.com/hairyhenderson/gomplate/issues/new) is encouraged from early adopters!
- [\#926](https://github.com/hairyhenderson/gomplate/pull/926) Fall back to JSON/YAML arrays when parsing datasources instead of refusing to parse (implements [\#924](https://github.com/hairyhenderson/gomplate/pull/924))
- [\#925](https://github.com/hairyhenderson/gomplate/pull/925) Gomplate is now built with Go 1.15

#### New functions

- [\#876](https://github.com/hairyhenderson/gomplate/pull/876) [`base64.DecodeBytes`](https://docs.gomplate.ca/functions/base64/#base64-decodebytes)
- [\#876](https://github.com/hairyhenderson/gomplate/pull/876) Some [_experimental_](https://docs.gomplate.ca/config/#experimental) functions in the `crypto` namespace.
    These should function correctly, but I'm [looking for feedback](https://github.com/hairyhenderson/gomplate/issues/new) on naming and usability, especially as related to encryption/decryption with other algorithms!
    - [`crypto.RSADecrypt`](https://docs.gomplate.ca/functions/crypto/#crypto-rsadecrypt-experimental)
    - [`crypto.RSADecryptBytes`](https://docs.gomplate.ca/functions/crypto/#crypto-rsadecryptbytes-experimental)
    - [`crypto.RSAEncrypt`](https://docs.gomplate.ca/functions/crypto/#crypto-rsaencrypt-experimental)
    - [`crypto.RSAGenerateKey`](https://docs.gomplate.ca/functions/crypto/#crypto-rsageneratekey-experimental)
    - [`crypto.RSADerivePublicKey`](https://docs.gomplate.ca/functions/crypto/#crypto-rsaderivepublickey-experimental)
- [\#931](https://github.com/hairyhenderson/gomplate/pull/931) [`aws.EC2Tags`]() for returning all EC2 tags on the host - thanks to [@surki](https://github.com/surki)!
- [\#900](https://github.com/hairyhenderson/gomplate/pull/900) [`test.Kind`](https://docs.gomplate.ca/functions/test/#test-kind) and [`test.IsKind`](https://docs.gomplate.ca/functions/test/#test-iskind) (implements [\#892](https://github.com/hairyhenderson/gomplate/pull/892))
- [\#891](https://github.com/hairyhenderson/gomplate/pull/891) [`gcp.Meta`](https://docs.gomplate.ca/functions/gcp/#gcp-meta) - thanks to [@jen20](https://github.com/jen20)!

#### Bug fixes

- [\#874](https://github.com/hairyhenderson/gomplate/pull/874) Allow referencing `aws+sm` and `aws+smp` keys that don't start with `/` (fixes [\#868](https://github.com/hairyhenderson/gomplate/issues/868))
- [\#875](https://github.com/hairyhenderson/gomplate/pull/875) Reverted to UPX v3.94 for compressing the `slim` variant of gomplate, to avoid some bugs caused by a newer version (fixes [\#861](https://github.com/hairyhenderson/gomplate/issues/861))
- [\#934](https://github.com/hairyhenderson/gomplate/pull/934) Only open input/output files when necessary (fixes [\#928](https://github.com/hairyhenderson/gomplate/pull/928))
- [\#935](https://github.com/hairyhenderson/gomplate/pull/935) Fixing _"wrong type for value"_ error when parsing YAML documents containing anchors (fixes [\#909](https://github.com/hairyhenderson/gomplate/pull/909))

#### Documentation fixes/updates

- [\#895](https://github.com/hairyhenderson/gomplate/pull/895) & [\#896](https://github.com/hairyhenderson/gomplate/pull/896) Clarified some of the installation instructions
- [\#897](https://github.com/hairyhenderson/gomplate/pull/897) Documented `AWS_META_ENDPOINT` environment variable - thanks to [@jen20](https://github.com/jen20)!
- [\#906](https://github.com/hairyhenderson/gomplate/pull/906) Fix a number of typos in some of the examples (fixes [\#901](https://github.com/hairyhenderson/gomplate/pull/901))
- [\#907](https://github.com/hairyhenderson/gomplate/pull/907) Documented the [`--datasource-header` flag](https://docs.gomplate.ca/usage/#datasource-header-h)