### PR TITLE
mole 1.0.1

### DIFF
--- a/Food/mole.lua
+++ b/Food/mole.lua
@@ -1,9 +1,9 @@
 local name = "mole"
-local release = "v1.0.0"
-local version = "1.0.0"
+local release = "v1.0.1"
+local version = "1.0.1"
 food = {
     name = name,
-    description = "cli app to create ssh tunnels",
+    description = "CLI application to create ssh tunnels focused on resiliency and user experience.",
     license = "MIT",
     homepage = "https://davrodpin.github.io/mole/",
     version = version,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".darwin-amd64.tar.gz",
-            sha256 = "0e9d15f60a189e82fc60df4897e469a9d7b5f006df5d55a4e90b270ce2722e55",
+            sha256 = "b1254b8a06c79cfdd892ee312f4fba1c0e815ddc70d6865e4557b0b0bdab72a5",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".linux-amd64.tar.gz",
-            sha256 = "7e98e21a8f450784d9f68bd05135470bffed645d84c7071de0c73a1276f42673",
+            sha256 = "5012785c28a3fd292a0883a1dcb38e27c534671ec9673b1cc134adebd6b838d3",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/davrodpin/" .. name .. "/releases/download/" .. release .. "/" .. name .. "" .. version .. ".windows-amd64.zip",
-            sha256 = "113f0d1ca5afe49f7c2388d6c85f4e098950e5ad8a189d7af57faf51e72d0548",
+            sha256 = "82a68c67502df7abf08c82508994fec8607df07aaaf79fa18dd4bf921c457839",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package mole to release v1.0.1. 

# Release info 

 CHANGELOG

v1.0.1

BUGFIX: Verbose, Insecure and Detach flags are not working when loading from an alias [#127]
NEW FEATURE: The installation script can now receive a parameter to install a specific version instead of always installing the latest [#124]

v1.0.0

NEW FEATURE: Complete revamp of CLI user experience [#112]
NEW FEATURE: Support for ssh remote port forwarding [#114]
NEW FEATURE: Support for authentication ssh session using ssh agent [#102]
NEW FEATURE: Add builds for ARM [#109]

v0.5.0

NEW FEATURE: Reconnect to SSH Server if connection drops for any reason (-connection-retries and -retry-wait) [#95]
BUGFIX: SSH config file is required even if all required arguments were provided through CLI [#75]
BUGFIX: Missing port in remote address [#86]
NEW FEATURE: Configurable connection timeout [#92]
BUGFIX: Fix persistence of insecure mode flag (-insecure) [#90]
IMPROVEMENT: Better protecting keys loaded in memory [#78]
NEW FEATURE: Keep idle connection open by sending periodic synthetic packets (-keep-alive-interval flag) [#77]

v0.4.0

NEW FEATURE: Multiple tunnels using the same ssh connection (support for multiple -remote flags) [#72]
INFRA: Project dependencies are now managed by Go modules instead of vendor/ [#69]

v0.3.0

NEW FEATURE: Windows Support! Mole now works on windows (tested on Windows 10) [#65]
INFRA: Using Github Actions for code quality checks (e.g. unit tests, code formatting, etc.)
NEW FEATURE: Users will be prompted to enter the key's password if it is encrypted [#54]
NEW FEATURE: Skip the host key validation by using the -insecure option [#52]
BUGFIX: Server names can contain underscore character [#50]
BUGFIX: Always use the same ssh connection if multiple clients use the same tunnel [#43]
NEW FEATURE: Run mole in background by using the -detach option [#35]
BUGFIX: Return error if required flags are missing [#33]
NEW FEATURE: New -aliases option added to list all configured aliases [#29]
NEW FEATURE: LocalForward option from ssh config file will be used if both -local and -remote are absent [#18]
INFRA: Developers can spawn a small local infra using docker to test their changes

v0.2.0

NEW FEATURE: Aliases can be created to reuse tunnel settings.
Website update

v0.1.0

IP addresses of both local and remote are now optional
Add -version option to display the current version
New website: https://davrodpin.github.io/mole/

v0.0.1

First release. No changes.