### PR TITLE
hugo 0.75.1

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.75.0"
+local version = "0.75.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "3265ec60a9f5996c1b1b2611413b5fecfefc393bbd6f5c63bf686133c0b10ab1",
+            sha256 = "e028466505d25df6f426767dacbb6c1cc057406eb0981d2ac529f19ab0c4dd25",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "3628614c0cdeefa4eb2530cd653c2d6084b5c68aaa65138790d680a40898b8c2",
+            sha256 = "98e157dc2eda1f78b19959ff45c8a750abd6ae12330fad6574b466efdb58bd1d",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "6412fa86dd7e9f83204ddd17c305c7c16662231ee616657054c67e417a646303",
+            sha256 = "bdb12757be5546ea2f88f1f9b93f54fe70c84d2715a4404e0e23d25b7ea4c29c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.75.1. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* resources/image: Fix nilpointer for images with no Exif [cd00f7f9](https://github.com/gohugoio/hugo/commit/cd00f7f9661d67951ef16c5198541f09f1c058b4) [@bep](https://github.com/bep) [#7688](https://github.com/gohugoio/hugo/issues/7688)
* modules/npm: Preserve the original package.json if it exists [214afe4c](https://github.com/gohugoio/hugo/commit/214afe4c1bb9c37bc6159e659d66ba9a268a2849) [@bep](https://github.com/bep) [#7690](https://github.com/gohugoio/hugo/issues/7690)
* tpl: Fix grammar in the new 'requires non-zero' error message [cd830bb0](https://github.com/gohugoio/hugo/commit/cd830bb0275fc39240861627ef26e146985b5c86) [@nekr0z](https://github.com/nekr0z) 




