### PR TITLE
aks-engine 0.58.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.57.0"
+local version = "0.58.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "907d02674f589f252c55e0f8bec2e0cf9dba4d13d9c5b3f388f82b6b17c44450",
+            sha256 = "2239bfed4613d7dfdae0c1fd5bf0f764473f566e3c402b9d17a73db4a752dbfc",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "2c37d40b8b31d0f60d7fc16b6c9253dbed364e6b0a3c47d0beeeceec0572aeda",
+            sha256 = "a7481b603c68c32ae57b5ac376e1205fd69bfa784184dc0a67c8e1bcc704643e",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "541e093cf527b8bf5319ee12439de6ed8ccbab11d0d49a681353c6869cd949f2",
+            sha256 = "fcfa985180116fa2c842951a428f76dea97bc38d9a8765498df24a862e8195b6",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.58.0. 

# Release info 

 <a name="v0.58.0"></a>
# [v0.58.0] - 2020-12-03
### Code Refactoring 💎
- remove unsupported orchestrators ([#3965](https://github.com/Azure/aks-engine/issues/3965))
- move ssh-related funcs to its own package ([#3990](https://github.com/Azure/aks-engine/issues/3990))
- delete Azure Stack's KubernetesClient implementation ([#3957](https://github.com/Azure/aks-engine/issues/3957))

### Features 🌈
- disable livenessProbe timeout enforcement ([#4085](https://github.com/Azure/aks-engine/issues/4085))
- add support for Kubernetes v1.20.0-rc.0 ([#4076](https://github.com/Azure/aks-engine/issues/4076))
- Enable chrony and host-based time sync by default on Ubuntu 18.04 ([#4011](https://github.com/Azure/aks-engine/issues/4011))
- add support for Kubernetes v1.19.4 ([#4042](https://github.com/Azure/aks-engine/issues/4042))
- add support for Kubernetes 1.18.12 ([#4043](https://github.com/Azure/aks-engine/issues/4043))
- add support for Kubernetes v1.20.0-beta.1 ([#3999](https://github.com/Azure/aks-engine/issues/3999))
- set apiserver tokenRequest flags in 1.20+ ([#3989](https://github.com/Azure/aks-engine/issues/3989))
- add support for Kubernetes v1.20.0-beta.0 ([#3991](https://github.com/Azure/aks-engine/issues/3991))
- add support for Kubernetes v1.20.0-alpha.3 ([#3934](https://github.com/Azure/aks-engine/issues/3934))
- upload collected logs to storage account container ([#3944](https://github.com/Azure/aks-engine/issues/3944))
- add support for Kubernetes v1.17.13 ([#3954](https://github.com/Azure/aks-engine/issues/3954))
- add support for Kubernetes v1.18.10 on Azure Stack ([#3950](https://github.com/Azure/aks-engine/issues/3950))
- add support for Kubernetes v1.18.10 ([#3948](https://github.com/Azure/aks-engine/issues/3948))
- updates for container monitoring addon omsagent agent September 2020 release ([#3942](https://github.com/Azure/aks-engine/issues/3942))
- add support for Kubernetes v1.19.3 ([#3937](https://github.com/Azure/aks-engine/issues/3937))
- custom Windows log collection script ([#3940](https://github.com/Azure/aks-engine/issues/3940))
- enable system-assigned identity by default ([#3856](https://github.com/Azure/aks-engine/issues/3856))

### Bug Fixes 🐞
- filter out KeyVault resources during upgrade ([#4072](https://github.com/Azure/aks-engine/issues/4072))
- make system role assignments work w/ upgrade ([#4078](https://github.com/Azure/aks-engine/issues/4078))
- cleanup VMSSName + addpool ([#4067](https://github.com/Azure/aks-engine/issues/4067))
- enforce Azure CNI config via jq instead of sed ([#4060](https://github.com/Azure/aks-engine/issues/4060))
- persist VMSS name in API model ([#4051](https://github.com/Azure/aks-engine/issues/4051))
- Windows and VMSS version validation for azs ([#4030](https://github.com/Azure/aks-engine/issues/4030))
- always ensure etcd on control plane vms ([#4045](https://github.com/Azure/aks-engine/issues/4045))
- fixing an issue where windows cannot start kubelet to get podCIDR on Windows nodes when using kubenet ([#4039](https://github.com/Azure/aks-engine/issues/4039))
- Adding csi-proxy logs to prevent access denied errors ([#4029](https://github.com/Azure/aks-engine/issues/4029))
- upgrade broken for VMAS + managed identities ([#4021](https://github.com/Azure/aks-engine/issues/4021))
- enable dhcpv6 only for ubuntu 16.04 ([#4017](https://github.com/Azure/aks-engine/issues/4017))
- Re-ordering HNS policy removal due to 10c change in behavior and consolidating logic in Windows cleanup scripts  ([#4002](https://github.com/Azure/aks-engine/issues/4002))
- Mount /usr/local/share/ca-certificates folder into kube-controller-manager ([#4001](https://github.com/Azure/aks-engine/issues/4001))
- cancel Pod Eviction jobs when timeout ([#3970](https://github.com/Azure/aks-engine/issues/3970))
- ensure flatcar configs use transparent Azure CNI ([#3972](https://github.com/Azure/aks-engine/issues/3972))
- page not done logic bug ([#3971](https://github.com/Azure/aks-engine/issues/3971))
- resource identifier not passed to custom cloud profile ([#3953](https://github.com/Azure/aks-engine/issues/3953))
- get-logs command collects control plane logs even if apiserver is down ([#3939](https://github.com/Azure/aks-engine/issues/3939))
- use InternalIP for metrics-server DNS resolution ([#3929](https://github.com/Azure/aks-engine/issues/3929))
- VMSS control plane + availability zones ([#3917](https://github.com/Azure/aks-engine/issues/3917))
- Azure Stack upgrade operations clear old MCR ImageBase ([#3922](https://github.com/Azure/aks-engine/issues/3922))
- remove NSG rules for AzureStack ([#3914](https://github.com/Azure/aks-engine/issues/3914))

### Continuous Integration 💜
- use 3 replicas for no-vnet E2E jobs ([#4061](https://github.com/Azure/aks-engine/issues/4061))
- Updating pr-windows-signed-scripts.yaml to allow for overriding cluster definition ([#4015](https://github.com/Azure/aks-engine/issues/4015))
- remove node-problem-detector addon from PR E2E ([#4010](https://github.com/Azure/aks-engine/issues/4010))
- Adding CI pipeline to verify windows provisioning script content BEFORE it gets check in ([#4008](https://github.com/Azure/aks-engine/issues/4008))
- Windows VHD pipeline tests ([#3977](https://github.com/Azure/aks-engine/issues/3977))
- reduce addons area for containerd config tests ([#3923](https://github.com/Azure/aks-engine/issues/3923))

### Documentation 📘
- fixed broken link in Azure Stack topic page ([#4056](https://github.com/Azure/aks-engine/issues/4056))
- remove double quotes(") at the aks-deploy sample ([#3967](https://github.com/Azure/aks-engine/issues/3967))
- adding instructions for how how to build the Windows VHD for di… ([#3911](https://github.com/Azure/aks-engine/issues/3911))

### Maintenance 🔧
- update Windows image ([#4086](https://github.com/Azure/aks-engine/issues/4086))
- rev Linux VHDs to 2020.12.02 ([#4081](https://github.com/Azure/aks-engine/issues/4081))
- k8s v1.18 conformance model for Azure Stack ([#4070](https://github.com/Azure/aks-engine/issues/4070))
- validate VHD availability before upgrade/scale on Azure Stack Hub ([#4062](https://github.com/Azure/aks-engine/issues/4062))
- mark Kubernetes 1.17.14 as disabled ([#4044](https://github.com/Azure/aks-engine/issues/4044))
- cleanup dead code ([#4053](https://github.com/Azure/aks-engine/issues/4053))
- only warn about master stuff during create ([#4057](https://github.com/Azure/aks-engine/issues/4057))
- Upgrade CNI to v1.2.0 ([#4058](https://github.com/Azure/aks-engine/issues/4058))
- Updating default csi-proxy version to v0.2.2 ([#4047](https://github.com/Azure/aks-engine/issues/4047))
- format some json in addpool.md ([#4049](https://github.com/Azure/aks-engine/issues/4049))
- remove deprecated AKS code paths ([#4040](https://github.com/Azure/aks-engine/issues/4040))
- deprecate orchestratorType ([#4038](https://github.com/Azure/aks-engine/issues/4038))
- remove deprecated localizations ([#4036](https://github.com/Azure/aks-engine/issues/4036))
- Use Windows November(11b) updates as default vhd ([#4033](https://github.com/Azure/aks-engine/issues/4033))
- Windows November Patches ([#4023](https://github.com/Azure/aks-engine/issues/4023))
- Add 10c image as default ([#4020](https://github.com/Azure/aks-engine/issues/4020))
- rev Linux VHDs to 2020.10.30 ([#4016](https://github.com/Azure/aks-engine/issues/4016))
- Install Windows Server 2019 10C updates in Windows VHD ([#3956](https://github.com/Azure/aks-engine/issues/3956))
- update powershell signed scripts ([#4012](https://github.com/Azure/aks-engine/issues/4012))
- Adding csi-proxy-v0.2.2 to Windows VHD ([#4004](https://github.com/Azure/aks-engine/issues/4004))
- update cluster-autoscalers to latest patches ([#4000](https://github.com/Azure/aks-engine/issues/4000))
- set go sdk log level for Azure Stack clusters ([#3993](https://github.com/Azure/aks-engine/issues/3993))
- update cluster-autoscaler to v1.19.1 ([#3996](https://github.com/Azure/aks-engine/issues/3996))
- update go toolchain to v1.15.3 ([#3879](https://github.com/Azure/aks-engine/issues/3879))
- use transparent mode for Azure CNI ([#3958](https://github.com/Azure/aks-engine/issues/3958))
- gofmt ([#3982](https://github.com/Azure/aks-engine/issues/3982))
- longer default cordonDrainTimeout for Azure Stack Cloud ([#3969](https://github.com/Azure/aks-engine/issues/3969))
- kubelet systemd job depends on CRI service ([#3943](https://github.com/Azure/aks-engine/issues/3943))
- Upgrade CNI to v1.1.8 ([#3907](https://github.com/Azure/aks-engine/issues/3907))
- remove support for Kubernetes 1.15 ([#3751](https://github.com/Azure/aks-engine/issues/3751))
- bump calico to 3.8.9 to get latest patches ([#3924](https://github.com/Azure/aks-engine/issues/3924))
- set the csi-secrets-store to have a priority class ([#3909](https://github.com/Azure/aks-engine/issues/3909))
- rev Linux VHDs to 2020.10.06 ([#3906](https://github.com/Azure/aks-engine/issues/3906))
- enable VHD re-use in no outbound scenarios ([#3897](https://github.com/Azure/aks-engine/issues/3897))

### Testing 💚
- more resilient azure-arc-onboarding E2E ([#4069](https://github.com/Azure/aks-engine/issues/4069))
- use 3 control plane VMs for base test config ([#4075](https://github.com/Azure/aks-engine/issues/4075))
- dns-liveness livenessProbe tweaks ([#4080](https://github.com/Azure/aks-engine/issues/4080))
- disable useManagedIdentity default value on Azure Stack ([#4063](https://github.com/Azure/aks-engine/issues/4063))
- skip rotate docker log tests if omsagent ([#4059](https://github.com/Azure/aks-engine/issues/4059))
- only test flannel + containerd thru k8s 1.19 ([#4041](https://github.com/Azure/aks-engine/issues/4041))
- re-engage cluster-autoscaler tests if no ssh ([#4034](https://github.com/Azure/aks-engine/issues/4034))
- add dns-loop (actually curl) stress test ([#4024](https://github.com/Azure/aks-engine/issues/4024))
- configurable stability iterations timeout ([#4022](https://github.com/Azure/aks-engine/issues/4022))
- fix two UTs to work with "cli" auth ([#3995](https://github.com/Azure/aks-engine/issues/3995))
- ensure azure-kms-provider E2E coverage ([#3985](https://github.com/Azure/aks-engine/issues/3985))
- "useManagedIdentity": false for VMSS masters ([#3981](https://github.com/Azure/aks-engine/issues/3981))
- Retry label when cluster first comes online ([#3976](https://github.com/Azure/aks-engine/issues/3976))
- Jenkinsfile bool vars ([#3980](https://github.com/Azure/aks-engine/issues/3980))
- Windows Metrics failure when High CPU  ([#3962](https://github.com/Azure/aks-engine/issues/3962))
- validate azure arc in everything config ([#3961](https://github.com/Azure/aks-engine/issues/3961))
- CCM + azurefile + MSI test scenarios ([#3932](https://github.com/Azure/aks-engine/issues/3932))
- skip tests for flatcar cluster config ([#3921](https://github.com/Azure/aks-engine/issues/3921))
- Add azure.json path for custom cloud k8s config & Update stability timeout for Azure CNI network policy ([#3895](https://github.com/Azure/aks-engine/issues/3895))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.58.0...HEAD
[v0.58.0]: https://github.com/Azure/aks-engine/compare/v0.57.0...v0.58.0