### PR TITLE
skaffold 1.17.1

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,5 +1,5 @@
 local name = "skaffold"
-local version = "1.17.0"
+local version = "1.17.1"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "027acb5b9af075f00571e2d2366886ea7bb06e0a74b51bca1878ca4e2f2bd83a",
+            sha256 = "5f008c8b1a1c3c5ae786270cdc5619bc902f9886647682038d24b70cbbe5894d",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "734a23dfe90b01feb927c44168c93b72afd05d8b978319b4670dc7e6a5e887fe",
+            sha256 = "a44d548aea2ee67099f3f7ecf6dbaa0b309d120dee8862f02ff69f32b5f86821",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "21db162d32a0e391444ab8d4826a6f632432a434a2ad49024cd9d48924801494",
+            sha256 = "56a92d23466840e853a6afed281fc50d35c72b082f572dadf735606b389b4686",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.17.1. 

# Release info 

 # v1.17.1 Release - 12/01/2020
**Linux**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.17.1/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
 
**macOS**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.17.1/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
 
**Windows**
 https://storage.googleapis.com/skaffold/releases/v1.17.1/skaffold-windows-amd64.exe
 
**Docker image**
`gcr.io/k8s-skaffold/skaffold:v1.17.1`
 
This is a minor release with few updates.

Highlights:
* Improve deployment times to local kind/k3d by setting `kind-disable-load` and `k3d-disable-load` to true in global config [#5012](https://github.com/GoogleContainerTools/skaffold/pull/5012)

Fixes:
* Change default kaniko image to `gcr.io/k8s-skaffold/skaffold-helpers/busybox` from `busybox` [#5080](https://github.com/GoogleContainerTools/skaffold/pull/5080)
* Support multi-level repos for Artifact Registry [#5053](https://github.com/GoogleContainerTools/skaffold/pull/5053)

Updates:
* Add distinct error codes for all deploy errors [#5070](https://github.com/GoogleContainerTools/skaffold/pull/5070)
* Bump k8s and docker client library deps [#5038](https://github.com/GoogleContainerTools/skaffold/pull/5038)
* add docker build distinct error codes [#5059](https://github.com/GoogleContainerTools/skaffold/pull/5059)
* add jib tool errors [#5068](https://github.com/GoogleContainerTools/skaffold/pull/5068)
* Update to pack 0.15 and add debug support for CNB Platform API 0.4 [#5064](https://github.com/GoogleContainerTools/skaffold/pull/5064)


Huge thanks goes out to all of our contributors for this release:

- Brian de Alwis
- Gaurav
- Halvard Skogsrud
- Isaac Duarte
- Marlon Gamez
- Nick Kubala
- Tejal Desai
- Thomas Strömberg
- Zbigniew Mandziejewicz