### PR TITLE
jcli 0.0.32

### DIFF
--- a/Food/jcli.lua
+++ b/Food/jcli.lua
@@ -1,6 +1,6 @@
 local name = "jcli"
-local release = "v0.0.31"
-local version = "0.0.31"
+local release = "v0.0.32"
+local version = "0.0.32"
 food = {
     name = name,
     description = "Jenkins CLI allows you manage your Jenkins as an easy way",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "93a81499eaa1be1d1382f062acf2967364de430df96a4054891706c5b058fd06",
+            sha256 = "aef8af57f87b002620ce46ac550dac2c85c7aa8172a2b5d20e96a61588d50887",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "64ccd883ca77ddc74a1f00cf04061405b198ce3d8e4899daaeaa6bbc3f83c121",
+            sha256 = "5b481d46ffdfb9ac9177c6b27360afedede1312b29c7cfed5a34605b23bd2a73",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "8cf41eda76d48331a442a262fe6481ec2d0e7fd1ad9094c2bc6c14129b31a8c3",
+            sha256 = "9d29ec7c082b5977cf83528481ea2ae5fee54d9687979af41a5bb71a8136cce3",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jcli to release v0.0.32. 

# Release info 

 ## What’s Changed

This is a small release version. The main idea of this is to remove CASC from jcli core. You want to use it. Please see [here](https://github.com/jenkins-zh/jcli-casc-plugin).

## 🚀 Features

* Move casc sub-command into jcli-casc-plugin (#475) @LinuxSuRen

## 🐛 Bug Fixes

* Fix the missing checking of the 'current' option in the config file (#474) @gocruncher
* Fix the wrong path of config plugin (#472) @LinuxSuRen

## 👻 Maintenance

* Bump gopkg.in/yaml.v2 from 2.3.0 to 2.4.0 (#476) @dependabot-preview
