### PR TITLE
golangci-lint 1.33.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.32.2"
+local version = "1.33.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "a86bd2fc10bfcd183c7368aa2cfd047a341be11e0bef242a6ed181d4f7dc0fb0",
+            sha256 = "fa80509612c2058ca0252647718d1a9b43c0ea19cac30440e7944302cb61ec33",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "e7ab86d833bf9faed39801ab3b5cd294f026d26f9a7da63a42390943ead486cc",
+            sha256 = "e2d6082f1df53c5d2c280765000f9e82783ea909ba419c6c4e172936b076031e",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "73280119955d69f83285581568bd82ec7a702fef1c19990d27c29ca6b675c775",
+            sha256 = "d2af35135d71c2bd45e7ee1a09553c056ebf71f1088d098225c1095d8f93f975",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.33.0. 

# Release info 

 

## Changelog

9948153 DefaultExcludePatterns should only be used for specified linter (#1494)
1ca232a Fix typos (#1476)
c68692e Missing sort-results in the docs (#1514)
947dae1 Unknown linter breaks //nolint (#1497)
df2e9e2 Update godot to 1.3.0 (#1498)
993337b Using upstrem goconst (#1500)
b90551c add new paralleltest linter (#1503)
b1755c1 build(deps): bump github.com/kyoh86/exportloopref from 0.1.7 to 0.1.8 (#1501)
3fe444c build(deps): bump lodash from 4.17.15 to 4.17.19 in /.github/peril (#1252)
e8043b6 feat(release): Update metadata for golangci-lint-action (#1491)


