### PR TITLE
jcli 0.0.31

### DIFF
--- a/Food/jcli.lua
+++ b/Food/jcli.lua
@@ -1,6 +1,6 @@
 local name = "jcli"
-local release = "v0.0.30"
-local version = "0.0.30"
+local release = "v0.0.31"
+local version = "0.0.31"
 food = {
     name = name,
     description = "Jenkins CLI allows you manage your Jenkins as an easy way",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "ca49b17c0223a98682605ace5e9cb0aaf048dc132357541277cac3831b7d5667",
+            sha256 = "93a81499eaa1be1d1382f062acf2967364de430df96a4054891706c5b058fd06",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "f9671353e14d58b4fbe08aca23a8e427d3a1426ce2f72a8a82aef9b4d14fa574",
+            sha256 = "64ccd883ca77ddc74a1f00cf04061405b198ce3d8e4899daaeaa6bbc3f83c121",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "648f1c644180f3e0221c8f7d60288d858f24dc5e3a6af2fc240627ff40b04cce",
+            sha256 = "8cf41eda76d48331a442a262fe6481ec2d0e7fd1ad9094c2bc6c14129b31a8c3",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jcli to release v0.0.31. 

# Release info 

 ## What’s Changed

It's been a long time not to have a release of [jcli](https://github.com/jenkins-zh/jenkins-cli/). But it's totally worth to upgrade it. Let's see what you can get.

Normally, you need to set up the config file of [jcli](https://github.com/jenkins-zh/jenkins-cli/) if this is the first time you install it. Generating the user token from Jenkins, then write it back to the config file is a pretty annoying process. But it's not necessary anymore. It can be automatically now. You just need to run the following command:

`jcli center login`

It will open the browser, and your config file will be ready once you login into Jenkins. But there's one limitation that does exist. Jenkins and your computer must be about to connect to each other. Besides, you need to install one more [plugin](https://github.com/jenkinsci/pipeline-restful-api-plugin).

The second feature is the Jenkins formula. Thanks @oleg-nenashev for taking the initiative to start [Custom Jenkins WAR packager](https://github.com/jenkinsci/custom-war-packager). We can generate a custom distribution of Jenkins. [jcli](https://github.com/jenkins-zh/jenkins-cli/) support to export a formula from a Jenkins. Also, it can install all plugins that come from a Jenkins formula file. Check out these two commands below:

```
jcli plugin formula > formual.yaml            # export into a YAML formula file
jcli plugin install --formula formual.yaml    # install plugins from a formula file
```

The third feature is that we can run Jenkins as a docker container via `jcli center start -m docker`.

What is next? I know a lot of newcomers to Jenkins feel terrible when they meet the plugins dependency issues. So please don't hesitate to file a pull request to close [this issue](https://github.com/jenkins-zh/jenkins-cli/issues/365) if you're interested.

Do you want to upgrade?  It's very simple: `jcli version upgrade`.

## 🚀 Features

* Improve plugin upload command (#440) @LinuxSuRen
* Improve the version upgrade of jcli (#435) @LinuxSuRen
* Add support to install plugins via Jenkins formula (#469) @LinuxSuRen
* Add support fetch Jenkins token automatically (#469) @LinuxSuRen
* Add support to connect to ssh server (#468) @LinuxSuRen
* Add support to run docker image with center start cmd (#464) @LinuxSuRen
* Add support to download a plugin with specific version (#465) @LinuxSuRen
* Add http proxy support which can ready from env variable (#414) @LinuxSuRen
* Add an option to print cwp version (#462) @LinuxSuRen
* Support export current Jenkins as a formula (#458) @LinuxSuRen
* Add a global timeout option for all commands (#446) @LinuxSuRen
* Improve the self-upgrade when no privileges (#437) @LinuxSuRen

## 📝 Documentation updates

* Add documentation for more package manager (#461) @LinuxSuRen

## 👻 Maintenance

* Bump github.com/spf13/cobra from 1.0.0 to 1.1.1 (#452 #453) @dependabot-preview
* Bump github.com/AlecAivazis/survey/v2 from 2.0.8 to 2.2.2 (#445 #459) @dependabot-preview
* Bump github.com/onsi/ginkgo from 1.14.0 to 1.14.2 (#449 #451) @dependabot-preview
* Bump github.com/onsi/gomega from 1.10.1 to 1.10.3 (#448 #450) @dependabot-preview
* Bump golang.org/x/text from 0.3.2 to 0.3.4 (#444 #454) @dependabot-preview
* Bump go.uber.org/zap from 1.15.0 to 1.16.0 (#447) @dependabot-preview
* Bump github.com/golang/mock from 1.4.3 to 1.4.4 (#442) @dependabot-preview
