### PR TITLE
golangci-lint 1.32.2

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.32.1"
+local version = "1.32.2"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "b8159a2274e48bfbee80b862678cf9303ff5cbacdac77f5826ff82f61708db88",
+            sha256 = "a86bd2fc10bfcd183c7368aa2cfd047a341be11e0bef242a6ed181d4f7dc0fb0",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "913ada29a2d38313a10145baa7b86484d3634102c74732cb0fb97e10a195bb93",
+            sha256 = "e7ab86d833bf9faed39801ab3b5cd294f026d26f9a7da63a42390943ead486cc",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "0f58bdc5b52783d23d2e1d5c776cba5e9216ad096f7e801480b10df5423c9a63",
+            sha256 = "73280119955d69f83285581568bd82ec7a702fef1c19990d27c29ca6b675c775",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.32.2. 

# Release info 

 

## Changelog

c1fe84c build(deps): bump gatsby-alias-imports from 1.0.4 to 1.0.6 in /docs (#1479)
00e3e73 build(deps): bump gatsby-remark-embedder from 3.0.0 to 4.0.0 in /docs (#1478)
97cb05c build(deps): bump github.com/fatih/color from 1.9.0 to 1.10.0 (#1485)
0b24526 build(deps): bump github.com/securego/gosec/v2 from 2.4.0 to 2.5.0 (#1484)
7a1ae96 build(deps): bump polished from 3.6.6 to 4.0.3 in /docs (#1482)
3277bdb build(deps): bump puppeteer from 5.3.1 to 5.4.1 in /docs (#1480)
6338971 feat(release): Update metadata for golangci-lint-action (#1475)
52d26a3 fix(docker): Fix docker tag for alpine build (#1487)
9ff0f31 pkg/lint/lintersdb: report all unknown linters at once (#1477)


