### PR TITLE
buffalo 0.16.16

### DIFF
--- a/Food/buffalo.lua
+++ b/Food/buffalo.lua
@@ -1,5 +1,5 @@
 local name = "buffalo"
-local version = "0.16.15"
+local version = "0.16.16"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Darwin_x86_64.tar.gz",
-            sha256 = "ab7884d94016816a34655a2fd0634bc9a2c170002e60a5f6e6448fca03e38c80",
+            sha256 = "b9fab10f5ca9ff073375b61c4eed1f7a7e9cb1d0ef24233844c255316cfe9fff",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux_x86_64.tar.gz",
-            sha256 = "3d4f5120c8f31fa9aa7d01c488dd5d6fcc886d01ca32faf229329c5e21d70c7c",
+            sha256 = "a39635dc8a37f3f9b2d9d48d036a92e7fa657db9990a3a68325bc166aaa2644a",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows_x86_64.tar.gz",
-            sha256 = "d3bb26b9b8ba736ff6aee580752b5800af8643bacbed6e8e57a7f2a42b30824e",
+            sha256 = "4bc9d238ca831be36c5795646d293c2b07def990354196353fc2cc1d3f7688cb",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package buffalo to release v0.16.16. 

# Release info 

 - [Bugfix] Fixing an issue with non-cooking session store. #1913
- [Bugfix] Removing a false error on the build folder when `.git` folder is not found. #2048
- [Maintenance] Removes grifts folder from the Buffalo repo as its no longer needed