### PR TITLE
aks-engine 0.57.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.56.0"
+local version = "0.57.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "0f289a47a064cba67854ee3a334985faeafa0a406618c4ac81bfea3227cd4711",
+            sha256 = "907d02674f589f252c55e0f8bec2e0cf9dba4d13d9c5b3f388f82b6b17c44450",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "351141b7af7b0a0b5cfea3130b15db4787ea3cff45eecab4a993d8738e9b703d",
+            sha256 = "2c37d40b8b31d0f60d7fc16b6c9253dbed364e6b0a3c47d0beeeceec0572aeda",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "40acc2b328a1375b4b7ec79fe4482508cd2c3a2984bcb212415523399217cfbb",
+            sha256 = "541e093cf527b8bf5319ee12439de6ed8ccbab11d0d49a681353c6869cd949f2",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.57.0. 

# Release info 

 <a name="v0.57.0"></a>
# [v0.57.0] - 2020-10-08
### Features 🌈
- Target new windows VHD with new K8s binaries (1.19.2, 1.18.9, etc) ([#3905](https://github.com/Azure/aks-engine/issues/3905))
- add ScaleCPULimitsToSandbox for hyperv runtimeclasses ([#3889](https://github.com/Azure/aks-engine/issues/3889))
- allow custom containerd package for Linux nodes ([#3878](https://github.com/Azure/aks-engine/issues/3878))
- Updating Windows VHD build files to support building for multiple OS versions ([#3847](https://github.com/Azure/aks-engine/issues/3847))
- add support for Kubernetes v1.18.9 ([#3841](https://github.com/Azure/aks-engine/issues/3841))
- add support for Kubernetes v1.19.2 ([#3842](https://github.com/Azure/aks-engine/issues/3842))
- add support for Kubernetes v1.17.12 ([#3840](https://github.com/Azure/aks-engine/issues/3840))
- update VMSS node pools ([#3830](https://github.com/Azure/aks-engine/issues/3830))

### Maintenance 🔧
- rev Linux VHDs to 2020.10.06 ([#3906](https://github.com/Azure/aks-engine/issues/3906))
- enable VHD re-use in no outbound scenarios ([#3897](https://github.com/Azure/aks-engine/issues/3897))

### Bug Fixes 🐞
- Add azure.json path for custom cloud k8s config & Update stability timeout for Azure CNI network policy ([#3895](https://github.com/Azure/aks-engine/issues/3895))
- fix jumpbox custom data ([#3896](https://github.com/Azure/aks-engine/issues/3896))
- don't warn about CRI update on cluster create ([#3890](https://github.com/Azure/aks-engine/issues/3890))
- ensure addon hostNetwork ports don't conflict ([#3894](https://github.com/Azure/aks-engine/issues/3894))
- de-dup vnet roleAssignment deployments ([#3857](https://github.com/Azure/aks-engine/issues/3857))
- add #EOF sentinel chars to custom search file ([#3862](https://github.com/Azure/aks-engine/issues/3862))
- E2E scale scenario broken if update is false ([#3852](https://github.com/Azure/aks-engine/issues/3852))

### Continuous Integration 💜
- adding github actions to create nightly builds
- add containerd PR E2E tests ([#3892](https://github.com/Azure/aks-engine/issues/3892))
- update OWNERS ([#3853](https://github.com/Azure/aks-engine/issues/3853))

### Documentation 📘
- confirm flannel + docker is not supported ([#3886](https://github.com/Azure/aks-engine/issues/3886))
- add notes about not upgrading LB config ([#3884](https://github.com/Azure/aks-engine/issues/3884))
- clarify that update is for node pools only ([#3877](https://github.com/Azure/aks-engine/issues/3877))
- CLI operations ([#3837](https://github.com/Azure/aks-engine/issues/3837))
- mark rotate-certs command as experimental ([#3869](https://github.com/Azure/aks-engine/issues/3869))
- add v0.55.4 to Azure Stack topic page ([#3846](https://github.com/Azure/aks-engine/issues/3846))
- remove mention about library for AKS ([#3835](https://github.com/Azure/aks-engine/issues/3835))
- add required attribution reminder to PR template ([#3826](https://github.com/Azure/aks-engine/issues/3826))

### Maintenance 🔧
- update csi-secrets-store addon manifest and images (v0.0.9) ([#3891](https://github.com/Azure/aks-engine/issues/3891))
- create azure.json via CSE ([#3876](https://github.com/Azure/aks-engine/issues/3876))
- distribute apiserver.crt to control plane nodes only ([#3860](https://github.com/Azure/aks-engine/issues/3860))
- update azure cni to 1.1.7 ([#3864](https://github.com/Azure/aks-engine/issues/3864))
- update Dashboard addon to v2.0.4 ([#3855](https://github.com/Azure/aks-engine/issues/3855))
- check VHD media name length before being published to Marketplace ([#3799](https://github.com/Azure/aks-engine/issues/3799))
- remove no-op 1.15 version checks in templates ([#3851](https://github.com/Azure/aks-engine/issues/3851))

### Testing 💚
- E2E fix scale test indexing out of bounds ([#3873](https://github.com/Azure/aks-engine/issues/3873))
- not nil defense broke logic ([#3881](https://github.com/Azure/aks-engine/issues/3881))
- fixes for akse e2e tests ([#3874](https://github.com/Azure/aks-engine/issues/3874))
- E2E optionally validates rotate-certs ([#3866](https://github.com/Azure/aks-engine/issues/3866))
- add more E2E timeout tolerance ([#3850](https://github.com/Azure/aks-engine/issues/3850))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.57.0...HEAD
[v0.57.0]: https://github.com/Azure/aks-engine/compare/v0.56.0...v0.57.0