### PR TITLE
eksctl 0.29.2

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.29.1"
+local version = "0.29.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "e4797da2cf695bd235dda6c38835d63100c78a17b80e5a67ba42ddd9136e7c09",
+            sha256 = "4fa81925d4cd456e4ecb8cfc8b58ef9ec9d37a81908fb1f04800e7d9d3426a4e",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "25c30c224ff3798db8b527c013ad7c91213c6735f25dc2b3cd95fa532fe031d5",
+            sha256 = "4cc9eb5615d2755c15400f8dafc72c6f44acf9d7ebf8e9b96c434ed79da75d04",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "94410c6b9ff52952e586ac3f79748cd391ae6d910d0172a2074963e0b352d548",
+            sha256 = "f56a7da8dfd333147d858e86cfc383ca2f7cdeb0726bd71457d9d089045a9173",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.29.2. 

# Release info 

 # Release 0.29.2

## Bug Fixes

- Fix kubernetesNetworkConfig with new nodegroups for existing clusters (#2713)

## Acknowledgments
Weaveworks would like to sincerely thank our contributors!


