### PR TITLE
istioctl 1.8.0

### DIFF
--- a/Food/istioctl.lua
+++ b/Food/istioctl.lua
@@ -1,5 +1,5 @@
 local name = "istioctl"
-local version = "1.7.4"
+local version = "1.8.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-osx.tar.gz",
-            sha256 = "b87663e6bd9168837b317f71bc0bb42a70bdfd30af983be1770211aeadfcbb35",
+            sha256 = "6c108a80aa7cf1f4c4a5859576ed417b90c005d8dfbc31232ca808c10eedefff",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "6ed5eb68e71a0884cad39c94616e4ce0a93b90369b20d3659cfaf71da015f902",
+            sha256 = "8b41dfac9836772480fa07227262fbc99c449f33799ad9e4950fd7b5323ab9e5",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name ,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/istio/istio" .. "/releases/download/" .. version .. "/istio" .. "-" .. version .. "-win.zip",
-            sha256 = "1652ce4cb8846f2bc98ef4f2e89a3306c84785126731d5a123f6a88877fa4573",
+            sha256 = "a7ff4b12cce959af9e35de15d52d68aae1331a97a001b3ea86edf7658d756ced",
             resources = {
                 {
                     path = "istio-" .. version .. "/bin/" .. name .. "exe",


### PR DESCRIPTION
Updating package istioctl to release 1.8.0. 

# Release info 

 [Artifacts](http://gcsweb.istio.io/gcs/istio-release/releases/1.8.0/)
[Release Notes](https://istio.io/news/announcing-1.8.0/)