### PR TITLE
flux 0.5.7

### DIFF
--- a/Food/flux.lua
+++ b/Food/flux.lua
@@ -1,0 +1,51 @@
+local name = "flux"
+local org = "fluxcd"
+local release = "v0.5.7"
+local version = "0.5.7"
+food = {
+    name = name,
+    description = "Open and extensible continuous delivery solution for Kubernetes",
+    license = "Apache-2.0",
+    homepage = "https://toolkit.fluxcd.io",
+    version = version,
+    packages = {
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
+            sha256 = "f7d4322a80edb4bc8d4184171e2c2bbda1db769fd1cbac131e397c813de74c84",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
+            sha256 = "c5bd4548548234c0de94ac94ebfae8506ff79fbff58170bacce0c34468a280d0",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
+            sha256 = "4563953bb40d76acbe6b1c49ea58126b8af6e24bdaa84297b3aa443b8a065615",
+            resources = {
+                {
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds flux (aka flux2), which is the next version of the [flux project](https://fluxcd.io/). The binary has been changed from fluxctl to flux.