### PR TITLE
Update kubeaudit.lua to 0.11.5

### DIFF
--- a/Food/kubeaudit.lua
+++ b/Food/kubeaudit.lua
@@ -1,5 +1,5 @@
 local name = "kubeaudit"
-local version = "0.11.3"
+local version = "0.11.5"
 
 food = {
     name = name,
@@ -12,25 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "56af94d2b9eb814c8a28b72144d5a0fe0f47a5d68ddd7f52dffe08e4a8326cf8",
-            resources = {
-                {
-                    path = name,
-                    installpath = "bin/" .. name,
-                    executable = true
-                },
-                {
-                    path = name,
-                    installpath = "bin/kubectl-audit",
-                    executable = true
-                }
-            }
-        },
-        {
-            os = "darwin",
-            arch = "386",
-            url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_darwin_386.tar.gz",
-            sha256 = "c4173a0014f3653e27604afefa238d1e313e28089c45f4e8dad406fae0675b92",
+            sha256 = "f899c1d010037f32ad4b00a019493bf3be175cfe67c751ca5f7f800cbfd29d4c",
             resources = {
                 {
                     path = name,
@@ -48,7 +30,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "30f0eaec794bd296d407ee1d0af8361b9376179197733802250126b5b313f243",
+            sha256 = "3e8babceed0d3f0a1366abbd8e67084c704874621bd617e57f63b6d1ec51993f",
             resources = {
                 {
                     path = name,
@@ -66,7 +48,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/Shopify/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_386.tar.gz",
-            sha256 = "e09098cfe19aae3ffc6d72e820f31a4ba42f037da51a63e42baa6aa491ec0dcc",
+            sha256 = "2cca2053a2bd485b0a19f8c9096f6429576fddcb25efc68bdef91122752924ba",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
`kubeaudit` is no longer releasing the `darwin_386` binary.