### PR TITLE
fluxctl 1.21.0

### DIFF
--- a/Food/fluxctl.lua
+++ b/Food/fluxctl.lua
@@ -1,7 +1,7 @@
 local name = "fluxctl"
 local org = "fluxcd"
-local release = "1.20.2"
-local version = "1.20.2"
+local release = "1.21.0"
+local version = "1.21.0"
 food = {
     name = name,
     description = "The GitOps Kubernetes operator",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_darwin_amd64",
-            sha256 = "96686c1d72f0e91371719a1506125afc13a18c895df6f7d840aa5c1f14d6bac8",
+            sha256 = "84dc0e54a652ddbf4cf38e7c487bbbc0187d65d9b78406fc351272ca9c664c29",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_linux_amd64",
-            sha256 = "a3ace35ebc5dc96a00c118e1c51eaf4f21a2507affbf79f7418e41b5766bdcc6",
+            sha256 = "b429f7bf20703fa2ebbd4b7b2955fb787545e0dc424c17c1d654caea24910653",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_windows_amd64",
-            sha256 = "a49ae50d547ff31d58e761c94f736164c3b1118aefbd5b1b3ad323bef3a011c5",
+            sha256 = "3f137446a7313613bc07768448091a21397616921c05b7bb1bdbca4f46d7ced8",
             resources = {
                 {
                     path = name .. "_windows_amd64",


### PR DESCRIPTION
Updating package fluxctl to release 1.21.0. 

# Release info 

 This minor version release updates the versions of `kubectl` and `kustomize`.

> **NB**: the updated version of Kustomize includes a _breaking change_ (despite being a patch release), in which [prefix transformers no longer apply to namespaces](https://github.com/kubernetes-sigs/kustomize/issues/235).

### Fixes

- Update go, kubectl and kustomize [fluxcd/flux#3309][]

### Maintenance and documentation

- Correct FAQ typo: fluxcd.io/ignore value must be string [fluxcd/flux#3303][]
- Clarify misleading FAQ entry. [fluxcd/flux#3281][]
- Update Fluxcloud URL [fluxcd/flux#3307][]
- Add production users to list [fluxcd/flux#3249][], [fluxcd/flux#3300][], [fluxcd/flux#3274][]
- FOSSA scan enabled [fluxcd/flux#3294][]
- Exclude chart releases from Snap [fluxcd/flux#3266][]

### Thanks

Thanks to @Frederik-Baetens, @austinpray, @bricef, @dewe, @dholbach, @idvoretskyi, @lloydchang, @lucioveloso and @stefanprodan for their contributions to this release.

[fluxcd/flux#3309]: https://github.com/fluxcd/flux/pull/3309
[fluxcd/flux#3307]: https://github.com/fluxcd/flux/pull/3307
[fluxcd/flux#3303]: https://github.com/fluxcd/flux/pull/3303
[fluxcd/flux#3300]: https://github.com/fluxcd/flux/pull/3300
[fluxcd/flux#3294]: https://github.com/fluxcd/flux/pull/3294
[fluxcd/flux#3281]: https://github.com/fluxcd/flux/pull/3281
[fluxcd/flux#3274]: https://github.com/fluxcd/flux/pull/3274
[fluxcd/flux#3266]: https://github.com/fluxcd/flux/pull/3266
[fluxcd/flux#3263]: https://github.com/fluxcd/flux/pull/3263
[fluxcd/flux#3249]: https://github.com/fluxcd/flux/pull/3249

