### PR TITLE
jx 2.1.148

### DIFF
--- a/Food/jx.lua
+++ b/Food/jx.lua
@@ -1,5 +1,5 @@
 local name = "jx"
-local version = "2.1.143"
+local version = "2.1.148"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "cc703eb6e77b5ee106799eead5e27aef7fb0ad4584099f1212f8231b43bb1f6f",
+            sha256 = "24b4d6683c945fdef3518c76a9943558a05006ac66a635a67f8478b4fb9994d3",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "5a921edfe710440cc8734ed1a5d4a2546e51f39147ab9fe59da8df07f60bf3d7",
+            sha256 = "fa44dc682535ca81d4dc08161b55a253919f10b7e202625b35da69056e92d5db",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-x/jx/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "1004b1e641aeffe96e681452c4f4bbccfd4236969c6fee3f76e83404cc7b5cfb",
+            sha256 = "4fedb75cfa973a515e7fce8836d4b5b4c2c31efc6eeb5c94cb58f463a1055ee5",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jx to release v2.1.148. 

# Release info 

 To install jx 2.1.148 see the [install guide](https://jenkins-x.io/getting-started/install/)

### Linux

```shell
curl -L https://github.com/jenkins-x/jx/releases/download/v2.1.148/jx-linux-amd64.tar.gz | tar xzv 
sudo mv jx /usr/local/bin
```

### macOS

```shell
brew tap jenkins-x/jx
brew install jx
```
## Changes

### New Features

* add support to gitlab to the environment controller (Justo Alonso)

