### PR TITLE
helmfile 0.132.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.131.0"
+local version = "0.132.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "f9c536b1fa985b9136140307c752a32f7919b0182db65957f6992c84b9486574",
+            sha256 = "a703fbe6f710370495654a29fbc27399d80fc56b9d340edefcf7a1ffa7248f6a",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "d5fbde2f67c3d4c72191a04866c10f812feffcbf18d5d6b9dc98de6df7ab7155",
+            sha256 = "deebfdbb9548d60856d93e24be7638b9835b0d1703192ce88799069004469a37",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "3c690a09822546e5935696eb1dc84747a74e73bc4cb6d31a4a123a7ebd624642",
+            sha256 = "90a62907b4d98ebaba695b6d328f82259f32f0925c9838b7443bc5c871d3b056",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "ff031a3c3c06b6e1467b8616e0139b2a590a2577811949f47c3accc214967f50",
+            sha256 = "8f24649bc4df1b836342321eb19e98b5c2b39e8416465fa4c5a7c740a4e8c8a4",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "b985eaf9e51b3ec5b76500232adc3d24a11bb19e149da348a15d24e595976292",
+            sha256 = "65474d284718546ac64c22c2753ddb70a6d35e53001fbb96292ced364d014572",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "13e54060844de7e06401206334efc33063621db7a37bbc6520f72790af1e0817",
+            sha256 = "f60ba7a6b8bc8d817cfac75826421ac0ee4f3737af3ac60117351177964ae045",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.132.0. 

# Release info 

 9ec4a85 (HEAD, tag: v0.132.0, origin/master, origin/HEAD, master) Minor README improvement (#1543)
4d86879 Improve capitalization and formats of README.md. (#1545)
1aca099 feat: Upgrade to kubectl version supported by latest stable release and upgrade helm3 to 3.3.4 (#1498)
f5d0988 Retain the option `helm repo add --force-update` when Helm is v3.3.4 or above. (#1546) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/6935)