### PR TITLE
helm 3.4.2

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.4.1"
+local version = "3.4.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d",
+            sha256 = "c33b7ee72b0006f23b33f5032b531dd609fff7b08a4324f9ba07722a4f3fec9a",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420",
+            sha256 = "cacde7768420dd41111a4630e047c231afa01f67e49cc0c6429563e024da4b98",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "45b210c55851dfeebf33d42bbfee14500b8fd7db4289f4d59e3b7e351e354646",
+            sha256 = "c7df94d515bae7cd787182d13d718fa824521b2813a0647b23d99b607128fcca",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.4.2. 

# Release info 

 Helm v3.4.2 is a patch release. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.4.2. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.4.2-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-darwin-amd64.tar.gz.sha256sum) / c33b7ee72b0006f23b33f5032b531dd609fff7b08a4324f9ba07722a4f3fec9a)
- [Linux amd64](https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz.sha256sum) / cacde7768420dd41111a4630e047c231afa01f67e49cc0c6429563e024da4b98)
- [Linux arm](https://get.helm.sh/helm-v3.4.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-arm.tar.gz.sha256sum) / feafaebe64f0fa4228d5b2014defb462d1898fcddbd33a1c34531cbad24e159f)
- [Linux arm64](https://get.helm.sh/helm-v3.4.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-arm64.tar.gz.sha256sum) / 486cad35b9ac1da88781847f2fcaaaed729e44705eb42593322e4b52d0f2c1a1)
- [Linux i386](https://get.helm.sh/helm-v3.4.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-386.tar.gz.sha256sum) / c7a4872d7409bc2840a2c82380b2abbd94b69b4264fad08ed8bb2a4cc617118e)
- [Linux ppc64le](https://get.helm.sh/helm-v3.4.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-ppc64le.tar.gz.sha256sum) / 52062596e5625a3238c6b967d31cf6ec1f0fd5926d2443a1179aeb91ed14d539)
- [Linux s390x](https://get.helm.sh/helm-v3.4.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.4.2-linux-s390x.tar.gz.sha256sum) / c33b7ee72b0006f23b33f5032b531dd609fff7b08a4324f9ba07722a4f3fec9a)
- [Windows amd64](https://get.helm.sh/helm-v3.4.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.4.2-windows-amd64.zip.sha256sum) / 76ff3f8c21c9af5b80abdd87ec07629ad88dbfe6206decc4d3024f26398554b9)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.5.0 is the next feature release. This will be released on January 13. 2021.

## Changelog

- Updating to Kubernetes 1.19.4 package versions 23dd3af5e19a02d4f4baa5b2f242645a1a3af629 (Matt Farina)
- fix: ingress path issue 3ba833f5ad97c157a3a27b9985d6f0c660db901e (Salim Salaues)