### PR TITLE
crictl 1.20.0

### DIFF
--- a/Food/crictl.lua
+++ b/Food/crictl.lua
@@ -1,5 +1,5 @@
 local name = "crictl"
-local version = "1.19.0"
+local version = "1.20.0"
 local repo = "cri-tools"
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "83f3c232c0958d836330fb04ff94a53d93abcc710e4f7a93a17a710e04421b60",
+            sha256 = "53cec377b002c2514036de0baca58aedc0c173ab45db42be0ab9bd42df6b4967",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae",
+            sha256 = "44d5f550ef3f41f9b53155906e0229ffdbee4b19452b4df540265e29572b899c",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. repo .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "df60ff65ab71c5cf1d8c38f51db6f05e3d60a45d3a3293c3248c925c25375921",
+            sha256 = "cc909108ee84d39b2e9d7ac0cb9599b6fa7fc51f5a7da7014052684cd3e3f65e",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package crictl to release v1.20.0. 

# Release info 

 # Changelog since v1.19.0

## Changes by Kind

### API Change

- Update the `timeout` option in create, run, runp requests to be `cancel-timeout` ([#668](https://github.com/kubernetes-sigs/cri-tools/pull/668), [@haircommander](https://github.com/haircommander))

### Feature

- Add `timeout` option to create, run, runp requests, allowing users to cancel CRI requests after a timeout ([#666](https://github.com/kubernetes-sigs/cri-tools/pull/666), [@haircommander](https://github.com/haircommander))

### Documentation

- Add getting started w/development guide ([#667](https://github.com/kubernetes-sigs/cri-tools/pull/667), [@adams0619](https://github.com/adams0619))

## Dependencies

### Added
_Nothing has changed._

### Changed
- github.com/docker/docker: [7ae5222 → c710949](https://github.com/docker/docker/compare/7ae5222...c710949)
- github.com/golang/protobuf: [v1.4.2 → v1.4.3](https://github.com/golang/protobuf/compare/v1.4.2...v1.4.3)
- github.com/google/go-cmp: [v0.4.0 → v0.5.0](https://github.com/google/go-cmp/compare/v0.4.0...v0.5.0)
- github.com/google/uuid: [v1.1.1 → v1.1.2](https://github.com/google/uuid/compare/v1.1.1...v1.1.2)
- github.com/onsi/ginkgo: [v1.14.0 → v1.14.2](https://github.com/onsi/ginkgo/compare/v1.14.0...v1.14.2)
- github.com/onsi/gomega: [v1.10.1 → v1.10.3](https://github.com/onsi/gomega/compare/v1.10.1...v1.10.3)
- github.com/sirupsen/logrus: [v1.6.0 → v1.7.0](https://github.com/sirupsen/logrus/compare/v1.6.0...v1.7.0)
- github.com/urfave/cli/v2: [v2.2.0 → v2.3.0](https://github.com/urfave/cli/v2/compare/v2.2.0...v2.3.0)
- golang.org/x/net: c890458 → ff519b6
- golang.org/x/sys: f9321e4 → 4d91cf3
- google.golang.org/grpc: v1.31.1 → v1.33.2
- google.golang.org/protobuf: v1.24.0 → v1.25.0

### Removed
_Nothing has changed._


## Downloads

| file | sha256 |
| --------------- | ------- |
| [crictl-v1.20.0-darwin-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-darwin-amd64.tar.gz) |  53cec377b002c2514036de0baca58aedc0c173ab45db42be0ab9bd42df6b4967 |
| [crictl-v1.20.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-386.tar.gz) |  13ab9493cefca1d1ac5848ed52572e2ee5518a5bf2c527c0e5ed75b0e5c42c39 |
| [crictl-v1.20.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-amd64.tar.gz) |  44d5f550ef3f41f9b53155906e0229ffdbee4b19452b4df540265e29572b899c |
| [crictl-v1.20.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-arm64.tar.gz) |  eda6879710eb046d335162d4afe8494c6f8161142ad3188022852f64b92806a8 |
| [crictl-v1.20.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-arm.tar.gz) |  ed5ffdd386261ec1146731421d4ac9c5c7f91e08486fee409452a3364bef792a |
| [crictl-v1.20.0-linux-ppc64le.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-ppc64le.tar.gz) |  da0c052983ba884f9605b14bf627664df67fcdb41c7f6908368bf4745f889b26 |
| [crictl-v1.20.0-linux-s390x.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-linux-s390x.tar.gz) |  88e1e41502e6f649e1a9dd0392d6ddec1854d6cd9d826b69d092e80d74fc4aca |
| [crictl-v1.20.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-windows-386.tar.gz) |  b37edede7e4eb11247f5677f4cab1a8bca4ea1bc26a5c6b3ee599adddc01f926 |
| [crictl-v1.20.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/crictl-v1.20.0-windows-amd64.tar.gz) |  cc909108ee84d39b2e9d7ac0cb9599b6fa7fc51f5a7da7014052684cd3e3f65e |
| [critest-v1.20.0-darwin-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-darwin-amd64.tar.gz) |  25cecd5689a898aaf84e27a2678b18fb57922d6d0cba6bca914f72cd02d14974 |
| [critest-v1.20.0-linux-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-linux-386.tar.gz) |  5e30db24b22427a9179c31ff3f434b4e55962f2ac98ba9867ae55fcf02776931 |
| [critest-v1.20.0-linux-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-linux-amd64.tar.gz) |  bf5a7f185bd5ba48b3188eaff11f4d371000b3f4af92792706c088c5a289c74d |
| [critest-v1.20.0-linux-arm64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-linux-arm64.tar.gz) |  83ff22f55af8c13da3eaca46ba41bae5e5e77d61eb444bd5d9095529bc68d532 |
| [critest-v1.20.0-linux-arm.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-linux-arm.tar.gz) |  064d333a42bd8cb4fc5205b41850bb252685b65e44b5ca411735062c0fa47f2a |
| [critest-v1.20.0-windows-386.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-windows-386.tar.gz) |  2ded93a40cd03b637b84f9059b66ea999f276cc6bbf2f0fc75bea25f9537c6ed |
| [critest-v1.20.0-windows-amd64.tar.gz](https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.20.0/critest-v1.20.0-windows-amd64.tar.gz) |  e04cb23c3b446f11a90a917846064a323a65867254203db9bd067b86da7f4c8d |
