### PR TITLE
k9s 0.24.1

### DIFF
--- a/Food/k9s.lua
+++ b/Food/k9s.lua
@@ -1,5 +1,5 @@
 local name = "k9s"
-local version = "0.24.0"
+local version = "0.24.1"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Darwin_x86_64.tar.gz",
-            sha256 = "54f79c44f075b614e0dfe9f492c814461730f7ad229fc75d04e18cec190e4e6b",
+            sha256 = "a5f48b76cce9fcccd0a055524123e486f4b7ff83d14b268931c5141457fe1fdd",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "a6fd3a12930eb699da741e247be6e60ff9ffc03eee640ec35686e63f78a531e6",
+            sha256 = "58707af45652b26ebc764bd8422725940832348ccef07f38d2d31c17572e3bf8",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/derailed/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_Windows_x86_64.tar.gz",
-            sha256 = "5c06dc11230340595d02556a2afd4ce7bd65dd499a106a04f27bff52cbf3de96",
+            sha256 = "e16ad67fa66f7ded6b5bc411042ebfd14824ee462d1372abe47dec5565483f03",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package k9s to release v0.24.1. 

# Release info 

 <img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/k9s_small.png" align="right" width="200" height="auto"/>

# Release v0.24.1

## Notes

Thank you to all that contributed with flushing out issues and enhancements for K9s! I'll try to mark some of these issues as fixed. But if you don't mind grab the latest rev and see if we're happier with some of the fixes! If you've filed an issue please help me verify and close. Your support, kindness and awesome suggestions to make K9s better are as ever very much noted and appreciated!

If you feel K9s is helping your Kubernetes journey, please consider joining our [sponsorhip program](https://github.com/sponsors/derailed) and/or make some noise on social! [@kitesurfer](https://twitter.com/kitesurfer)

On Slack? Please join us [K9slackers](https://join.slack.com/t/k9sers/shared_invite/enQtOTA5MDEyNzI5MTU0LWQ1ZGI3MzliYzZhZWEyNzYxYzA3NjE0YTk1YmFmNzViZjIyNzhkZGI0MmJjYzhlNjdlMGJhYzE2ZGU1NjkyNTM)

## Maintenance Release!

☡ IMPORTANT!! v0.24.0 is a bad drop!! Apparently while upgrading the dependencies in the v0.24.0,  I've managed to hose the dialog's buttons focus hence producing the incorrect default button behavior. So please upgrade to v0.24.1 ASAP!!

---

## Resolved Issues/Features

* [Issue #821](https://github.com/derailed/k9s/issues/821) Default color is no longer transparent.
* [Issue #933](https://github.com/derailed/k9s/issues/933) Unable to cordon node.

## Resolved PRs

* [PR #941](https://github.com/derailed/k9s/pull/941) Add Monokai skin. My new favorite skin! Big Thanks to [Mike SigsWorth](https://github.com/mikesigs)!!

---

<img src="https://raw.githubusercontent.com/derailed/k9s/master/assets/imhotep_logo.png" width="32" height="auto"/> © 2020 Imhotep Software LLC. All materials licensed under [Apache v2.0](http://www.apache.org/licenses/LICENSE-2.0)

