### PR TITLE
jq: fix semver

### DIFF
--- a/Food/jq.lua
+++ b/Food/jq.lua
@@ -1,5 +1,6 @@
 local name = "jq"
-local version = "1.6"
+local version = "1.6.0"
+local release = "1.6"
 
 food = {
     name = name,
@@ -11,7 +12,7 @@ food = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. version .. "/" .. name .. "-osx-amd64",
+            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. release .. "/" .. name .. "-osx-amd64",
             sha256 = "5c0a0a3ea600f302ee458b30317425dd9632d1ad8882259fcaf4e9b868b2b1ef",
             resources = {
                 {
@@ -24,7 +25,7 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. version .. "/" .. name .. "-linux64",
+            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. release .. "/" .. name .. "-linux64",
             sha256 = "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44",
             resources = {
                 {
@@ -37,7 +38,7 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. version .. "/" .. name .. "-win64.exe",
+            url = "https://github.com/stedolan/jq/releases/download/" .. name .. "-" .. release .. "/" .. name .. "-win64.exe",
             sha256 = "a51d36968dcbdeabb3142c6f5cf9b401a65dc3a095f3144bd0c118d5bb192753",
             resources = {
                 {


### PR DESCRIPTION
jq does not use a traditional semver. gofish will parse a semver number
(1.6.0 vs. 1.6) and will continually upgrade jq.

Fixes #1138
