### PR TITLE
eksctl 0.27.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.26.0"
+local version = "0.27.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "225d718a2be6b286043b7ef83cced281a1564b0953f69974b2791e6d77782238",
+            sha256 = "d6790ec4a80da34ecbc24e2f0e0d08d2ba8b194509c532d71cd31cb0642b2f68",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "a69012e867c9888db3335c91401de6640d1165c155339414b0cf67cc27762a05",
+            sha256 = "62b15bced0e4a21d8f8af144836c8493af889e626a2d54a6931f9c78c3d4e4fe",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "f37e2142cb19d4d2d11a7a45b2cc9af7311916a31b141ab21c73ffcee3375da8",
+            sha256 = "2f1e6a859b3800577c03f5251b1c492e2d07e961bd6efaca97b285dd71c6aa0c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.27.0. 

# Release info 

 # Release 0.27.0

## Features

- Add support for mapAccounts to `create iamidentitymapping` (#2549)
- Added ASG SuspendProcesses support (#2487)

## Improvements

- Update maxpods (#2580)
- Support for managed VPC controller (#2616)

## Bug Fixes

- Fix route validation for subnets with an explicit main route table association (#2577)
- Use partition prefix for VPC endpoint services (#2576)
- Add missing permission required for ELB (#2571)
- Fix upgrading nodegroups with old template format (#2572)
- Respect --ssh-access flag (#2540)

## Acknowledgments
Weaveworks would like to sincerely thank:
 @klausenbusk and @efim-a-efim

