### PR TITLE
argocd 1.7.10

### DIFF
--- a/Food/argocd.lua
+++ b/Food/argocd.lua
@@ -1,5 +1,5 @@
 local name = "argocd"
-local version = "1.7.9"
+local version = "1.7.10"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/argoproj/argo-cd/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "16ec6a74d6847c9c8dd37b50c991693d69d5ffe2d09769e4909f7e4da55a9614",
+            sha256 = "67f945e75f2a7d27a3d92f154537a0a92bbd5cff07d423de0a882598867010f1",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/argoproj/argo-cd/releases/download/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "696fd14adfca77ff6293e67de67fe795b4a0746ac1a96431b70f219d94683384",
+            sha256 = "292b945926d953768d10166d26638e333326aeb31cf77322d1599549a824215b",
             resources = {
                 {
                     path = name .. "-linux-amd64",


### PR DESCRIPTION
Updating package argocd to release v1.7.10. 

# Release info 

 ## Quick Start
### Non-HA:
```
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v1.7.10/manifests/install.yaml
```

### HA:
```
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v1.7.10/manifests/ha/install.yaml
```

## Changes

- fix: increase max grpc message size (#4869)