### PR TITLE
buffalo 0.16.18

### DIFF
--- a/Food/buffalo.lua
+++ b/Food/buffalo.lua
@@ -1,5 +1,5 @@
 local name = "buffalo"
-local version = "0.16.17"
+local version = "0.16.18"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Darwin_x86_64.tar.gz",
-            sha256 = "31973a20c73f17840d99d495c536c9cd3d3433de831dc670538d0e20555b2871",
+            sha256 = "7b7e22e553e759ff53ebbf6cd286119960379a2cf5571aef400ac089906450cf",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux_x86_64.tar.gz",
-            sha256 = "4c52c2325a968b2cf840962df211fbd7e34dd92f7a552c7fa6c746e5c5c04f09",
+            sha256 = "b73b61d91eaa016b641f8b3561c9c2ad21939d1d10623b534fe6b05954705a8d",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gobuffalo/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows_x86_64.tar.gz",
-            sha256 = "55912ad35f246e407ca9e685b13d499f506d4cefca55928bc644490727550eca",
+            sha256 = "3a5653ca3aa2c0d1d936e51a1e8d7497efdf1711d5a4fe3250ceabe8fc5878d3",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package buffalo to release v0.16.18. 

# Release info 

 [Fix] prevents error when attempting to write twice to the http response header.
[Enhancement] Allows to specify custom `partialFeeder` helper.