### PR TITLE
eksctl 0.29.1

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.28.1"
+local version = "0.29.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "6fd619739df5a3778c882965e1f40b0a2998349434dc321ac54d5a6a1e93eeb0",
+            sha256 = "e4797da2cf695bd235dda6c38835d63100c78a17b80e5a67ba42ddd9136e7c09",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "9d4f5001bedbdf6afa53bb190c85453266317f5170f3794ae20f4b6a1853cbe8",
+            sha256 = "25c30c224ff3798db8b527c013ad7c91213c6735f25dc2b3cd95fa532fe031d5",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "15e9ca2a55a9c6b7acc78d9955ead2d8276ee49f6b1c87afd6c23b9bf9af91e3",
+            sha256 = "94410c6b9ff52952e586ac3f79748cd391ae6d910d0172a2074963e0b352d548",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.29.1. 

# Release info 

 # Release 0.29.1

## Bug Fixes

- Do OIDC provider and SA creation before nodegroups (#2703)

## Acknowledgments
Weaveworks would like to sincerely thank our contributors!

