### PR TITLE
k9s 0.23.10

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,5 +1,5 @@
 local name = "k9s"
-local version = "0.23.9"
+local version = "0.23.10"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "c96e29384c9b1fb2028cd239276bbd8479af8cab53d536f72b7adcc08e9fa92b",
+            sha256 = "664f7a90f3f6771c58ed2f75cf493046c45e234fca15e5b886d5ef77b092e92b",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "85a54d7f0d7a7af6daf6cb6fb36b13fd75e0dd42a5a301562fcd49a2c25e8c3c",
+            sha256 = "7838b227164bb67c44caba4a1ecaee44c200580b6c6e8d6fc2acb741e5a95017",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "5fba6d5568bf2def3672af3206f102bb0c7317983dc0e0e6a52ed090864f13ff",
+            sha256 = "67c837e306829e134ddfcff02b999c1be1d939493c14219401bb8cc1d1501d3d",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.23.10. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.23.10

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better are as ever very much noted and appreciated!

If you feel K9s is helping your Kubernetes journey, please consider joining our [sponsorhip program](https://github.com/sponsors/derailed) and/or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

---

## Maintenance Release!

---

## Resolved Issues/Features

* [Issue #933](https://github.com/derailed/k9s/issues/933) Unable to cordon node starting in v0.23.8
* [Issue #932](https://github.com/derailed/k9s/issues/932) Won't start if api.github.com is inaccessible
* [Issue #931](https://github.com/derailed/k9s/issues/931) Describe ingress not showing labels

## Resolved PRs

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

