### PR TITLE
kubeseal 0.12.6

### DIFF
--- a/Food/kubeseal.lua
+++ b/Food/kubeseal.lua
@@ -1,7 +1,7 @@
 local name = "kubeseal"
 local org = "bitnami-labs"
-local release = "v0.12.5"
-local version = "0.12.5"
+local release = "v0.12.6"
+local version = "0.12.6"
 food = {
     name = name,
     description = "A Kubernetes controller and tool for one-way encrypted Secrets",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "238a1d290f80527ead1c521e0bb01d42df6e025fdcd711c5d30a039bc4d6c2fd",
+            sha256 = "2cf77775b0c16f68a498ea537673489a185d441bd1fbf86e86e722433b6612d1",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "9e6f5e6a98b86e4801fb14677815655013776140d739c66b74b5968a4bb8be0e",
+            sha256 = "9572b161c6e98faf28a71f8137b3d78c401b531fdc7a0658a519b77caae7ed69",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. ".exe",
-            sha256 = "261a627b215b7d54c7442f8036f02d602a0c95c5211a95d33a512574131dffdd",
+            sha256 = "73c7206bde5bda40a3cf7056f5843deb83fecdd8e8a0f8c5475d5d5eb5c01ad9",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package kubeseal to release v0.12.6. 

# Release info 

 ## Release Notes

Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v0126) which contain among other things important information for who is upgrading from previous releases.

## Install

### Client side

Install client-side tool into `/usr/local/bin/`:

* **Linux x86_64:**

```bash
wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.6/kubeseal-linux-amd64 -O kubeseal
sudo install -m 755 kubeseal /usr/local/bin/kubeseal
```



* **Macos:** (might lag a few hours behind a new release, this icon will reflect that latest release)

[![](https://img.shields.io/homebrew/v/kubeseal)](https://formulae.brew.sh/formula/kubeseal)

```bash
brew install kubeseal
```

* **Other OS/arch:** you might find binaries for your OS/arch combo attached to this release below.

### Cluster side

Install SealedSecret CRD, server-side controller into kube-system namespace.

```sh
$ kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.12.6/controller.yaml
```

NOTE: If you can't (or don't want) to use the `kube-system` namespace, please consider [this approach](https://github.com/bitnami-labs/sealed-secrets#kustomize) 

NOTE: if you want to install it on a GKE cluster for which your user account doesn't have admin rights, please read [this](https://github.com/bitnami-labs/sealed-secrets/blob/master/docs/GKE.md)

NOTE: since the helm chart is currently maintained elsewhere (see https://github.com/helm/charts/tree/master/stable/sealed-secrets) the update of the helm chart might not happen in sync with releases here.
