### PR TITLE
helm 3.4.1

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.4.0"
+local version = "3.4.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "e1588ee03cfa3f2140199acafc29aff95960a4f593b8f4ca8fc0a6be169827bf",
+            sha256 = "71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "270acb0f085b72ec28aee894c7443739271758010323d72ced0e92cd2c96ffdb",
+            sha256 = "538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "16ff9c2d8348a289da2997cb939f5426ff8931d02a02b133cbd6546047ca142f",
+            sha256 = "45b210c55851dfeebf33d42bbfee14500b8fd7db4289f4d59e3b7e351e354646",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.4.1. 

# Release info 

 Helm v3.4.1 is a patch release. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.4.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz.sha256sum) / 71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d)
- [Linux amd64](https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz.sha256sum) / 538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420)
- [Linux arm](https://get.helm.sh/helm-v3.4.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-arm.tar.gz.sha256sum) / 00617f17981d4d21ffc1db549a46308dc59d0cc0fa9e692c576e7b2f6ef306d0)
- [Linux arm64](https://get.helm.sh/helm-v3.4.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-arm64.tar.gz.sha256sum) / 639b2a4692e215e6c172739bd08da03d1fdb204e010cfb72f3ea822b0ba29825)
- [Linux i386](https://get.helm.sh/helm-v3.4.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-386.tar.gz.sha256sum) / 2620607b68adbdae03b7224839562946aeedc8da00bfb148b2f21cd901d85787)
- [Linux ppc64le](https://get.helm.sh/helm-v3.4.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-ppc64le.tar.gz.sha256sum) / 5083d59b53afcd10774781d58999c5dd21cd624616e6a115dec74499c71bdd02)
- [Linux s390x](https://get.helm.sh/helm-v3.4.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.1-linux-s390x.tar.gz.sha256sum) / 71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d)
- [Windows amd64](https://get.helm.sh/helm-v3.4.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.4.1-windows-amd64.zip.sha256sum) / 67f19f370b1f47d71cbd05c288d7adf627921e7a6dc57c6e713c389569ad1c34)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.4.2 will contain only bug fixes and be released on December 9, 2020
- 3.5.0 is the next feature release and will be released on January 13, 2020

## Changelog

- add unittes for 'helm dep build' with --skip-refresh flag. c4e74854886b2efe3321e185578e6db9be0a6e29 (yxxhero)
- Add --skip-refresh option in helm dep build 5522ce93fd9e1fcbeecb163e7dd843683d7f9890 (yxxhero)
- Added tests for PR 8948 6cdd6114dce6fbd834f00a031a0755a435eea7ab (Matt Farina)
- [#7696] Avoid crash in chart loader on unexpected file sequence 5257ee5821a87419c4423147f84d72734dfcf18c (Lehel Gyuro)
- [#7696] Avoid crash in chart loader on unexpected file sequence 5f5975d9c853e12bba0d3314a555594669f84dba (Lehel Gyuro)
- Updating to k8s 1.19.3 based packages c3548b39467063baadb6ec5cef5860b73c453912 (Matt Farina)
- lint: lint all documents in a multi-doc yaml file 32689d04fc22c64a46792c65b285ecd07b97e591 (Nandor Kracser)
- List either incubator or stable. eba288f6e9f4959eecaa097cc13ed827f0e8a981 (Bridget Kromhout)
- Clarifies action needed to list new stable repo 4e1a52428dd6938abacace28172afa9e4e5d4d70 (Bridget Kromhout)
- added test for https://github.com/helm/helm/pull/8913 related to https://github.com/helm/helm/issues/8621 7d9837a858046af7598217a1537cbc1a65fd72e9 (Christophe VILA)
- do not check YAML if nothing was parsed fe23c0955234310993c25e44eadf00ccf2708839 (Christophe VILA)
- helm search supports semver pre version numbers starting with 0 d589c9a9a86640018428c5088c98bf38d33768ba (wawa0210)
- Fix that the invalid version number of the helm package command will escape b266b571ce971574ac07e4513cdce05e2db0a8be (wawa0210)
- Update err message to use the regex pattern directly cbaeaaa0c8bd2d49bdb21a117fd797a9412abb21 (Martin Hickey)
- Fix the lint error message for valid names 1f6fd5df26514907d1ac2014f44ca399cdf0b8fc (Martin Hickey)
- Updating descriptions e049bd2e8409baafe0d12373adeae526d9e37ac3 (Bridget Kromhout)
- Adjusted import 8f4601546e55c4c0e41049dc5a528e75013c84d5 (Janario Oliveira)
- Reuse kube-client f7edaa7459558c0253f52b7bd00f35eb711dc06d (Janario Oliveira)
- Fixes Error: could not find protocol handler for e1858f78359af4948a94628fa318e44cd2e1aaa0 (Matt Farina)
- Add test case for LoadFiles d0721819fb60abc56339048e655cfb23b7fa9ccb (Zhengyi Lai)
- Bugfix: panic when chart contains requirements.lock 3755f8a673c729e75e997f3839d1e3055264700a (Zhengyi Lai)