### PR TITLE
helm 3.3.4

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.3.3"
+local version = "3.3.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "6acf1640d59a273996b67ba9e3d8e636254aa3e34dd423edcce9ac77b9727330",
+            sha256 = "9fffc847c61da0e06319788d3998ea173eb86c1cc5600ac3ada8d0d40c911793",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "246d58b6b353e63ae8627415a7340089015e3eb542ff7b5ce124b0b1409369cc",
+            sha256 = "b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "b8efa77dcd46b1289a88845075963d1bcc5e8483ea6711ae9b5593843137b12e",
+            sha256 = "510677f99d7ee44d736e2289562538acc97eb80ab1386ad49f87bd63aac828bb",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.3.4. 

# Release info 

 Helm v3.3.4 is a bugfix release that fixes several regressions introduced in Helm 3.3.2.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.3.4. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.3.4-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-darwin-amd64.tar.gz.sha256sum) / 9fffc847c61da0e06319788d3998ea173eb86c1cc5600ac3ada8d0d40c911793)
- [Linux amd64](https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz.sha256sum) / b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c)
- [Linux arm](https://get.helm.sh/helm-v3.3.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-arm.tar.gz.sha256sum) / 9da6cc39a796f85b6c4e6d48fd8e4888f1003bfb7a193bb6c427cdd752ad40bb)
- [Linux arm64](https://get.helm.sh/helm-v3.3.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-arm64.tar.gz.sha256sum) / bdd00b8ff422171b4be5b649a42e5261394a89d7ea57944005fc34d34d1f8160)
- [Linux i386](https://get.helm.sh/helm-v3.3.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-386.tar.gz.sha256sum) / 2c14d4d944c94f4487fa15ae99d974304554850a8decd726419e6a8cb0f9038c)
- [Linux ppc64le](https://get.helm.sh/helm-v3.3.4-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-ppc64le.tar.gz.sha256sum) / fed9553cd7459f0c37dc99b8566bd397b6893e48dc63f154e63eb8919179b99a)
- [Linux s390x](https://get.helm.sh/helm-v3.3.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.3.4-linux-s390x.tar.gz.sha256sum) / 9fffc847c61da0e06319788d3998ea173eb86c1cc5600ac3ada8d0d40c911793)
- [Windows amd64](https://get.helm.sh/helm-v3.3.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.3.4-windows-amd64.zip.sha256sum) / 001f38788ed7ecfe336881b991d46bfd73596380185dc70557a1e352f27c0b22)

The [Quickstart Guide](https://docs.helm.sh/using_helm/#quickstart-guide) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://docs.helm.sh/using_helm/#installing-helm). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.3.5 will contain only bug fixes.
- 3.4.0 is the next feature release.

## Changelog

- Fixing import package issue a61ce5633af99708171414353ed49547cf05013d (Matt Farina)
- use warning function e5bd79faefedbbaf4a6a5f7faaa13eba4ddc55aa (Matthew Fisher)
- Fixing issue with idempotent repo add 520416adf0723321101235780f86245c3a714c3c (Matt Farina)