### PR TITLE
gh 1.4.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "1.3.1"
+local version = "1.4.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "96d7f4c85a24f0b83e0451a313eb7097275aa25c325b6e6639033459fdbe62ec",
+            sha256 = "9a9d0139267e91d06b5dff4f5947d3b89c98a4ae2534acd7beb8ac74baf8dde2",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "20ab593cb3c66b16e22058a9d9fc28d75d281513b8afc3de00adf58fb0d1639f",
+            sha256 = "bea14d3f99da06ac4c1d162f80345fb5c094202130d799e1a5fab3e629edbaa6",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "467f7bd00a89b5506068bbe3932e57d1394f05770019aeb1bf4fd33a03ab2ced",
+            sha256 = "007b640ae0867e9560f143f5cbc1353669ad32713b57f65af1ef510865bea8d3",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v1.4.0. 

# Release info 

 ## New features

### View issue and pull request comment threads (#2462, #2575)

`gh issue view` and `gh pr view` commands now include the latest comment in their output. To render the entire comment thread, use the new `--comments` flag:

```sh
$ gh issue view <number> --comments
```

Note that, for now, `gh pr view` will only render regular comments and not review comments.

### Manage GitHub Actions secrets (#2529)

The new `gh secret` commands enables setting, listing, and removing secrets for a repository or an organization. For example, to set a repository secret from file:

```sh
$ gh secret set MY_SECRET < file.txt
```

To manage organization secrets, you will need to require an additional permission scope for GitHub CLI:

```
$ gh auth refresh --scopes admin:org
```

For more information, see [`gh help secret set`](https://cli.github.com/manual/gh_secret_set).

### Set up git credentials when logging into GitHub CLI (#2449)

The `gh auth login` flow now includes a step to authenticate git as well when "HTTPS" is selected as the default clone protocol. This enables operations like `git clone`, `git push`, etc. to automatically work with GitHub on a pristine system after the user has authenticated to GitHub CLI. Previously, users had to authenticate git separately.

This is enabled by the git credential helper. In the background, GitHub CLI runs this for the user:

```sh
$ gh auth login
#=> git credential approve <<<"url=https://USERNAME:TOKEN@github.com"
```

If no git credential helper was configured on the system, `gh` configures git to set itself as the credential helper for GitHub.

If you had already logged in with GitHub CLI, you can sync your git credentials with those of GitHub CLI with:

```sh
$ gh auth refresh --scopes workflow
# (the additional "workflow" scope is required for pushing changes to any Actions workflow files)
```

### Build system

* Statically build our Linux binaries so they work on Alpine Linux  #2556

* Add `armv6` build for Raspberry Pi #2621

* Add `make install`, `make uninstall` targets for POSIX systems when building from source #2455

## Fixes

* `pr merge`: attempt the merge even if mergeability status could not be determined  #2582

* `repo clone`: enable cloning repository wikis  #2493

* Recognize `Include` directives when parsing ssh config files  #2230

* Display the new release notice only once per 24 hours  #2488
