### PR TITLE
helm 3.4.0

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.3.4"
+local version = "3.4.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "9fffc847c61da0e06319788d3998ea173eb86c1cc5600ac3ada8d0d40c911793",
+            sha256 = "e1588ee03cfa3f2140199acafc29aff95960a4f593b8f4ca8fc0a6be169827bf",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c",
+            sha256 = "270acb0f085b72ec28aee894c7443739271758010323d72ced0e92cd2c96ffdb",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "510677f99d7ee44d736e2289562538acc97eb80ab1386ad49f87bd63aac828bb",
+            sha256 = "16ff9c2d8348a289da2997cb939f5426ff8931d02a02b133cbd6546047ca142f",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.4.0. 

# Release info 

 Helm v3.4.0 is a feature release. This release, we focused on the Helm stable and incubator repository changes. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)

## Notable Changes

- On November 13, 2020 the Helm stable and incubator chart repositories will reach the end of their life. An archive of those charts will be housed in a new location. Helm will now detect the previous location and direct you to update to the new location if you are using the stable or incubator repository.
- `helm list` can not accept a flag to set the time format
- The `index.yaml` file in a chart repository can now have a top level annotations key/value pair for services to put information in to.
- A flag to show descriptions was added to the `helm status` command
- `helm lint` will now report name length errors
- `helm lint` now checks dependencies

## Installation and Upgrading

Download Helm v3.4.0. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.4.0-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-darwin-amd64.tar.gz.sha256sum) / e1588ee03cfa3f2140199acafc29aff95960a4f593b8f4ca8fc0a6be169827bf)
- [Linux amd64](https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz.sha256sum) / 270acb0f085b72ec28aee894c7443739271758010323d72ced0e92cd2c96ffdb)
- [Linux arm](https://get.helm.sh/helm-v3.4.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-arm.tar.gz.sha256sum) / ed79f27756426832774c27608aede6f25a636795fa0b4913a827a99b0892f867)
- [Linux arm64](https://get.helm.sh/helm-v3.4.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-arm64.tar.gz.sha256sum) / 83cd7a30f4c5ce83eb2afb4974777bf99bb74a5f587c85774d747e3d32e3cb48)
- [Linux i386](https://get.helm.sh/helm-v3.4.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-386.tar.gz.sha256sum) / 1fe95d89397d9a2d92bc303a222ab71e342a4971193321fb1b39ba06cf8305b3)
- [Linux ppc64le](https://get.helm.sh/helm-v3.4.0-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-ppc64le.tar.gz.sha256sum) / 85e34eca3db0357fed69affe3f37fa5d6e3a4ba21f05ab291ee1cf3a773a381f)
- [Linux s390x](https://get.helm.sh/helm-v3.4.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.0-linux-s390x.tar.gz.sha256sum) / e1588ee03cfa3f2140199acafc29aff95960a4f593b8f4ca8fc0a6be169827bf)
- [Windows amd64](https://get.helm.sh/helm-v3.4.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.4.0-windows-amd64.zip.sha256sum) / bd56473202394e20b80dafc85b4ce40c13c3159464cd2d164fc224b86fc9cf78)

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.4.1 will contain only bug fixes. It will be released on November 11, 2020.
- 3.5.0 is the next feature release. It will be released on January 13, 2021.

## Changelog

- bump version to v3.4.0 7090a89efc8a18f3d8178bf47d2462450349a004 (Matt Farina)
- this rewrites a whole bunch of old repo URLs to the new repo URL (#8902) fe2d7f779296941c167ceda972a950739e93f60c (Matt Butcher)
- warn and block old repo URLs (#8903) af01394e9fdc44a30b3deda2dc310ad0b0ae6a1f (Matt Butcher)
- improved user-facing error messages to explain the underlying problem (#8731) 5f3e56002908bfff7924503cf71db9a2bbc3954e (Matt Butcher)
- Linking to a more complete list of meeting details. 0f55fb53164ebeff656a6038c12c74dad7cacbc0 (Bridget Kromhout)
- add authentication to CircleCI jobs 360212393bf1c9cc8feebbcf6711fe4e3777cb4b (Matthew Fisher)
- helm create: make generated YAML indentation more consistent 1d9767fea29189ea2ebb2b08fea743a8190d0f0b (Erik Sundell)
- Makefile: check and use GOBIN environment variable first e97975d7ad329779384d627d91e00b5d28041d0b (Li Zhijian)
- TestCheckPerms: utilize pipe to read stderr 59c77716ad61331da28c37e9430d5f6a3ab23fed (Li Zhijian)
- Bump github.com/DATA-DOG/go-sqlmock from 1.4.1 to 1.5.0 b08c7d2429ed445b9571c6c275c26b7bac7236e3 (dependabot[bot])
- Bump github.com/sirupsen/logrus from 1.6.0 to 1.7.0 2bc79d32940a10d5221edfeb408f48f590ccc808 (dependabot[bot])
- feat(install): add requested version to error 6aa54eacc52db045e82faa6b256678863e325a20 (Mikuláš Dítě)
- Bump github.com/gofrs/flock from 0.7.1 to 0.8.0 253a9500d7e4b1ae3a9c7943e39cfc19c55a1e25 (dependabot[bot])
- Bump github.com/lib/pq from 1.7.0 to 1.8.0 a6e76cbbbeee153ad93cb7a269714080b4c37e1d (dependabot[bot])
- Fix wrong function's name in comment a167b3fc8719db19e87280bc134a24801808272e (zouyu)
- ref(cmd): prevent klogs flags from polluting the help text 66034e403548417ac90d9769f5dcde2d354e0033 (Adam Reese)
- Adding support for k8s 1.19 b7c38c879a91cabec02699be1c4070206f84c88e (Matt Farina)
- remove redudant time func 3ca46f3b2370f5f2f571af0f0eba6575a91e8729 (Abhilash Gnan)
- fix example time format b17cf19a2eab5664375c8578531940cafe4aa035 (Abhilash Gnan)
- rename to time format flag c5e9732a9fdda5c1bb74a1d29827cf60158d218c (Abhilash Gnan)
- refactor time formatting 190e0b4a818df967215ad26a9cebdf114795614a (Abhilash Gnan)
- fix ls command example 78177de664942452485aee890ddf07fa1cf4e420 (Abhilash Gnan)
- add time-format flag to list command f61332f379fb8734e8124435de416a6fcf3338a2 (Abhilash Gnan)
- Adding annotation to index.yaml file 4c121c30851c5f607e6383c342d3a4be69dc4004 (Matt Farina)
- Fixing import package issue 036832eba9dd604683d0803af96479bbfbe3b58f (Matt Farina)
- Update go version to 1.14 in go.mod 3baaace868910d9b74f0d960e9441a2f3181fd00 (lemonli)
- use warning function 92c4bda184cda8323ad961d889a8186b2baa98bd (Matthew Fisher)
- Adding size labels pointer 8b546e90a96aaa541ccf818f515e418a18d77fbc (Matt Farina)
- Fixing issue with idempotent repo add baf5b76a957dc52a2fca84fa1328628cc78cc307 (Matt Farina)
- support passing signing passphrase from file or stdin (#8394) 467bd49bb0cb0d613e802c738a0e38225eec054a (Sebastian Sdorra)
- size/S and larger requiring 2 LGTMs 1138def202c95c2e76d0bd9d27bc36aa35224326 (Matthew Fisher)
- Update docs links in release notes script 3eeeb0345d1ef7e8990efc761a7d10ddf6e67f52 (Scott Rigby)
- fix: allow serverInfo field on index files f19acbdc94578194d19a6758f01cd8eed85b792e (Matthew Fisher)
- fix(cmd/helm): add build tags for architecture 45d230fcc95c1c4d2e055b7451a988441f038509 (Adam Reese)
- switched to stricter YAML parsing on plugin metadata files 6eeec4a00241b7da1acaddcbf3278355de1f216e (Matthew Fisher)
- Merge pull request from GHSA-m54r-vrmv-hw33 809e2d999e2c33e20e77f6bff30652d79c287542 (Matt Butcher)
- Merge pull request from GHSA-jm56-5h66-w453 055dd41cbe53ce131ab0357524a7f6729e6e40dc (Matt Butcher)
- Merge pull request from GHSA-9vp5-m38w-j776 59d5b94d35b24a500e30839a7c69f05d9ff077e2 (Matt Butcher)
- go fmt 2a74204508f005d89fe51b0e2824dae4f30b3252 (Matthew Fisher)
- improve the HTTP detection for tar archives e2da16f5146e2709211f116cb81dd8f9c9a62fd5 (Matt Butcher)
- replace --no-update with --force-update and invert default. BREAKING. 882eeac7271858124a3cecbe22c5d7d61560714f (Matt Butcher)
- handle case where dependency name collisions break dependency resolution 40b78002873d525a31c5dec75c8607be67327360 (Matt Butcher)
- fixed bug that caused helm create to not overwrite modified files 106f1fb45c93fe862ac86d9b774e2de8b1dd314c (Matt Butcher)
- refactor the release name validation to be consistent across Helm ed5fba5142fa5a2366df143616e9161ff866a53d (Matt Butcher)
- fix: if not .Values.autoscaling.enabled indent b4bb73d8ceeb4abf70c1a2e57d4779b5bfd6a82e (Thulio Ferraz Assis)
- validate the name passed in during helm create c4ef82be13a0a3b6b42ce92bdd0357f4f6ac9e62 (Matt Butcher)
- fix: check mode bits on kubeconfig file 82398667dfe208407be9fe499ac96240aa8ce54b (Matt Butcher)
- fix incorrect wildcard expand d1c8561be6e6b08bbf425dc79631149100a1e0db (Li Zhijian)
- fix(comp): Disable file comp for output formats 459dcd7f728b38ec44c72d79192ee93d6964d53d (Marc Khouzam)
- Makefile: Fix LDFLAGS overriding f917c169d001a96fbdfd7943c441fb09509b9f7f (Morten Linderud)
- Add support to install helm 8b2cf17648889270ac5c5985f5bb9ef5e43d12d6 (Ma Xinjian)
- Fixing typo in engine comments 319240841575d97bbac0cc274c18fdb162b72919 (Paul Brousseau)
- Use T.cleanup() to cleanup cmdtest_temp file 4258e8664e6b8dfd1b9c3b8ca2115930b296c41c (Li Zhijian)
- Use RemoveAll to remove a non-empty directory d9ad9153c8ddd910bdd3bb0d0cb6b0f693189c54 (Li Zhijian)
- mark NewTempServer as Deprecated cccc2867ea8242de55e32910b1d6c2f252ed1af5 (Li Zhijian)
- Use T.Cleanup() to cleanup temp dir helm-repotest 35c5268d9dd98238319578c469072e80e4aeb1e7 (Li Zhijian)
- Support impersonation via flags similar to kubectl --as="user" 9429af8b39c6888a41ffa2945d7c73676afb577e (leigh capili)
- Document all env vars for CLI help 6f780bb7502cab2b1eddcdb3a127a15a5b2579f9 (leigh capili)
- Use T.cleanup() to cleanup helm-action-test ba4c8029c2faa452496dd743fa41b55e20c9614c (Li Zhijian)
- Add GPG signature verification to install script (#7944) 6898ad14576463ea1df857bb17f2f0ee47653756 (Josh Dolitsky)
- fix: with .Values.podAnnotations indent template 6766017d388cbc21636f6b1deb9ab931a4617259 (Thulio Ferraz Assis)
- Revert PR 8562 daa104d60e258fff57da12f13c49ecdcba1263c6 (Martin Hickey)
- feat(comp): Add support for fish completion 36d931105212758fb7054068e392a75d40d3a6b9 (Marc Khouzam)
- feat: status command display description da6878dc0f5c99d1062c2c220b0ab5a8d548a773 (Ling Samuel)
- Remove duplicate variable definition 317616482cbdca1b47605d707803f31b4ee2a26f (Liu Ming)
- Fixed a variable name collision caused by two PR merges (#8681) 04fb35814f64122c0aa08165f6fdb7b67c216558 (Matt Butcher)
- Fix/8467 linter failing (#8496) 70d03e5cefa8f42727e29db310f78aeae4d65bb0 (Matt Butcher)
- fix name length check on lint (#8543) 96d9ab9663b69cbd85444ca5232d8283017eeeea (Matt Butcher)
- Fix spelling in completion.go 45b084b25504a1e19592684f964f43b57792875a (knrt10)
- cleanup tempfiles for load_test 0669f40e814707ce43c560f33f363d19f40e6800 (Zhou Hao)
- add checkFileCompletion for env HELM_BIN 195d7a650712d8eee2db887bf8e1a4e2c363328b (Yuchen Cheng)
- feat(env): add support of accepting a specific variable for helm env 10d4d2ed999a403e2464f673e0e19b95ee4e1ac6 (rudeigerc)
- Fixing failing CI for windows 3fc88f24929b3cac6e5284bbb5701ff94b3f11e0 (Matt Farina)
- pkg/*: Small linting fixes 4abcdc40efb9ad455ed99bc73c8ee716fe89123d (Manuel Rüger)
- Correct checksum file links 8a545d6ca7e40ae412c53f5dc683ecc8a8ecdb96 (Ma Xinjian)
- Fixing linting of templates on Windows 11f658e2234f5d3c02212e30ba38cd579d134aaa (Matt Farina)
- use URL escape codes d13c43d3e8d54c09d82d2aff68b06255538649c8 (Matthew Fisher)
- add v4 to list of exempt labels 9664bb2a0a528e1b9262501dfaee587e0e459c39 (Matthew Fisher)
- optimise if condition in service ready logic b07b2589fb157f017079c0f7285f98bc56a33ae2 (Tariq Ibrahim)
- feat(comp): Disable file completion when not valid d6708667da5c79ab4a093ea7473e96b93be5f1f7 (Marc Khouzam)
- Bump Kubernetes to v0.18.8 + Bump jsonpatch 065b7f6e257f7ee47ca0194f8c3b804e14173514 (Maartje Eyskens)
- release/mock: Ensure conversion from int to string yields a string 83a5e620d0acde77502b1f814f749268e8d8ef6e (Morten Linderud)
- Update Common Lables template in starter chart 4b1fa60d5883d53b4e4f09d3420b108e66bbd737 (Thomas O'Donnell)
- chore(deps): add dependabot.yml 4bd68b75cf0fdf2355285ad0e386fbce806fce5f (Jinesi Yelizati)
- Fix Quick Start Guide Link in README.md 5421c7e99526af9683491fe5e069ed001fb5fd58 (Tero)
- add helm v4 todo comments for FindChartInAuthAndTLSRepoURL. 0674d93609bfb82fe49eaf72b0ae84f348f4ee57 (yxxhero)
- polish the error handler df4708a9de8a6f4c89dca7555a5b338c8298128d (Dong Gang)
- Move selector filtering after latest release version filtering 266c74f390c6dcd08ffbbe942df99d5557632806 (Dmitry Chepurovskiy)
- Added testing for list action with selector 2ea8f805b9348201f95d6eacd893cccfdaeb8624 (Dmitry Chepurovskiy)
- Added notice about supported backends 6d60d26913ef81180eb6cfc13cdc2106e3ae24ef (Dmitry Chepurovskiy)
- Fix linting issues 09172b468a7c8278c566880c26efd1078e43e5c8 (Dmitry Chepurovskiy)
- Added selector filtering 357a0785bcd09e068c240595f12f14ab29fae066 (Dmitry Chepurovskiy)
- Pass labels from secret/configmap to release object 99bd709530bbcbee4fc21822164ad44aa1770b24 (Dmitry Chepurovskiy)
- Added selector option to list command edc7d8ea320c4f32fa86a4278c175b96a8da9f2a (Dmitry Chepurovskiy)
- fix test that modifies the wrong cache data 131510aa94faaa66ea4b3c3b7e4156206902ffc5 (Matt Butcher)
- bufix: fix validateNumColons docs fbc32aea3d43853f94768e4bc7bc4045fe9fb749 (bellkeyang)
- Fix typo 4cc19d1d82c4f4ee4bb9af5739e1184f5800f588 (Martin Hickey)
- darwin-386 and windows-386 are not supported now 8bb0413552ca5b2de39d9cb2ec06089c6569908c (Ma Xinjian)
- Fix issue with install and upgrade running all hooks 44212f83dc9c893d962fe48648320e7b7b66950c (Matt Farina)
- introduce stale issue bot b13247c333339bcd8bf963e62df2e03f37383984 (Matthew Fisher)
- Close gzip reader when done. b6bbf34097312fefec8120fe066780340f2d983f (Haoming Zhang)
- fix watch error due to elb/proxy timeout 4faeedd98b03e5af7733317a84e77ebff28c55f7 (Rajat Jindal)
- Avoid hardcoded container port in default notes d141593d834f99822c08b9f3ca768258483afbf1 (She Jiayu)
- add unit tests for FindChartInAuthAndTLSRepoURL. 0ecc500c451f423bbcfb393a61953170c479fc51 (yxxhero)
- Restoring Build behavior 25f67f74eeee861e132d1a0220144c87631dbe38 (Matt Farina)
- Adding helm v4 todo 1458113696297a7d0426f275c9d0689d4d0ff47e (Matt Farina)
- Make unmanaged repositories version resolvable 9cb90a8b234f98c16aef0918cba92d83061d7c97 (Matt Farina)
- Locking file URIs to a version in lockfile ff147e9ed7463f6349ee416da723949ae2d33330 (Matt Farina)
- Enhance readability by extracting bitwise operation f9d35242d0cc3774e4c4d937e6c00c49aa8c6c7f (Andrew Melis)
- fix(sdk): Polish the downloader/manager package error return (#8491) ffc3d42f87f8334684f12372bbdda8147702a12d (Holder)
- fix insecure-skip-tls-verify flag does't work on helm install, Keep FindChartInRepoURL and FindChartInAuthRepoURL functions signatures intact. 52295490fd7a22c05058ad6eab794ccd4fdf3193 (yxxhero)
- fix: Allow building in a path containing spaces 9a13385022b0976a704c24c8d11e7b0f3561b931 (Chris Wells)
- Alter whitespace in "Update Complete" output 844e575d2a7090903c26e658037e3298ecff9479 (Simon Shine)
- fix(create): update the hook name of test-connection pod 9777925a2ae1e98a3e7ec3923d0b56b7199c7806 (Dong Gang)
- polish the help text of flag 3ee7047827b0fc5b87fb2d8bde6bb64fa93fcf73 (Dong Gang)
- Reinstating comment that is still accurate c709e10b3204b823f7e00bae8ca59b6db65e9865 (Bridget Kromhout)
- Rollback command support for max history 4be3804c50e4a4260e8e49680e2826c66e32d898 (wawa0210)
- fix(helm): Update test during pending install 0d70c63396083f868963797632715f06c9b90ca9 (Cristian Klein)
- Correct make target in Makefile 08517a9ec0abbf238d56ec97de80e6ecc8946ab6 (Bridget Kromhout)
- fix(helm): Added test for concurrent upgrades 20fb7bac4e9001751a0b04c71006b4bb506378cf (Cristian Klein)
- fix(helm): Avoid corrupting storage via a lock 9a4f4ec64b8092d2ba3d7493001837df4737e36c (Cristian Klein)
- Fixing version and spelling errors 5684c864908819ad43dfa6efb6f474611d721e7c (Bridget Kromhout)
- Clarify comments to match practice fe40c4bf844feee87c3b3c1163b7f5f40dc9a793 (Bridget Kromhout)
- fix the code style error 1dfe66aa85bf09cd1f09271c2810c5deb9f22454 (Dong Gang)
- feature(show): support jsonpath output for `helm show value` 57bd8a71b0002b00a13b6a4bfa17e45839b73795 (Dong Gang)
- fix(kube): use logger instead of fmt.Printf 8217aba4a6cf04bac538ba2178603ec1378dbaef (Hidde Beydals)
- fix windows build failure caused by #8431 7ba8343b8d0edc1a3de96ee15003b072c7e72627 (Jack Weldon)
- address PR comment, adding whitespace for formatting ac1a25517b5ee5c13556a2d4eff313a2909ee497 (Jack Weldon)
- feat(helm): prompt for password with helm repo add 971c9215d19ea5ab63f6e3eca971e186442564d6 (Jack Weldon)
- Lint dependencies (#7970) 2750e4d78181b614776d82031f6ddfece8d020e2 (Matt Butcher)
- Environment variable for setting the max history for an environment 637a5c649469935e9d0e69873190dc014ce4d9cf (wawa0210)
- chore(OWNERS): move michelleN to emeritus ebe6abd660eda59b497d683d418e658b323ca4ea (Michelle Noorali)
- bump version to v3.3 fc4a11c131822df4dcb4c8a1e5a1448cc109c39d (Matthew Fisher)
- fix conflict d58a984878ea290e04a135ef037b75e13b7b8df5 (zwwhdls)
- add test case 1b39857ac32165db1ad64f66a03d74f1fa09a3f7 (zwwhdls)
- fix another extreme case 4532485fd03a8cb56186c93ffeba285431073429 (zwwhdls)
- add test case c41c72cee980b8763a3701450b4b5da8ebf343a2 (zwwhdls)
- fix #6116 5396df2e282c61ffb1fc8fa65240c36a0216055f (zwwhdls)
- Make helm ls return only current releases if providing state filter 70f89e5f26015a92432bdeb94ddb6d6e52532b19 (Andrew Melis)
- Report what cause finding chart to fail 8f3c0a160cb9e5aa15a2c7a2f618704eea5de743 (Calle Pettersson)
- Simplify chart installable check 36c9c0e5202789f0f2c87fabf816900259de0fb8 (Simon Alling)
