### PR TITLE
aks-engine 0.56.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.55.4"
+local version = "0.56.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "f16e80c408c9dd814260cde834647f5424f7ec1716c716dd4feede5b819ee2a9",
+            sha256 = "0f289a47a064cba67854ee3a334985faeafa0a406618c4ac81bfea3227cd4711",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "8804db259e0caa16dd1a745cb1a5a3e23f64e478a28ae4f2d6312db61e220ec1",
+            sha256 = "351141b7af7b0a0b5cfea3130b15db4787ea3cff45eecab4a993d8738e9b703d",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "4ecdd940c70f0164b570de412b1ea560391aa8b416cc8608c147b6c5251bc526",
+            sha256 = "40acc2b328a1375b4b7ec79fe4482508cd2c3a2984bcb212415523399217cfbb",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.56.0. 

# Release info 

 <a name="v0.56.0"></a>
# [v0.56.0] - 2020-09-17
### Bug Fixes 🐞
- Azure Stack CNI network interfaces file creation fix ([#3792](https://github.com/Azure/aks-engine/issues/3792))
- clean up stale CNI data regardless of HNS state ([#3822](https://github.com/Azure/aks-engine/issues/3822))
- working systemd monitor jobs ([#3788](https://github.com/Azure/aks-engine/issues/3788))
- set correct ssh private key for e2e get-logs ([#3824](https://github.com/Azure/aks-engine/issues/3824))
- check if windows profile exists in upgrade ([#3820](https://github.com/Azure/aks-engine/issues/3820))
- update GPU driver to 450.51.06 ([#3814](https://github.com/Azure/aks-engine/issues/3814)) ([#3821](https://github.com/Azure/aks-engine/issues/3821))
- more resilient etcd systemd ([#3809](https://github.com/Azure/aks-engine/issues/3809))
- updating pub to v0.2.6 ([#3802](https://github.com/Azure/aks-engine/issues/3802))
- Enable Windows VHD version update in aks-engine upgrade scenario ([#3774](https://github.com/Azure/aks-engine/issues/3774))
- mount /etc/ssl/certs for apiserver ([#3800](https://github.com/Azure/aks-engine/issues/3800))
- mount certs directory in apiserver pod ([#3782](https://github.com/Azure/aks-engine/issues/3782))
- update the flag due to using higher version of csi livenessprobe ([#3770](https://github.com/Azure/aks-engine/issues/3770))
- availabilityZones value in template to read from parameter ([#3767](https://github.com/Azure/aks-engine/issues/3767))
- validate k8s control plane before addons ([#3729](https://github.com/Azure/aks-engine/issues/3729))
- ensure cleanup scripts can login w/ sp ([#3765](https://github.com/Azure/aks-engine/issues/3765))
- Restart=always docker systemd service ([#3758](https://github.com/Azure/aks-engine/issues/3758))
- use cached v1.15-azs kube-proxy on Azure Stack ([#3757](https://github.com/Azure/aks-engine/issues/3757))
- fix issue where installing a different version of containerd vs what was pre-installed on VHD failed silently ([#3743](https://github.com/Azure/aks-engine/issues/3743))
- add missing 1.16.14 kube-proxy image to the vhd dependencies ([#3736](https://github.com/Azure/aks-engine/issues/3736))

### Continuous Integration 💜
- use 1.4.0 containerd release for windows in CI ([#3742](https://github.com/Azure/aks-engine/issues/3742))

### Doc
- update azure stack doc for aks-engine v0.55.0 (additional) ([#3769](https://github.com/Azure/aks-engine/issues/3769))
- update azure stack doc for aks-engine v0.55.0 ([#3766](https://github.com/Azure/aks-engine/issues/3766))

### Documentation 📘
- clarify project support policy in SUPPORT.md ([#3813](https://github.com/Azure/aks-engine/issues/3813))
- add doc and example api model for IPv6 ([#3777](https://github.com/Azure/aks-engine/issues/3777))

### Features 🌈
- azure kms provider as static pod ([#3667](https://github.com/Azure/aks-engine/issues/3667))
- add support for Kubernetes 1.19.1 ([#3816](https://github.com/Azure/aks-engine/issues/3816))
- secrets store addon can pull from custom env ([#3787](https://github.com/Azure/aks-engine/issues/3787))
- add support for Kubernetes v1.16.15 ([#3780](https://github.com/Azure/aks-engine/issues/3780))
- add support for Kubernetes v1.19.0 ([#3754](https://github.com/Azure/aks-engine/issues/3754))
- variable upgrade timeout based on num nodes ([#3752](https://github.com/Azure/aks-engine/issues/3752))
- collect hyperv logs ([#3737](https://github.com/Azure/aks-engine/issues/3737))

### Maintenance 🔧
- updating Windows VHD with new cached artifacts ([#3843](https://github.com/Azure/aks-engine/issues/3843))
- adding 1.19.1 bits to Windows VHD ([#3834](https://github.com/Azure/aks-engine/issues/3834))
- rev Linux VHDs to 2020.09.14 ([#3827](https://github.com/Azure/aks-engine/issues/3827))
- update signed powershell script package to include azure CNI fixes ([#3829](https://github.com/Azure/aks-engine/issues/3829))
- pin virtual-kubelet to version 1.2.1.2 ([#3815](https://github.com/Azure/aks-engine/issues/3815))
- reduce customData payload ([#3793](https://github.com/Azure/aks-engine/issues/3793))
- remove apiserver /etc/kubernetes/certs mount ([#3808](https://github.com/Azure/aks-engine/issues/3808))
- update Linux VHDs to 2020.09.08 ([#3811](https://github.com/Azure/aks-engine/issues/3811))
- get calico and v-k from mcr.microsoft.com ([#3803](https://github.com/Azure/aks-engine/issues/3803))
- add keyVaultEndpoint to Azure Stack environment ([#3790](https://github.com/Azure/aks-engine/issues/3790))
- update node-problem-detector addon to v0.8.4 ([#3779](https://github.com/Azure/aks-engine/issues/3779))
- simplify addons config for calico and flannel ([#3773](https://github.com/Azure/aks-engine/issues/3773))
- update CNI plugins to v0.8.7 ([#3771](https://github.com/Azure/aks-engine/issues/3771))
- Update NPM to latest version 1.1.7 ([#3740](https://github.com/Azure/aks-engine/issues/3740))
- always install moby-runc ([#3763](https://github.com/Azure/aks-engine/issues/3763))
- specify containerd version to install with moby-engine package ([#3723](https://github.com/Azure/aks-engine/issues/3723))
- rev Linux VHDs to 2020.08.24 ([#3750](https://github.com/Azure/aks-engine/issues/3750))
- add new Azure VM SKUs ([#3744](https://github.com/Azure/aks-engine/issues/3744))
- update windows default VHD for August ([#3730](https://github.com/Azure/aks-engine/issues/3730))
- update csi-secrets-store addon manifest and images ([#3728](https://github.com/Azure/aks-engine/issues/3728))

### Testing 💚
- add private key input to e2e suite + keep all junit result files ([#3747](https://github.com/Azure/aks-engine/issues/3747))
- remove tiller addon from PR E2E cluster configuration ([#3794](https://github.com/Azure/aks-engine/issues/3794))
- don't try to kill docker if using containerd ([#3764](https://github.com/Azure/aks-engine/issues/3764))
- add REBOOT_CONTROL_PLANE_NODES E2E config ([#3745](https://github.com/Azure/aks-engine/issues/3745))
- validate kubelet and docker systemd during E2E ([#3759](https://github.com/Azure/aks-engine/issues/3759))
- disable azure-arc-onboarding addon in everything cluster config ([#3756](https://github.com/Azure/aks-engine/issues/3756))
- update kubernetes e2e to use GINKGO_FAIL_FAST parameter value ([#3660](https://github.com/Azure/aks-engine/issues/3660))
- fix ginkgo failFast ([#3738](https://github.com/Azure/aks-engine/issues/3738))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.56.0...HEAD
[v0.56.0]: https://github.com/Azure/aks-engine/compare/v0.55.4...v0.56.0