### PR TITLE
hugo 0.76.4

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.76.2"
+local version = "0.76.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "622c7aa97e58ba8f6bcf9567b92c01fef812804ce6f76ab53f4249d6a4e9e47e",
+            sha256 = "f04724faf5ff4d85763ded83101013edf05ef0cb5b08836f3b0e60aaf70bc190",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "f220dbf793819790028def08ff4c934742dd73de9bb0a4a4be59cc70314008cb",
+            sha256 = "723d36ad66082d1beef80a750277aff58de71eaae2d0fca7df6de737eec64e26",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "9e316f78542cc0f4e363008ec049912e4d94d09ee2d36704edf9b75943f05e6c",
+            sha256 = "8add378fa5fd79d005d29adb0f8ce08fd25f13b771ca5c7c57e42d469f1b6b32",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.76.4. 

# Release info 

 

This is a bug-fix release with a couple of important fixes.

* snap: Install postcss v8 explicitly as it is now a peer dependency [e9a7ebaf](https://github.com/gohugoio/hugo/commit/e9a7ebaf67a63ffe5e64c3b3aaefe66feb7f1868) [@anthonyfok](https://github.com/anthonyfok) 
* lang/i18n: Fix for language code case issue with pt-br etc. [50682043](https://github.com/gohugoio/hugo/commit/506820435cacb39ce7bb1835f46a15e913b95828) [@bep](https://github.com/bep) [#7804](https://github.com/gohugoio/hugo/issues/7804)
* Merge branch 'release-0.76.3' [49972d07](https://github.com/gohugoio/hugo/commit/49972d07925604fea45afe1ace7b5dcc6efc30bf) [@bep](https://github.com/bep) 
* Add merge helper [c98132e3](https://github.com/gohugoio/hugo/commit/c98132e30e01a9638e61bd888c769d30e4e43ad5) [@bep](https://github.com/bep) 




