### PR TITLE
clusterctl 0.3.11

### DIFF
--- a/Food/clusterctl.lua
+++ b/Food/clusterctl.lua
@@ -1,5 +1,5 @@
 local name = "clusterctl"
-local version = "0.3.10"
+local version = "0.3.11"
 local release = "v" .. version
 local org = "kubernetes-sigs"
 local repo = "cluster-api"
@@ -16,7 +16,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
             -- shasum of the release archive
-            sha256 = "37eef184d65fe4f6ce1fb0c7270011a08db4d43ea35a9c31755117c8c2e38ac6",
+            sha256 = "87dc72d13e10e35ccfef0968f32038d45fb94bf3ed1d270de3f0ce108269b307",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -30,7 +30,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
             -- shasum of the release archive
-            sha256 = "5b66025473bd8bbf3ed5316d7fa8433e4d7d68648f613cd25200eb43824a56ff",
+            sha256 = "9e914628c9bd1ca32137cbb763dc781e6c4570f02912c69c50baf65ece002303",
             resources = {
                 {
                     path = name .. "-linux-amd64",


### PR DESCRIPTION
Updating package clusterctl to release v0.3.11. 

# Release info 

 Changes since v0.3.10
---
## :warning: Breaking Changes
- E2E test now resolve CNI_RESOURCES without using env variables (#3846)
- Infrastructure provider DigitalOcean was renamed to `digitalocean` (previously do) (#3816)

## :sparkles: New Features
- KubeadmControlPlane now remediates unhealthy machines when setup with MachineHealthCheck (#3830)
- MachineHealthCheck now has `remediationsAllowed` field under Status (#3372)
- MachineHealthCheck now supports external remediation templates (#3606)
- Adds machine health check conditions to Machine Ready condition (#3796)

## :bug: Bug Fixes
- Relax update validation to allow rotating ssh keys for KCP (#3927)
- Prevents reconcileEtcdMember to remove etcd members when etcd starts slowly (#3919)
- High cpu usage during kubectl drain (#3915)
- Fix Makefile docker targets by prepulling required images (#3897)
- Fix link to proposal root to /docs/proposals/ (#3842)

## :book: Documentation
- Update required configurations for Metal³ provider (#3829)

## :seedling: Others
- Modifies DockerMachine condition status to report for control plane to be ready (#3726)
- Avoid MachineHealthCheck to return early on patch errors (#3713)
- Add Node related condition to Machine conditions (#3670)
- Upgrade corefile migration to v1.0.11 (#3856)
- Refactor controlplane health check in KCP (#3806)
- CAPD webhooks should use 9443 as port (#3819)
- Add Node watch to Machine controller (#3748)
- Add KCP conditions, split reconcileHealth into preflight and reconcileEtcdMembers, make both use conditions (#3900)
- MachineHealthCheck External Remediation

_Thanks to all our contributors!_ 😊
