### PR TITLE
hugo 0.76.2

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.76.0"
+local version = "0.76.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "1b87ca528eb1eb2e4c500cc25b7fb6f1d8db509b64838ea7e380bb0bec43bf82",
+            sha256 = "622c7aa97e58ba8f6bcf9567b92c01fef812804ce6f76ab53f4249d6a4e9e47e",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "41716915d69418237e85f9a642173c76a398a84a9b1578b85645fd5de350fbbf",
+            sha256 = "f220dbf793819790028def08ff4c934742dd73de9bb0a4a4be59cc70314008cb",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "49503dcf48d93e5f9e8574d9bad69b3fad4485d260fd7f0d71a9e7fadbae6fd2",
+            sha256 = "9e316f78542cc0f4e363008ec049912e4d94d09ee2d36704edf9b75943f05e6c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.76.2. 

# Release info 

 

This is a bug-fix release with one important fix.

* Revert "deps: Update to  github.com/tdewolff/minify v2.9.4" [6dd60fca](https://github.com/gohugoio/hugo/commit/6dd60fca73ff96b48064bb8c6586631a2370ffc6) [@bep](https://github.com/bep) [#7792](https://github.com/gohugoio/hugo/issues/7792)




