### PR TITLE
golangci-lint 1.32.1

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.32.0"
+local version = "1.32.1"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "294bca5902a5c992345dc773549cabcf25029383aa3bafd06cf65d0164b22faf",
+            sha256 = "b8159a2274e48bfbee80b862678cf9303ff5cbacdac77f5826ff82f61708db88",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "774fc71efc2b41327aeca7bdff335c6387ff3750e0cfd5cc18a64709ba1e412a",
+            sha256 = "913ada29a2d38313a10145baa7b86484d3634102c74732cb0fb97e10a195bb93",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "97a69c2a153cd4285b7000b327aa6e77b694534e7463cbd1b77481c22b6113cf",
+            sha256 = "0f58bdc5b52783d23d2e1d5c776cba5e9216ad096f7e801480b10df5423c9a63",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.32.1. 

# Release info 

 

## Changelog

55e35d2 Update exhaustivestruct (#1472)
f414375 build(deps): bump golangci/golangci-lint-action from v2.2.1 to v2.3.0 (#1469)
dc2d6b5 build(docker): Fix version details in docker image (#1471)
8071657 feat(release): Update metadata for golangci-lint-action (#1467)


