### PR TITLE
clusterctl 0.3.12

### DIFF
--- a/Food/clusterctl.lua
+++ b/Food/clusterctl.lua
@@ -1,5 +1,5 @@
 local name = "clusterctl"
-local version = "0.3.11"
+local version = "0.3.12"
 local release = "v" .. version
 local org = "kubernetes-sigs"
 local repo = "cluster-api"
@@ -16,7 +16,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
             -- shasum of the release archive
-            sha256 = "87dc72d13e10e35ccfef0968f32038d45fb94bf3ed1d270de3f0ce108269b307",
+            sha256 = "4d6e5882588f2369e599b3b0d7673ab152215853832c70264ef6707dcf98c62a",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -30,7 +30,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
             -- shasum of the release archive
-            sha256 = "9e914628c9bd1ca32137cbb763dc781e6c4570f02912c69c50baf65ece002303",
+            sha256 = "26a6247e73bab4c113114e7c88368abdaaaf67522955a3024731cd12544b326d",
             resources = {
                 {
                     path = name .. "-linux-amd64",


### PR DESCRIPTION
Updating package clusterctl to release v0.3.12. 

# Release info 

 Changes since v0.3.11
---
## :sparkles: New Features
- Use uncached client and partial metadata for secret and configmaps (#3986) — Impact: Reduced memory usage, the controller now hits the API Server directly when querying for Secrets and ConfigMap resources, instead of building a local cache of all objects in all watched namespaces.
- Add Cluster API GCP Provider to clusterctl providers list (#4008)

## :bug: Bug Fixes
- MachineHealthCheck now sorts status targets to avoid continuous patches (#3998)
- KubeadmControlPlane scale down checks should exclude machines about to be deleted (#3984)
- KubeadmControlPlane should use its own NodeRefs when reconciling etcd members (#3971) — Impact: Solves a race condition between the controller trying to upgrade a cluster and the Kubernetes node not being fully registered yet in the list of nodes as a control-plane.
- Properly check errors.Cause when checking with apierrors (#3969) — Impact: Solves an issue where the Machine deletion would get stuck or timeout after a number of retries.
- Rotate MachinePool bootstrap token (#3965) — Impact: MachinePool bootstrap token were not previously rotated, and expired after 15m. With this change, new MachinePool instances should be able to join the cluster after the timeout. 

## :book: Documentation
- Updating Cluster API OpenStack variables in Quick Start (#3952)

## :seedling: Others
- Move @ncdc to emeritus (#4010) — A huge thanks to Andy for his immense work in the Cluster API community and leadership. 🤗 
- Un-deprecate OwnedConditions and WithOwnedConditions (#3936)

_Thanks to all our contributors!_ 😊