### PR TITLE
aks-engine 0.55.1

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.55.0"
+local version = "0.55.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "500d476374d0db11a3ec1d459481e8b06e3a08672ee7bf57c97fe6f6e954a4fe",
+            sha256 = "359d905cdd795e650e2d1adf7e0176dabebfc6062dfa9fb2bda5236889ebc5c8",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "d8071cb607738849bd95aca0fcb0a1b2fa68633f1ed5f3222311b811f48497ed",
+            sha256 = "644f98abf0738e3ad27c45cb37a9b0c96e879b7725fc08a23e51de99d303c467",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "b2b3a734be7b65557121f69acacea078a49f5c4786c8ccb6e075c281636da627",
+            sha256 = "ece37607d826d11efa2414dcaa56d97207857bc1d297acef1b44bffdcc8c146a",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.55.1. 

# Release info 

 <a name="v0.55.1"></a>
# [v0.55.1] - 2020-09-02
### Bug Fixes 🐞
- update the flag due to using higher version of csi livenessprobe ([#3770](https://github.com/Azure/aks-engine/issues/3770))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.55.1...HEAD
[v0.55.1]: https://github.com/Azure/aks-engine/compare/v0.55.0...v0.55.1