### PR TITLE
kompose 1.22.0

### DIFF
--- a/Food/kompose.lua
+++ b/Food/kompose.lua
@@ -1,5 +1,5 @@
 local name = "kompose"
-local version = "1.21.0"
+local version = "1.22.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "9384e5233859d1bdc676c3ff80f2609e084a23fd5993e81a0a54e9976d18adf1",
+            sha256 = "ce35cec930f907ca49358ca4572ed92822908f91294e5ae203a5f78d9e90e25b",
             resources = {
                 {
                     path = name.."-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "88cac7b503cce5a4f83d3ac7690311307bc62a380e29b22a6557581c2b4c6d4d",
+            sha256 = "a695319ed141a522b4e8f82636fc7afb81c8956a71aa1c8aca19403130241126",
             resources = {
                 {
                     path = name.."-linux-amd64",


### PR DESCRIPTION
Updating package kompose to release v1.22.0. 

# Release info 

 Kompose 1.22.0!

Here's the new features in 1.22.0:
- Added support for pushing an image with `--build local` (https://github.com/kubernetes/kompose/pull/1257)

Breaking changes:
- `kompose up` and `kompose down` have been REMOVED in favour of `kompose convert` (https://github.com/kubernetes/kompose/pull/1297)

Bug fixes:
- Fixed printing docker buid output if -v is given (https://github.com/kubernetes/kompose/pull/1255)
- Fixed stop_grace_period in v3 of docker compose (https://github.com/kubernetes/kompose/pull/1300)
- Remove networkpolicy duplication (https://github.com/kubernetes/kompose/pull/1302)
- Added missing pod annotation (https://github.com/kubernetes/kompose/pull/1303)
- Updated networkpolicy version (https://github.com/kubernetes/kompose/pull/1307)
- Updated conversion for command and entrypoint (https://github.com/kubernetes/kompose/pull/1279)
- Fixed missing annotations for ingress (https://github.com/kubernetes/kompose/pull/1248)


Developmental changes:
- We have now moved to `go mod` (https://github.com/kubernetes/kompose/pull/1305)

# Installation

__Linux and macOS:__

```sh
# Linux
curl -L https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-amd64 -o kompose

# macOS
curl -L https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-darwin-amd64 -o kompose

chmod +x kompose
sudo mv ./kompose /usr/local/bin/kompose
```

__Windows:__

Download from [GitHub](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64.exe) and add the binary to your PATH.

__Checksums:__

| Filename        | SHA256 Hash |
| ------------- |:-------------:|
[kompose-1.21.0-1.x86_64.rpm](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-1.21.0-1.x86_64.rpm) | 2697238545d1a5801172c40f3e5a863a50f979fdb805c47deae66a2ed190d9d4
[kompose-1.21.0-1.x86_64.rpm.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-1.21.0-1.x86_64.rpm.tar.gz) | 19798ad8d5090541fcf5112cd59c68b7f35b510d909c6c0b0b91feb32203a5ca
[kompose-1.21.0-1.x86_64.rpm.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-1.21.0-1.x86_64.rpm.tar.gz.tar.gz) | 4de580808241bf3e9fbe53e815e3ab4a30ac5207eac6b48af77189a02f8983e7
[kompose_1.21.0_amd64.deb](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose_1.21.0_amd64.deb) | 5210fbae874c1695aea0b80eea0d89621e3f84389e9680ccb6605dadca7a5abf
[kompose_1.21.0_amd64.deb.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose_1.21.0_amd64.deb.tar.gz) | 15d021917bba699854182807509175371ef63be57fe31d7918aed34cc05cceb1
[kompose_1.21.0_amd64.deb.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose_1.21.0_amd64.deb.tar.gz.tar.gz) | 19ce17f154cddec8a8dbaee26f7e2bfe14162e076fd771d2f439bca0a98bbfa0
[kompose-1.22.0-1.x86_64.rpm](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-1.22.0-1.x86_64.rpm) | d8c3cdc41179114859ebbd5d9b93784eb3ce1b8923886ef9635287423dc5de77
[kompose-1.22.0-1.x86_64.rpm.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-1.22.0-1.x86_64.rpm.tar.gz) | df2cbfcdbd6248810d01a55e690490e9362cf2ce4305c5a7a9b18e09f408c548
[kompose_1.22.0_amd64.deb](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose_1.22.0_amd64.deb) | e10775f8e34d54da0c424a644af26087ee3bc4a47f76fb9eee2ddffa328644d1
[kompose_1.22.0_amd64.deb.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose_1.22.0_amd64.deb.tar.gz) | 15ffe723424756f8260c34bdcbb7970865a5189e558a4be5a03e46517f7d6c42
[kompose-darwin-amd64](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-darwin-amd64) | 7a51863acb1dd957e5015457260194d35feecf09d84ff2ec6ac07927e0c397d1
[kompose-darwin-amd64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-darwin-amd64.tar.gz) | ce35cec930f907ca49358ca4572ed92822908f91294e5ae203a5f78d9e90e25b
[kompose-darwin-amd64.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-darwin-amd64.tar.gz.tar.gz) | c47f556e36b4ea43e4abf49315aa01423180ec1b81758c9bd291f9e69850b465
[kompose-linux-amd64](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-amd64) | 6203d67263886bbd455168f59309496d486fc3a6df330b7ba37823b283bd9ea5
[kompose-linux-amd64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-amd64.tar.gz) | a695319ed141a522b4e8f82636fc7afb81c8956a71aa1c8aca19403130241126
[kompose-linux-amd64.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-amd64.tar.gz.tar.gz) | 53ed3899c17605a365cb091f5a1ce048802243e7bd614a41441f2a030574be5f
[kompose-linux-arm](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-arm) | af9a549e07a546d37ee855b172136417388764afd44b901789d9b8e70d2de086
[kompose-linux-arm64](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-arm64) | 022a04becbf05ad3edac7ac9175d414007b409f2b4fd5190af2a90649ec64b94
[kompose-linux-arm64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-arm64.tar.gz) | 9b07389ad2392ecefda3f284bf8ab3cb0b27afcb465841c240d3aab75594e17c
[kompose-linux-arm.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-arm.tar.gz) | c23fb85061b7cd4008420489ffb026036304661b77fec7362ab120673aa55d08
[kompose-linux-arm.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-linux-arm.tar.gz.tar.gz) | 074145667b2df6b677cb0555acdc5878149b00ad8b762e7a23df7ff9dc1489d0
[kompose-windows-amd64](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64) | 4f8eaa7e1c586ec33aebbb4090a3c5448b1208760e4431cc16159ded9677085b
[kompose-windows-amd64.exe](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64.exe) | 0a01f3eb0cb810b61a4d7aaa5b59824e829f2e9042f061ff27f3c419822f08d3
[kompose-windows-amd64.exe.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64.exe.tar.gz) | 9b18cc215be35858ab30c6930e19a79320d191e8106632cad55562fe7ab2c3e8
[kompose-windows-amd64.exe.tar.gz.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64.exe.tar.gz.tar.gz) | 7496ba0c4c12708526fc1bd9ce59fbc643b913861fc9538198c0f6eec0820e23
[kompose-windows-amd64.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/kompose-windows-amd64.tar.gz) | 849eff26402d7d684205e3687e360596d014c4e9c067ee899f8588d38d1b4564
[SHA256_SUM](https://github.com/kubernetes/kompose/releases/download/v1.22.0/SHA256_SUM) | cb6116a9e25925a75d54543f05681f92c241eaeabc37a5f6321ab713dc1dfff7
[SHA256_SUM.tar.gz](https://github.com/kubernetes/kompose/releases/download/v1.22.0/SHA256_SUM.tar.gz) | 0087d0e9c41f2a42ddf124df80c052fc419da672b0dde5fb1872e512a1cb61fe