### PR TITLE
helmfile 0.130.3

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.130.1"
+local version = "0.130.3"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "79fbd0aaab989309340b3cd6a978b656ee76478794c51022b7065b5532b78b12",
+            sha256 = "2ef163aede161a1ca328d7598598084ccc322b60e91a4be95c336488c3908102",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "3f90bd73c54361d94d22ef77ba4fae873fd0bc0f4c85f16bc2914a8441415b66",
+            sha256 = "6bc87cc2d2b85d9fc91522061ce80797f427c8a30d5e166b7b4ccdedcc847d94",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "606beae471f856a67933767f971423fd31e109728e83771f7a4bf5c6c191f346",
+            sha256 = "2bc66da12327d17ca83bd268e06de65f46ac7a062dd09564a7d41f45a69d3d0c",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "e33e73d31b015b4e4c1f282b8162625db917fe9d94346a2308655c128c87ade0",
+            sha256 = "6c771208209954c0e93a0c81181b215ddec385c79737ef5cf502d1bb5f71dbc7",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "88e237c548aa37a68435c85fc5256e2a19fd840fff4d448eb22ac930a0407c1d",
+            sha256 = "c5c92b8b4e2121bb99ee4da6d6a92d1de212c1fec7fa229843c8b85bc9da3137",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "a993618e2ee6cf2d8b286ff19b82dac82ac590d1845bcc988abacaee3c5164c4",
+            sha256 = "177c18dde136fd3fb49c5141eef0ed8f4acf18364c1bd074a8e8aff9fc107648",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.130.3. 

# Release info 

 563fce4 (HEAD, tag: v0.130.3, origin/master, origin/HEAD, master) Bump vals (#1537)
b287101 Update USERS.md (#1535) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/6823)