### PR TITLE
helmfile 0.133.0

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.132.1"
+local version = "0.133.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "b181ee1091747bdffe6b7bc6b2961c8289310cf1a59330ff34646d58ef945b0f",
+            sha256 = "ec3ab77d6f9876aa00e79f8efd2973f5302b8442d90ea5060aca2c5dbfa4a0f1",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "bb2f177f3a6bb5671d2d114d772d5e5e8f0cafd2d426b265d4df17645c8fb6ff",
+            sha256 = "84a52a4252d7818e787ac313bb8b3492c5d33ccc5db4c9429bf9fdea3e39c789",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "57c87855087c9ae013ef2f9a8d933d3bd698d8ed5299621d38ecbca1606e3d4b",
+            sha256 = "3c1c7244c54d5733f428df006144c46d26c86809e92cd793a61ff4d406cfa2de",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "0ec5ce191d613186b7d60ddda3b948a521ca9ab8e5490166d9b8c80c0c09d570",
+            sha256 = "12b33565d85aff31d2cacf20b74729d739a0f7cc78ee62025f62f84ddf5c743d",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "1304c4d2ce0c6f9fe8086e836acafcae3d642c4e54fa0a68affda8cf7d5d6874",
+            sha256 = "e42ee0c7d3fcb2b42e522bf1367e62b67ffee0b64eaa3a6b0d10e189eb8b9198",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "08262317a286dc6faa8a06ae6c93c05d146bca669f559824807a3da6487974f9",
+            sha256 = "2c6f677449a2ac5df5511f24455953ef7310a5a25fb6bf52144889e5362f78d1",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.133.0. 

# Release info 

 6b86408 (HEAD, tag: v0.133.0, origin/master, origin/HEAD, master) feat: Add `helmfile template --include-crds` (#1568) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/7137)