### PR TITLE
gh 1.1.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "1.0.0"
+local version = "1.1.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "5d646ebabacf80f365df8c26b493e8aff309642e85b8fc901200fd0302410b4c",
+            sha256 = "4d625455a07a4a6adf0e92183338979084829f28bda0f9593405a53da9d0e251",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "96575c888d979a6717928fe53bbd75d1acd52a6eec32aa41202d15919475ebfa",
+            sha256 = "2e1ca73bd7ecbd6e7e71368e901ebb7b1d83c3ca375752c7ab23cc664190d452",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "989c1f5a7d6f252e551ae7a9c0b19f1dcb1215f58ebad7d0798b83176b18f07a",
+            sha256 = "94cbfff8cf50ca24ae9d2f60dbda3e1f3aa1a68be896d657ce4885f2a045bad4",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v1.1.0. 

# Release info 

 ## Features

* Support `GH_PAGER` environment override for `PAGER`  #2020

* Disable terminal pager when its value is set to `cat`  #2021

* `repo view`: add option to specify a branch  #1766

* `repo view`: render `:emoji:` syntax as emoji characters  #1816

## Bugs

* Fix `pr create` when branch was already pushed to a non-base remote  #1926

* `pr status/view/create`: fix API-related failures with GitHub Enterprise Server  #2035

* Fix markdown rendering when terminal pager is enabled  #1917

* `repo create`: respect repo name input given in interactive prompt  #1880

* `auth login`: display correct hostname in Personal Access Token instructions   #1893

* `auth login`: document minimum required token scopes  #2057

* `pr checkout`: fix running on detached HEAD  #1889

* `pr merge`: default to "no" for "delete branch after merge" prompt  #1962

* `gist list`: switch to GraphQL API to improve fetching  #1763

  - support fetching more than 100 gists
  - list gists ordered by creation time, descending
  - for machine-readable output, serialize timestamps in RFC 3339 format
  - ensure newlines in gist description are rendered as spaces

* `gist view/edit`: fix passing Gist URL as argument  #1781

* `gist edit`: check ownership before editing  #2034

* `gist edit`: avoid updating gist when the contents haven't changed  #1828

* `repo garden`: fix for repositories with only a few commits  #1967

* `repo garden`: restore tty settings on exit  #2072

* Fix reading the current git branch name when it contains a non-breaking space  #2025

* Document `gh config set pager ...` option  #1710

* Fix `.tar` upload tests on different OSs  #1738
