### PR TITLE
bicep 0.2.212

### DIFF
--- a/Food/bicep.lua
+++ b/Food/bicep.lua
@@ -1,5 +1,5 @@
 local name = "bicep"
-local version = "0.2.59"
+local version = "0.2.212"
 local release = "v" .. version
 
 
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-osx-x64",
             -- shasum of the release archive
-            sha256 = "9b07831f1ac59a613ed8f95f23e691387ad2f3f0d70872b0b4737c4736c09013",
+            sha256 = "fe47919059bf1334c1e3453e4f760fe1b41ca04b99d219acd3c34f4cca522dd7",
             resources = {
                 {
                     path = name .. "-osx-x64",
@@ -28,7 +28,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-x64",
             -- shasum of the release archive
-            sha256 = "13eefdbe105b8a162b3bdebf247fc6ec3fb7cf838c917d04775249531ba70873",
+            sha256 = "ba1ba9a199f0f1c12c24757c14f80f65a755f822115e0e471a61801bd4a02593",
             resources = {
                 {
                     path = name .. "-linux-x64",
@@ -42,7 +42,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-win-x64.exe",
             -- shasum of the release archive
-            sha256 = "150f1cb9be8c9fd0b15fce653f1def1920b88462fa76ee7e183a755d5857a533",
+            sha256 = "c42d99dfe9123298aef15271320974520548a0fda5abaf15f21fa1337eb6bbfc",
             resources = {
                 {
                     path = name .. "-win-x64.exe",


### PR DESCRIPTION
Updating package bicep to release v0.2.212. 

# Release info 

 ## Highlights

* Support for conditional resources (#1014) [spec](https://github.com/Azure/bicep/blob/main/docs/spec/resources.md#conditions)
  * Supported for decompilation (#1150)
* Support for the `scope` property for extension resources (#1162) [spec](https://github.com/Azure/bicep/blob/main/docs/spec/resource-scopes.md#resource-scope-property)
  * This allows you to configure resources like resource locks and role assignments on individual resources
  * Supported for decompilation (#1190)
* Major perf improvement when loading the extension (#1147)

## Feature work and bug fixes

Bicep team:
* Add type definition for properties.templateLink.uri to deployments() return value (#986)
* Remove some limitations for decompiling nested/linked templates (#1001)
* Allow the list() function (#1065)
* Emit location automatically for non-rg module scopes (#1129)
* Allow cross-subscription deployments (#1165)
* Fix inlining behavior for modules (#1181)
* Set intellisense defaults (#1019)
* Fixed declaration type completions when extra whitespace is present (#1107)
* Fixed functions signatures in vararg functions (#1124)
* Added a function overload builder (#1126)
* upload language server artifact (#1152)
* Added function descriptions and parameter names (#1180)
* Implement retrying logic for VSCode E2E tests (#1096)
* Use relative path for user data and add logging (#1112)
* Fix an example file (#1184)


@miqm:
* Expanding Completion of objects & arrays to multiple lines (#1012)
  
@ljtill:
* Update bicep.rb (#993)

## Doc updates

Bicep team:
* Add pointer to playground for decompilation (#1005)
* Brief document on `decompile` command (#998)
* Add decompiler info to README (#1172)

@JFolberth:
* Update CONTRIBUTING.md (#1068)

@jongio:
* Add blank file create command (#1008)

@vhorne:
* Update 01-simple-template.md (#1062)
* Update 01-simple-template.md (#1063)

@StefanIvemo:
* Updated 02-deploying-a-bicep-file.md (#1070)
* Updated 06-convert-arm-template.md (#1074)

@miqm:
* Update CONTRIBUTING.md with instruction to run Bicep VSCode extension when using WSL2 (#972)

@lawrencegripper:
* Add note about using devcontainer to get started (#1090)

@emilguden:
* Update 02-deploying-a-bicep-file.md (#1157)
* Update 03-using-expressions.md (#1160)
* Update 04-using-symbolic-resource-name.md (#1163)


## Examples

Bicep team:
* deployment script example with no managed identity (#1006)

@fberson:
* TypeDiagnostics DesktopVirtualization (#1007)
* Bicep file that creates a basic WVD Backplane (#1003)
* added wvd-backplane example (#1009)
* diagnosticSettings WVD Workspaces (#1011)
* multi-module WVD deployment with some prereqs (#1010)
* Added readme.md (#1047)

@JFolberth:
* adding windows web app (#996)
* Added DataFactory Blob Copy Example, reordered missing types tests (#999)
* ReOrder examples on how they appear in Playground (#1040)
* Update CONTRIBUTING.md (#1068)
* Cosmosdb free (#1110)
* adding eventhub and missing type (#1111)

@miqm:
* [Example] Function App on Consumption Plan with Custom Domain and App Serivce Managed Certificate (#971)

@StefanIvemo:
* Added example modules-vwan-to-vnet-s2s-with-fw (#1018)

@wilfriedwoivre:
* Add sample for custom role definition and assignment (#1045)

@lr90:
* LR90 aadds example (#1158)

@MarcusFelling:
* Add web-app-linux example (#1148)

@mbsnl:
* Example: Azure Front Door w/ Web Application Firewall (#1076)

@MCKLMT:
* Add Data Lake Store example (#1029)
* Add Azure Search example (#1025)
* Add SQL database example (#1022)
* Add Azure DataFactory example (#1027)
* Add ACI Linux Public IP example (#1039)
* Add VM domain join example (#1038)
* Add API management with MSI example (#1037)
* Add ServiceBus and Queue example (#1032)
* Add VM scaleset with autoscaling example (#1033)
* Add Application Gateway v2 example (#1036)
* Add CDN with storage account example (#1030)
* Add WebApp and SQL database example (#1034)
* Add Cognitive Services example (#1052)
* Add WebApps Private Endpoint and Vnet-Injection example (#1053)
* Add expressroute-circuit-create example (#1059)
* Add function-premium-vnet-integration example (#1057)
* Add event-hub-and-consumer-group example (#1056)
* Add ServiceBus Namespace VNet (#1054)
* Add missing examples and sort them by name (#1066)
* Add nat-gateway-vnet example (#1091)
* Add azure-bastion example (#1122)
* Add azurefirewall-create-with-zones example (#1144)
* Add cosmosdb-private-endpoint example (#1127)
* Add hdinsight-spark-linux example (#1128)
* Add private-dns-zone example (#1130)
* Add azure-spring-cloud example (#1133)
* Add azure-sentinel example (#1132)
* Add aci-sftp-files example (#1159)
* Add api-management-create-all-resources example (#1131)