### PR TITLE
helm 3.3.2

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.3.1"
+local version = "3.3.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "ab999d5a5e701aa3b75f4b10698d957e75b482cb0fe3c7bb283ac8e1ac602c26",
+            sha256 = "eb86998f8db4e59fe2336ce78b3dc3b3ba5346d81b622dc0a1744bf97c2df5f3",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "81e3974927b4f76e9f679d1f6d6b45748f8c84081a571741d48b2902d816e14c",
+            sha256 = "cf82fe0ed1675030b203a9a3575b1a1bc4b0f5ce4584ce2cd7f75cd093cad259",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "72186fa89a47747ba732127bc964ddf839d810a329eebfc7d78a9fed1dfa77be",
+            sha256 = "5301da7a7942ae0a71ff01813943566bc18de613724b79240ef358f89ce987b9",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.3.2. 

# Release info 

 Helm v3.3.2 is a security (patch) release. Users are *strongly recommended* to update to this release. It fixes a variety of minor security issues, as well as four notable security issues for which we have opened security advisories. More information on the security advisory can be found [on the security advisory page](https://github.com/helm/helm/security/advisories).

Most of the issues were discovered by [Trail of Bits](https://www.trailofbits.com/) during their CNCF-sponsored audit of the Helm codebase. We are grateful for Trail of Bits' detailed and thorough analysis of the Helm codebase. In addition, a Helm core maintainer identified one more issue.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Notable Changes

One **breaking change** was made: The default behavior of `helm repo add` was changed: It no longer overwrites repositories by default. The flag `--force-update` was added to `helm repo add` to allow a repo to be overwritten. The flag `--no-update` still exists, but does nothing. This change accords with the Helm policy for allowing minor breaking changes in the name of security.

The main security issues are:

- [The plugin name field is not properly sanitized](https://github.com/helm/helm/security/advisories/GHSA-c52f-pq47-2r9j)
- [Alias names in Chart.yaml are not properly sanitized](https://github.com/helm/helm/security/advisories/GHSA-9vp5-m38w-j776)
- [The index.yaml file for repositories is not parsed in strict mode, enabling duplicate entries](https://github.com/helm/helm/security/advisories/GHSA-jm56-5h66-w453)
- [The plugin.yaml file for repositories is not parsed in strict mode, enabling duplicate entries](https://github.com/helm/helm/security/advisories/GHSA-m54r-vrmv-hw33)

Seven other minor changes were made in an effort to improve our security posture.

## Installation and Upgrading

Download Helm v3.3.2. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.3.2-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-darwin-amd64.tar.gz.sha256sum) / eb86998f8db4e59fe2336ce78b3dc3b3ba5346d81b622dc0a1744bf97c2df5f3)
- [Linux amd64](https://get.helm.sh/helm-v3.3.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-amd64.tar.gz.sha256sum) / cf82fe0ed1675030b203a9a3575b1a1bc4b0f5ce4584ce2cd7f75cd093cad259)
- [Linux arm](https://get.helm.sh/helm-v3.3.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-arm.tar.gz.sha256sum) / 0a8a9dae0526b527dacd4d3e0fcff06973ba492273a9ddc1c07f953de781683b)
- [Linux arm64](https://get.helm.sh/helm-v3.3.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-arm64.tar.gz.sha256sum) / 8a3d4624efea2a65ec09c8fce82df3dbc09867e5c8c6a7ef80c16dfdb9278877)
- [Linux i386](https://get.helm.sh/helm-v3.3.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-386.tar.gz.sha256sum) / 355a8a77dcd384c11fa0d710eff0459716451a2f1f6d2f56da2aad9c964ca192)
- [Linux ppc64le](https://get.helm.sh/helm-v3.3.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-ppc64le.tar.gz.sha256sum) / 10d46db09900d335056ff15009ac60c6ba20859bff01b83214ca1927a089452b)
- [Linux s390x](https://get.helm.sh/helm-v3.3.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.2-linux-s390x.tar.gz.sha256sum) / eb86998f8db4e59fe2336ce78b3dc3b3ba5346d81b622dc0a1744bf97c2df5f3)
- [Windows amd64](https://get.helm.sh/helm-v3.3.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.3.2-windows-amd64.zip.sha256sum) / 10cbf1b282dbbbbf138002747a8665888b08c3d911c6351bdcb48482fa356a03)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with \`bash\`.

## What's Next

- 3.3.3 will contain only bug fixes.
- 3.4.0 is the next feature release.

## Changelog

- fix(cmd/helm): add build tags for architecture 45d230fcc95c1c4d2e055b7451a988441f038509 (Adam Reese)
- switched to stricter YAML parsing on plugin metadata files 6eeec4a00241b7da1acaddcbf3278355de1f216e (Matthew Fisher)
- Merge pull request from GHSA-m54r-vrmv-hw33 809e2d999e2c33e20e77f6bff30652d79c287542 (Matt Butcher)
- Merge pull request from GHSA-jm56-5h66-w453 055dd41cbe53ce131ab0357524a7f6729e6e40dc (Matt Butcher)
- Merge pull request from GHSA-9vp5-m38w-j776 59d5b94d35b24a500e30839a7c69f05d9ff077e2 (Matt Butcher)
- go fmt 2a74204508f005d89fe51b0e2824dae4f30b3252 (Matthew Fisher)
- improve the HTTP detection for tar archives e2da16f5146e2709211f116cb81dd8f9c9a62fd5 (Matt Butcher)
- replace --no-update with --force-update and invert default. BREAKING. 882eeac7271858124a3cecbe22c5d7d61560714f (Matt Butcher)
- handle case where dependency name collisions break dependency resolution 40b78002873d525a31c5dec75c8607be67327360 (Matt Butcher)
- fixed bug that caused helm create to not overwrite modified files 106f1fb45c93fe862ac86d9b774e2de8b1dd314c (Matt Butcher)
- refactor the release name validation to be consistent across Helm ed5fba5142fa5a2366df143616e9161ff866a53d (Matt Butcher)
- validate the name passed in during helm create c4ef82be13a0a3b6b42ce92bdd0357f4f6ac9e62 (Matt Butcher)
- fix: check mode bits on kubeconfig file 82398667dfe208407be9fe499ac96240aa8ce54b (Matt Butcher)