### PR TITLE
k3d 3.1.4

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "3.1.3"
+local version = "3.1.4"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "c54aced7b8065e93d92438affada0bc1c4426f8b4cb6f2c4733be961b8af18e2",
+            sha256 = "9e8345ed2261f2449fc8d3e96c0650d5e5dc0a1ab820842ad4851093e1379b47",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "bd4a79d646ab81c2fbc484a26addd6620da9c43d47f935606f95c7e288151e72",
+            sha256 = "bd984a8f416aa2f5ca2cb117cb637e706bc0e03f02644b9dc4411f310fe28de1",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "82dd382bbad27e14918645006a1f18722903a8ad3fe724f8fb83e2e13777f03c",
+            sha256 = "f4203c2b3cca9d37ffdcb10ab30ec45d86624e763ef5cedc0942aa1cbf9e84ee",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "f2d14d06b2fe9eae4e18da2c28675330ab0d9c2689930f5ddc87c496b5837c6e",
+            sha256 = "d0a53c9e4835fd24ab6fbd146094172415e51937d2d877ed11972436993d455b",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "e779b6fdacd5b8093c71a07cc189b9787db2ac79a8774d97088211ab3c6eae6b",
+            sha256 = "31d0ab095301514611474b515712ca84838cd68353348012e733c6e9808ea8a5",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "aca25c60be732356d290d57a216d6f8dc0cc22c893d12b653cc64bd630f450ae",
+            sha256 = "196c571eb5ae257eb4d832bd9723c4d124a8c7ec1d515e35b9062d85063631a3",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v3.1.4. 

# Release info 

 # v3.1.4

# Fixes & Enhancements

- fix: injection of `host.k3d.internal` not working with k3s v1.19+
  - missing `xargs` executable from PATH
- fix: injection of `host.k3d.internal` failing on MacOS and Windows
  - logreader was emptied before scanning it

# Misc

- Enhanced end-to-end tests: test full lifecycle for multiple k3s versions with E2E_EXTRA=1
- Update cobra cli dependency to v1.1.0 (GA of custom ZSH completions)

# k3s versions tested

This k3d version passed end-to-end tests for the following k3s image versions:

- rancher/k3s:v1.17.12-k3s1
- rancher/k3s:v1.18.9-k3s1
- rancher/k3s:v1.19.2-k3s