### PR TITLE
minikube 1.15.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.14.2"
-local version = "1.14.2"
+local release = "v1.15.0"
+local version = "1.15.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "5d72bea6159e41f30865492298aa0e37af164ef22e56165ac78be179947d3b9d",
+            sha256 = "a744ed7fb5c317ef06b2c5ae0d94cec1d41e1d5c2ea40b5ece28e7a340abbad3",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "7b415e77bf80f9746b90ab82afd1aa62f72c1dfbdc928af2be7d3a082b42cd96",
+            sha256 = "114c17660bfc27f6fcbef18c3fef8c577188c0c19ae1c4555152207a2f7f4d99",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "f38f8da05a940589989eb0e85492edfe146caf57f9cfbb4ebb06de877f828f2e",
+            sha256 = "0b287e1cafc911ea6e39879f13ea302eeed5f6679bc77c719bfe21870056f3ca",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "174453403b1a1c4a75634eabaa86614f4bccfc0b45be87b8899de91b129cac7b",
+            sha256 = "0e414de4c8bd0c1fa0b91ff82b7a146a1c460af06c65ae2d82f835a85dd04d6c",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "cafd7a10a950d3c63425758b1afb3eaad12a4a5abd586fb83afc27a832a2c62b",
+            sha256 = "a9e3e52c262b8832f3a83cbef4cbfc3e4c9e9e14baab819b43af040def7a447f",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "d84f3c46167a7da0d961766e9a5578b6b2a8498670da94c22a4e525eecfa8629",
+            sha256 = "40a3ad57e2f9b5885a502055ecf8b5fc97aff8f2d4a872be75cd54bff56e0a91",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.15.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.15.0 - 2020-11-13

Features:

* Add support for latest kubernetes version v1.20.0-beta.1  [#9693](https://github.com/kubernetes/minikube/pull/9693)
* Implement schedule stop for unix [#9503](https://github.com/kubernetes/minikube/pull/9503)
* New flag --watch flag for minikube status with optional interval duration [#9487](https://github.com/kubernetes/minikube/pull/9487)
* New flag  --namespace for activating non default kubeconfig context [#9506](https://github.com/kubernetes/minikube/pull/9506)
* Add JSON output to stop, pause and unpause [#9576](https://github.com/kubernetes/minikube/pull/9576)
* Add support for podman v2 to podman-env command [#9535](https://github.com/kubernetes/minikube/pull/9535)
* Support ImageRepository for addons [#9551](https://github.com/kubernetes/minikube/pull/9551)

Bug Fixes:

* implement "--log_file" and "--log_dir" for klog [#9592](https://github.com/kubernetes/minikube/pull/9592)
* GCP Auth Addon: support special location for cloud shell [#9674](https://github.com/kubernetes/minikube/pull/9674)
* Enable TCP Path MTU Discovery when an ICMP black hole is detected [#9537](https://github.com/kubernetes/minikube/pull/9537)
* Remove hard-coded list of valid cgroupfs mountpoints to bind mount [#9508](https://github.com/kubernetes/minikube/pull/9508)
* Improve parsing of start flag apiserver-names [#9385](https://github.com/kubernetes/minikube/pull/9385)
* kvm: recover from minikube-net network left over failures  [#9641](https://github.com/kubernetes/minikube/pull/9641)
* fix help flag 'pflag: help requested' error [#9614](https://github.com/kubernetes/minikube/pull/9614)
* Update "parallels" driver library and make this driver built into minikube [#9517](https://github.com/kubernetes/minikube/pull/9517)

Minor Improvements:

* Upgrade crio to 1.18.4 [#9628](https://github.com/kubernetes/minikube/pull/9628)
* Update ingress-nginx image to v0.40.2 [#9445](https://github.com/kubernetes/minikube/pull/9445)
* Improving log message when profile not found [#9613](https://github.com/kubernetes/minikube/pull/9613)
* Upgrade buildroot and kernel minor version [#9523](https://github.com/kubernetes/minikube/pull/9523)

Thank you to our contributors for this release! 

- Anders F Björklund
- Evgeny Shmarnev
- Ma Xinjian
- Manuel Alejandro de Brito Fontes
- Medya Ghazizadeh
- Michael Ryan Dempsey
- Mikhail Zholobov
- Peter Lin
- Predrag Rogic
- Priya Wadhwa
- Sharif Elgamal
- Thomas Strömberg
- Yehiyam Livneh
- prezha
- vinu2003
- zouyu

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`c3b5682d484e0e507ccc39da7e12ac6a868a3e8e0ed7e3cf91836d9565e474ec`