### PR TITLE
aks-engine 0.55.4

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.55.3"
+local version = "0.55.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "aed06100144bb4e7361ff9312222bf52ba71a8eec2bb8c90156e33a0eb59ec35",
+            sha256 = "f16e80c408c9dd814260cde834647f5424f7ec1716c716dd4feede5b819ee2a9",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "00438d6928d7b97da86e028ba1b3e7ce054ec18f3938e8f53f9fe9e7fdc0c0fa",
+            sha256 = "8804db259e0caa16dd1a745cb1a5a3e23f64e478a28ae4f2d6312db61e220ec1",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "6a560f274045c089699ba5c4b245abb9edd3b93ed3ca4ae1a4158bfd848b20b4",
+            sha256 = "4ecdd940c70f0164b570de412b1ea560391aa8b416cc8608c147b6c5251bc526",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.55.4. 

# Release info 

 <a name="v0.55.4"></a>
# [v0.55.4] (Azure Stack Hub only) - 2020-09-15
### Bug Fixes 🐞
- update Azure Stack's Linux VHD to 2020.09.14 ([#3828](https://github.com/Azure/aks-engine/issues/3828))

### Maintenance 🔧
- validate Azure Stack's Linux VHD is in PIR ([#3831](https://github.com/Azure/aks-engine/issues/3831))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.55.4...HEAD
[v0.55.4]: https://github.com/Azure/aks-engine/compare/v0.55.3...v0.55.4