### PR TITLE
istioctl 1.7.4

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,5 +1,5 @@
 local name = "istioctl"
-local version = "1.7.3"
+local version = "1.7.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "e9693fef4bce8de4c7b8d1e413aa5b97cf10bc413d17c1c9149979b1fb128128",
+            sha256 = "b87663e6bd9168837b317f71bc0bb42a70bdfd30af983be1770211aeadfcbb35",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "027ca706cadd96b3013b31bae1365ef94ed41feef0018e871f64a8c4e6275402",
+            sha256 = "6ed5eb68e71a0884cad39c94616e4ce0a93b90369b20d3659cfaf71da015f902",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "28f2876f28b11ad98c74691a7e1292b1d485cff51bf39aa9f413c3b86864ae41",
+            sha256 = "1652ce4cb8846f2bc98ef4f2e89a3306c84785126731d5a123f6a88877fa4573",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.7.4. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.7.4/)
[Release Notes](https://istio.io/news/announcing-1.7.4/)