### PR TITLE
minikube 1.16.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.15.1"
-local version = "1.15.1"
+local release = "v1.16.0"
+local version = "1.16.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "ab47a4e3ff742db8a88d7bf0fe9cb9c6805e6f1df2545d8888f196c46b96f714",
+            sha256 = "546329a1a2448e1e8a483241c23a3ca272bd795df5a78bd6bf922699d3a75823",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "9a3fd31d044700fd6d0cb527bc4d75b664c8a5335b41172f6ec0dd70fa384b61",
+            sha256 = "c983b49af25f3b18720c255952ba25a11658778dde46b2cf117d5db791fcbb81",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "88c3bfac3880e897e4d032801b02f02fdda642b75d76ebeb5df545cd90eee409",
+            sha256 = "af29a48b2d79075f9d57be3a28724eef2cd628bb87283ed58dd72cbe1f8967c4",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "28273a9bf727dc48a61ee1b3f513464bfabcfa5fba721b9f6217d33eb487ed03",
+            sha256 = "9afa0d7343d8f35758cdff7b9d37cd9bfadb126c109ea1e0df9ed0444c331463",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "89e34d6137bba7a59b74e138af28746b883bb605cbf2d37c1ff29dce008050e8",
+            sha256 = "8928ad4ddcbcf203bf688be6fac826d12483116b4ac0625f28dbb8ab6a278979",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "4ea71f9c539e9336b17b42b5e0aa06caa1b40300f560e642e841d63febdbea95",
+            sha256 = "d52b4ceb182cf7d69e9a1d04b33dd7525a27ef15a7a0b071f904cc2a8ad4d86e",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.16.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.16.0 - 2020-12-17
* fix ip node retrieve for none driver [#9986](https://github.com/kubernetes/minikube/pull/9986)
* remove experimental warning for multinode [#9987](https://github.com/kubernetes/minikube/pull/9987)
* Enable Ingress Addon for Docker Windows [#9761](https://github.com/kubernetes/minikube/pull/9761)
* Bump preload to v8 to include updated dashboard [#9984](https://github.com/kubernetes/minikube/pull/9984)
* Add ssh-host command for getting the ssh host keys [#9630](https://github.com/kubernetes/minikube/pull/9630)
* Added sub-step logging to adm init step on start [#9904](https://github.com/kubernetes/minikube/pull/9904)
* Add --node option for command `ip` and `ssh-key` [#9873](https://github.com/kubernetes/minikube/pull/9873)
* Upgrade Docker, from 20.10.0 to 20.10.1 [#9966](https://github.com/kubernetes/minikube/pull/9966)
* Upgrade kubernetes dashboard to v2.1.0 for 1.20 [#9963](https://github.com/kubernetes/minikube/pull/9963)
* Upgrade buildkit from 0.8.0 to 0.8.1 [#9967](https://github.com/kubernetes/minikube/pull/9967)

Thank you to our contributors for this release!

- Anders F Björklund
- Jituri, Pranav
- Ling Samuel
- Sharif Elgamal
- Steven Powell
- Thomas Strömberg
- priyawadhwa
- wangxy518

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`acbd805831ad3afe8935c6e28888a414e9cde952afe5b574b9f44c853bde8814`