### PR TITLE
helm 3.3.3

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.3.2"
+local version = "3.3.3"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "eb86998f8db4e59fe2336ce78b3dc3b3ba5346d81b622dc0a1744bf97c2df5f3",
+            sha256 = "6acf1640d59a273996b67ba9e3d8e636254aa3e34dd423edcce9ac77b9727330",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "cf82fe0ed1675030b203a9a3575b1a1bc4b0f5ce4584ce2cd7f75cd093cad259",
+            sha256 = "246d58b6b353e63ae8627415a7340089015e3eb542ff7b5ce124b0b1409369cc",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "5301da7a7942ae0a71ff01813943566bc18de613724b79240ef358f89ce987b9",
+            sha256 = "b8efa77dcd46b1289a88845075963d1bcc5e8483ea6711ae9b5593843137b12e",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.3.3. 

# Release info 

 Helm v3.3.3 is a hotfix (patch) release from v3.3.2, fixing an issue where Helm cannot load chart repository index files with extra metadata.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.3.3. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.3.3-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-darwin-amd64.tar.gz.sha256sum) / 6acf1640d59a273996b67ba9e3d8e636254aa3e34dd423edcce9ac77b9727330)
- [Linux amd64](https://get.helm.sh/helm-v3.3.3-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-amd64.tar.gz.sha256sum) / 246d58b6b353e63ae8627415a7340089015e3eb542ff7b5ce124b0b1409369cc)
- [Linux arm](https://get.helm.sh/helm-v3.3.3-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-arm.tar.gz.sha256sum) / 94ddce8c497999113b31d7320ed5d2c61b25bb0066d95d81135135f73dbe5bf2)
- [Linux arm64](https://get.helm.sh/helm-v3.3.3-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-arm64.tar.gz.sha256sum) / e8b2695185188e956a6ccbddf16f2d6edb37507dd51be01317308852d4902769)
- [Linux i386](https://get.helm.sh/helm-v3.3.3-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-386.tar.gz.sha256sum) / 2d08fa20ac901ae3903fc0d3f5ae017ecf4a58d7ea9f9e0bf8a50b21b76dcb42)
- [Linux ppc64le](https://get.helm.sh/helm-v3.3.3-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-ppc64le.tar.gz.sha256sum) / 359ae5c7f7289c80e369e0e8bdc56de7e4943a4f26440541c3f9fdea458eb500)
- [Linux s390x](https://get.helm.sh/helm-v3.3.3-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.3-linux-s390x.tar.gz.sha256sum) / 6acf1640d59a273996b67ba9e3d8e636254aa3e34dd423edcce9ac77b9727330)
- [Windows amd64](https://get.helm.sh/helm-v3.3.3-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.3.3-windows-amd64.zip.sha256sum) / 7cf4f1e830e4a8f8af8b92140fef37976ab75194d1b60af5182619a4b31049e0)

This release was signed with `967F 8AC5 E221 6F9F 4FD2 70AD 92AA 783C BAAE 8E3B` and can be found at @bacongobbler's [keybase account](https://keybase.io/bacongobbler). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with \`bash\`.

## What's Next

- 3.3.4 will contain only bug fixes.
- 3.4.0 is the next feature release.

## Changelog

- fix: allow serverInfo field on index files 55e3ca022e40fe200fbc855938995f40b2a68ce0 (Matthew Fisher)