### PR TITLE
k3d 3.1.5

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "3.1.4"
+local version = "3.1.5"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "9e8345ed2261f2449fc8d3e96c0650d5e5dc0a1ab820842ad4851093e1379b47",
+            sha256 = "8d4a1fc30cb9638fa9e449b658f3d4e2d8e772bb0c0e0f9a32826244c0ea36b8",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "bd984a8f416aa2f5ca2cb117cb637e706bc0e03f02644b9dc4411f310fe28de1",
+            sha256 = "95c2014561599f3a94f44d05de1c25cf9e5ba6bb892faf43a02422e50e8e7e94",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "f4203c2b3cca9d37ffdcb10ab30ec45d86624e763ef5cedc0942aa1cbf9e84ee",
+            sha256 = "cd2948c8858448d1a87d2a558bf96490535e090c7a4b301ae733855a3f0e13ee",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "d0a53c9e4835fd24ab6fbd146094172415e51937d2d877ed11972436993d455b",
+            sha256 = "2e10fa254bb9a369e6caa3cad1c127a4f36463f5b41f5be756c811afcc624b08",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "31d0ab095301514611474b515712ca84838cd68353348012e733c6e9808ea8a5",
+            sha256 = "bd7016183970c3fd257068b6f028a2ed9b3b8e89ef78bb870434de30ecbdfa2d",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "196c571eb5ae257eb4d832bd9723c4d124a8c7ec1d515e35b9062d85063631a3",
+            sha256 = "054e9dbb5b931598525c21e2b6cb2cd89a9c8874814791a35ec0780b7ec06ce9",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v3.1.5. 

# Release info 

 # v3.1.5

## Features

- feat: bring back the `--label`/`-l` flag to add docker container labels to k3d node containers (@lionelnicolas, #378)

## Bugfixes

- fix: `k3d cluster delete` errored out (non-zero exit code), when no cluster with given name exists
  - now emits an info log and exits with `0`

## Misc

- CI/CD: build and push two more docker images (`latest` and `$GIT_TAG`, linux-amd64 only):
  - [`rancher/k3d:latest`](https://hub.docker.com/rancher/k3d): only contains the k3d binary (`FROM: scratch`)
  - [`rancher/k3d:latest-dind`](https://hub.docker.com/rancher/k3d): k3d binary and some tools (incl. kubectl) in a [`dind`](https://hub.docker.com/_/docker) container