### PR TITLE
gh 1.2.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "1.1.0"
+local version = "1.2.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "4d625455a07a4a6adf0e92183338979084829f28bda0f9593405a53da9d0e251",
+            sha256 = "e79a431fdf102b01c66dbdfa04db76deab4d177d71900496f84e37be1f0362f2",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "2e1ca73bd7ecbd6e7e71368e901ebb7b1d83c3ca375752c7ab23cc664190d452",
+            sha256 = "3e4e3c49497b18f5da46989b188091a25171a8090bfcf42bc75befa115f49322",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "94cbfff8cf50ca24ae9d2f60dbda3e1f3aa1a68be896d657ce4885f2a045bad4",
+            sha256 = "9dbf3e689670edb827806f36780cd81f82525cb69f0d4c729d164f6629fe047d",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v1.2.0. 

# Release info 

 ## Features

* `api`: add flag `--hostname` to set host target for api requests  #2058

* `pr merge`: add confirmation step in interactive mode  #1622

* `auth login`: add flag `--scopes` to set authorization scopes  #2201

* `auth status`: add flag `--show-token` to display auth token  #2157

* `config set`: add validation of configuration values  #2138

* `config set`: add warning for unknown configuration keys  #2183

* Codespaces: add support for "integration" tokens  #2207

* Add `GH_NO_UPDATE_NOTIFIER` environment variable to allow skipping of update checks  #2134

* Skip update checks in CI environments  #2134

## Bugs

* `issue list`: fix result inconsistencies when specifying limit  #2190

* `issue list`: fix filtering by milestone for large milestone numbers  #2178

* `repo clone`: use canonical capitalization for remote URLs  #2177

* `pr create`: fix continue in browser for branches with special characters  #2249

* `repo garden`: fix incorrect terminal state after <kbd>Ctrl-C</kbd>  #2205

* Improve shell autocompletions for bash, zsh, and PowerShell  #2237

## Build

* Rename the internal `command` package, resulting in a rename of `Version` and `Date` variables passed via ldflags at build time  #2247

  To set version and date when building from source, use the `GH_VERSION` and `BUILD_DATE` environment variables in conjunction with our Makefile. 
