### PR TITLE
golangci-lint 1.32.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.31.0"
+local version = "1.32.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "f3afeb6ad6964615e2b238f56cc2e5b32464f2f302a4f3ccf5874a04170c287a",
+            sha256 = "294bca5902a5c992345dc773549cabcf25029383aa3bafd06cf65d0164b22faf",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "9a5d47b51442d68b718af4c7350f4406cdc087e2236a5b9ae52f37aebede6cb3",
+            sha256 = "774fc71efc2b41327aeca7bdff335c6387ff3750e0cfd5cc18a64709ba1e412a",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "6ce6b1d3207a63256d82fbbac80bb9e85d7705ec1a408f005dfe324457c54966",
+            sha256 = "97a69c2a153cd4285b7000b327aa6e77b694534e7463cbd1b77481c22b6113cf",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.32.0. 

# Release info 

 

## Changelog

25fcad6 Add dummy maintainer to keep `dpkg` happy (#1406)
c57627b Add exhaustivestruct linter (#1411)
796a958 Add go-errorlint (#1420)
5f93c93 Add support for fish completion (#1201)
926e76d Add tparallel linter (#1380)
247b6c2 Add wrapcheck linter (#1407)
d20b8f9 Added `.golangci.yaml` to list of configuration files searched on startup (#1364)
89e9482 Added func to sort linters (#1451)
9b3ba43 Added support for only specifying default severity (#1396)
3e6b01e Mention macports installation procedure on macOS (#1352)
3368a55 Releasing docker image for arm64 (#1383)
140d51b Trigger the Netlify (#1358)
7330026 Update assets (#1357)
a8b7b00 Update gochecknoglobals, use source analyzer (#1422)
ad26b68 build(dep): Ignore known dependency failure in nancy (#1378)
fe976ff build(deps): bump @mdx-js/mdx from 1.6.16 to 1.6.18 in /docs (#1401)
f63ad9e build(deps): bump gatsby from 2.24.52 to 2.24.65 in /docs (#1400)
763b998 build(deps): bump gatsby-plugin-canonical-urls in /docs (#1390)
70cd9ba build(deps): bump gatsby-plugin-catch-links in /docs (#1415)
52c8e1c build(deps): bump gatsby-plugin-google-analytics in /docs (#1388)
caecdef build(deps): bump gatsby-plugin-mdx from 1.2.35 to 1.2.40 in /docs (#1386)
ea84543 build(deps): bump gatsby-plugin-mdx from 1.2.40 to 1.2.43 in /docs (#1419)
cbaa2ae build(deps): bump gatsby-plugin-offline from 3.2.23 to 3.2.27 in /docs (#1368)
8569ea2 build(deps): bump gatsby-plugin-sharp from 2.6.31 to 2.6.40 in /docs (#1423)
7e39563 build(deps): bump gatsby-plugin-sitemap from 2.4.12 to 2.4.14 in /docs (#1417)
2763cc4 build(deps): bump gatsby-remark-autolink-headers in /docs (#1387)
88285dc build(deps): bump gatsby-remark-images from 3.3.28 to 3.3.29 in /docs (#1365)
9198323 build(deps): bump gatsby-remark-mermaid from 2.0.0 to 2.1.0 in /docs (#1369)
9ea696e build(deps): bump gatsby-source-filesystem in /docs (#1366)
3da7f4c build(deps): bump gatsby-source-filesystem in /docs (#1389)
0ca6265 build(deps): bump gatsby-transformer-sharp in /docs (#1402)
25228eb build(deps): bump gatsby-transformer-yaml from 2.4.10 to 2.4.11 in /docs (#1367)
501f00c build(deps): bump github.com/mattn/go-colorable from 0.1.7 to 0.1.8 (#1413)
ae3aca7 build(deps): bump github.com/sirupsen/logrus from 1.6.0 to 1.7.0 (#1412)
3cc77d1 build(deps): bump github.com/sourcegraph/go-diff from 0.6.0 to 0.6.1 (#1414)
065be62 build(deps): bump github.com/tetafro/godot from 0.4.8 to 0.4.9 (#1384)
a0599ca build(deps): bump github.com/valyala/quicktemplate from 1.6.2 to 1.6.3 (#1385)
b2c7c37 build(deps): bump golangci/golangci-lint-action from v2 to v2.2.1 (#1447)
2f16572 build(deps): bump honnef.co/go/tools (#1448)
254f0d4 build(deps): bump honnef.co/go/tools (#1459)
857f744 build(deps): bump node-fetch in /.github/contributors (#1363)
da9f499 build(deps): bump puppeteer from 3.3.0 to 5.3.1 in /docs (#1418)
d4ebf99 build(go): Check if go.mod and go.sum are up to dated (#1377)
e4346a8 build(release): Prepare for release 1.32.0 (#1457)
5efb842 chore(dep): Update unparam/gofumpt to latest commit hash (#1376)
9d557ed chore(dep): Use tag version for cobra (#1458)
f163073 ci(dep): Check only for go.mod file (#1397)
838f590 ci(dependabot): Change interval for npm to monthly (#1424)
c1d7cfd ci(nancy): Bump nancy version to 1.0.1 (#1410)
c88841d ci(scan): Add codeQL scanning (#1405)
f6d7a75 ci: prevent macos to be marked as passing upon failure (#1381)
073e590 feat(completion): Add support for powershell completion (#1408)
8263147 fix Nancy's branch name (#1394)
58234f0 update exhaustive to latest; use version in go.mod (#1449)


