### PR TITLE
k3d 3.2.1

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "3.2.0"
+local version = "3.2.1"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "7ed5850c6a1e609f0976c254263c0ea704a0adfccb760a7cf0322a386cf3cb9a",
+            sha256 = "74a68bad47878641a24dcf0ea8a3e9e486c4211902ef8bc12ed9a687ddb9a12c",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "d4d2c3285b0b87175216bc6b2b5edbba5b2acbc8fca4277604d538ec9f38fb70",
+            sha256 = "cbc67edac74a645fdf803195277c5ac27a91036d089f67a2af5238a690cb7d57",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "8fc122ca062a9adb2f1920a58dd57cf5969c3cfbe1985514cfd7d7bf4e12ea87",
+            sha256 = "ee25e42e1e721de2b642b0aef204175ab0d85c6c943253485d6446e16db18956",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "8e740b361767f543548989a394904222ba363d87ea431ebb34c176ed07e2cdb3",
+            sha256 = "491b87ff42cfd33bb78cfe5f4f7728d3a91675cccf6904cffc2ec2bbe3f7069e",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "08a92596a08fc21ff9dce19eb189f3dbb3d17c871ad9e0c61d69ca79b41cc110",
+            sha256 = "3e680fead243fad5b82dac5d7154e921535c1d506101db6b2b6d237a2d4b79f1",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "f0a0c4f57d5f056f4a4c134207fd0961a8a6bfaad8409b9dc080bc0f378cc359",
+            sha256 = "4cc6bedc2b8c42d136815778c0ee5e77c00c78a521b7709601aac6324ac8bfba",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v3.2.1. 

# Release info 

 # v3.2.1

## Bugfixes

- fix: new Docker VM IP lookup breaking cluster creation on Docker for Desktop installations *not* using docker-machine