### PR TITLE
kubeseal 0.13.1

### DIFF
--- a/Food/kubeseal.lua
+++ b/Food/kubeseal.lua
@@ -1,7 +1,7 @@
 local name = "kubeseal"
 local org = "bitnami-labs"
-local release = "v0.12.6"
-local version = "0.12.6"
+local release = "v0.13.1"
+local version = "0.13.1"
 food = {
     name = name,
     description = "A Kubernetes controller and tool for one-way encrypted Secrets",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "2cf77775b0c16f68a498ea537673489a185d441bd1fbf86e86e722433b6612d1",
+            sha256 = "3f878e1eace7eec51f763afea759e4b1577c2f9210637be434769afa66eb92a1",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "9572b161c6e98faf28a71f8137b3d78c401b531fdc7a0658a519b77caae7ed69",
+            sha256 = "e6f2f5a8c22124a055c1b6bdbee7936c5b92bc44105a92441d86595b22d71604",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. ".exe",
-            sha256 = "73c7206bde5bda40a3cf7056f5843deb83fecdd8e8a0f8c5475d5d5eb5c01ad9",
+            sha256 = "24c8111c94e0f8fe5cb7b9174631899d1c725bcb7a057e6dd99925b340b36864",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package kubeseal to release v0.13.1. 

# Release info 

 ## Release Notes

Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v0131) which contain among other things important information for who is upgrading from previous releases.

## Install

### Client side

Install client-side tool into `/usr/local/bin/`:

* **Linux x86_64:**

```bash
wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/kubeseal-linux-amd64 -O kubeseal
sudo install -m 755 kubeseal /usr/local/bin/kubeseal
```



* **Macos:** (might lag a few hours behind a new release, this icon will reflect that latest release)

[![](https://img.shields.io/homebrew/v/kubeseal)](https://formulae.brew.sh/formula/kubeseal)

```bash
brew install kubeseal
```

* **Other OS/arch:** you might find binaries for your OS/arch combo attached to this release below.

### Cluster side

Install SealedSecret CRD, server-side controller into kube-system namespace.

```sh
$ kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/controller.yaml
```

NOTE: If you can't (or don't want) to use the `kube-system` namespace, please consider [this approach](https://github.com/bitnami-labs/sealed-secrets#kustomize) 

NOTE: if you want to install it on a GKE cluster for which your user account doesn't have admin rights, please read [this](https://github.com/bitnami-labs/sealed-secrets/blob/master/docs/GKE.md)

NOTE: since the helm chart is currently maintained elsewhere (see https://github.com/helm/charts/tree/master/stable/sealed-secrets) the update of the helm chart might not happen in sync with releases here.
