### PR TITLE
kubeaudit 0.11.1

### DIFF
--- a/Food/kubeaudit.lua
+++ b/Food/kubeaudit.lua
@@ -1,5 +1,5 @@
 local name = "kubeaudit"
-local version = "0.11.0"
+local version = "0.11.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "95b292eb0608aee7609413d9bf9372ef244093560ffb8971ab45fe6111232c58",
+            sha256 = "900c7ad80a36f95e009cef0850df89b87dc25c124b8381dd5fb101dd22caed40",
             resources = {
                 {
                     path = name,
@@ -30,7 +30,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_386.tar.gz",
-            sha256 = "a24a643c1d9cdd7deac98bcc0a0475fff4c9394be9582e7a1995a8248342c5a1",
+            sha256 = "a9f6b20391e5c2121db2bd623eef33cd99569d13f7274daac812deea23947a35",
             resources = {
                 {
                     path = name,
@@ -48,7 +48,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "648945737e1c79700139f73d24634da9014833140c902d739ef81b06d38af8c0",
+            sha256 = "5357e18cb9361a1101126646ce4c958d0f9c0804b27bc9930a50d00247b4e687",
             resources = {
                 {
                     path = name,
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_386.tar.gz",
-            sha256 = "eb92cd566d894aecbdde384a3ba449c4293a84e3f3f7bc98f246856cceae84ef",
+            sha256 = "ecd46f4b1fb1fb6ffe0754f4173e2139d73282490343088d543134e7fb320a5a",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package kubeaudit to release v0.11.1. 

# Release info 

 ## Changelog

We are now publishing an [official Docker image](https://hub.docker.com/repository/docker/shopify/kubeaudit/)! Thank you @hazcod  for making this happen.

620fe28 feat(docker): build Docker images too (#295) thank you @hazcod !
b43916e feat(gorelease): build native windows binaries too (#294) thank you @hazcod !

