### PR TITLE
bicep 0.2.3

### DIFF
--- a/Food/bicep.lua
+++ b/Food/bicep.lua
@@ -1,5 +1,5 @@
 local name = "bicep"
-local version = "0.1.37-alpha"
+local version = "0.2.3"
 local release = "v" .. version
 
 
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-osx-x64",
             -- shasum of the release archive
-            sha256 = "9502397b2680db391135d9558efefb1e14c3b1c4cd6385d8b53e50bf49b2dcbf",
+            sha256 = "a96e8aab745fe67dacc37d6d1f14dcf41fb439dabd8c40297fde030d2d4819a0",
             resources = {
                 {
                     path = name .. "-osx-x64",
@@ -28,7 +28,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-x64",
             -- shasum of the release archive
-            sha256 = "6520bde53d5dc5036d5025b8fdc1800f15c16e361f5b5f8c4456dc93e10ef55e",
+            sha256 = "bc0723e72256904c7d619dea5fa77e7aed14e7a5885aaf4148f6ebde2b02f3a2",
             resources = {
                 {
                     path = name .. "-linux-x64",
@@ -42,7 +42,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-win-x64.exe",
             -- shasum of the release archive
-            sha256 = "3ee7999e001a81182d2d2a11fd81a432f7e0595f402f7b3cb5fb5748b922ecac",
+            sha256 = "4dc6bf13396e8249f59b9388cbe9cc270a8eb18ab038c81987a77f04c455d1e6",
             resources = {
                 {
                     path = name .. "-win-x64.exe",


### PR DESCRIPTION
Updating package bicep to release v0.2.3. 

# Release info 

 **Major new features:**
* Intellisense - full details in the VS Code Extension [README](https://github.com/Azure/bicep/blob/main/src/vscode-bicep/README.md)
* Validation of all azure resource types
* Modules ([spec](https://github.com/Azure/bicep/blob/main/docs/spec/modules.md), [tutorial](https://github.com/Azure/bicep/blob/main/docs/tutorial/05-creating-modules.md))
* Code formatting
* Bicep VS Code extension is now available in the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-bicep)
* Ability to set `targetScope` for a given `.bicep` file ([spec](https://github.com/Azure/bicep/blob/main/docs/spec/resource-scopes.md#declaring-the-target-scope)) 

**Minor improvements:**
* Allow example selection in playground (#485)
* Allow string interpolation in property keys (#566)
* Add a homebrew formula. (#597) (@brendandburns) 
* adjust span to cover the key of the object (#767) (@sebastus)
* Don't add empty template properties - Issue 221 (#713) (@glav)

**New/updated examples:**
* Updated API versions to latest stable version (#574) (@azurekid)
* added vnet-vnet-bgp example (#509) (@bhummerstone)
* adding example for vwan w/ shared services (#734) (@bhummerstone)
* adding example for web app log analytics (#874) (@JFolberth) 
* Add Policy with Initiative Definition and Assignment Example (#620) (@joshuawaddell)
* Azure Firewall with public IP from IP Prefix sample (#535) (@StefanIvemo)
* add bicep azure container registry example (#644) (@dewolfs)
* AKS cluster with Virtual Machine Scale Sets Agent Pool and System-assigned managed identity (#675) (@dewolfs)
* Added cyclecloud example + snippets (#843) (@lr90)
* Add Azure Function example (#488) (@mikemassa84) 