### PR TITLE
bicep 0.2.59

### DIFF
--- a/Food/bicep.lua
+++ b/Food/bicep.lua
@@ -1,5 +1,5 @@
 local name = "bicep"
-local version = "0.2.14"
+local version = "0.2.59"
 local release = "v" .. version
 
 
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-osx-x64",
             -- shasum of the release archive
-            sha256 = "81f026d945d8916a784e313db2106b1649cb5eef772377ed5736f9de0590c587",
+            sha256 = "9b07831f1ac59a613ed8f95f23e691387ad2f3f0d70872b0b4737c4736c09013",
             resources = {
                 {
                     path = name .. "-osx-x64",
@@ -28,7 +28,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-x64",
             -- shasum of the release archive
-            sha256 = "6720d73807eec0e6632d90d5291c8bf3170e199c720013b3d913930f62d78e77",
+            sha256 = "13eefdbe105b8a162b3bdebf247fc6ec3fb7cf838c917d04775249531ba70873",
             resources = {
                 {
                     path = name .. "-linux-x64",
@@ -42,7 +42,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-win-x64.exe",
             -- shasum of the release archive
-            sha256 = "04b5c6640b827952c5f82d7462935dbd360d5d2252492f589c5332cd52639563",
+            sha256 = "150f1cb9be8c9fd0b15fce653f1def1920b88462fa76ee7e183a755d5857a533",
             resources = {
                 {
                     path = name .. "-win-x64.exe",


### PR DESCRIPTION
Updating package bicep to release v0.2.59. 

# Release info 

 @JFolberth:
* Update documentation (#908)

@johndowns
* Add missing examples (#919)
* Add Redis Cache example (#976)
* Fix string concatenation in Redis example (#984)

@ljtill:
* Bump homebrew from v0.2.6 to v0.2.14 (#915)

@miqm:
* Do not show completions inside comments (#974)

@StefanIvemo:
* Fixed typos (#975)

@wilfriedwoivre:
* Add sample for hub & spoke topology (#927)

@heikkiri:
* Update resource-scopes.md (#937)

@lr90:
* Multi Resource Group, Scope example (#921)
* Removing concats and polishing for 0.2.14 (#944)

Team Bicep:
* new any() doc, updates to arm2bicep doc, example cleanup (#936)
* Fix vscode launch commands (#913)
* Implement `bicep decompile` command (#833)
* Rename namespaces to avoid clashes with class names (#967)
* Make playground buttons look like buttons, display tooltips (#981)
* Add syntax rewriter framework and some decompiler simplification rewriters (#953)
* Add type definitions for environment() & deployment() built-ins (#983)
* Updated to .net 5 (#911)
* initial type system documentation (#914)
* Run VSIX tests on all platforms (#930)
* Create E2E tests for Bicep CLI commands (#938)
* Set PrivateAssets to all for analyzer packages (#948)
* Fix Span of ProgramSyntax (#954)
* Update spec for resource conditions (#966)