### PR TITLE
fluxctl 1.21.1

### DIFF
--- a/Food/fluxctl.lua
+++ b/Food/fluxctl.lua
@@ -1,7 +1,7 @@
 local name = "fluxctl"
 local org = "fluxcd"
-local release = "1.21.0"
-local version = "1.21.0"
+local release = "1.21.1"
+local version = "1.21.1"
 food = {
     name = name,
     description = "The GitOps Kubernetes operator",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_darwin_amd64",
-            sha256 = "84dc0e54a652ddbf4cf38e7c487bbbc0187d65d9b78406fc351272ca9c664c29",
+            sha256 = "70f9779cfdc38fae844d92d5504d12dff4edb47c03f5f87f39cc602d8268c2df",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_linux_amd64",
-            sha256 = "b429f7bf20703fa2ebbd4b7b2955fb787545e0dc424c17c1d654caea24910653",
+            sha256 = "29f55ca6fc528d2064191071b18d7fa26f56a53fa3e1316dc4d896465c58bf72",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_windows_amd64",
-            sha256 = "3f137446a7313613bc07768448091a21397616921c05b7bb1bdbca4f46d7ced8",
+            sha256 = "fd8c3b2330585691f56c58b7a5e429bd71d156fea6f33af4e06bb5a1f10881a5",
             resources = {
                 {
                     path = name .. "_windows_amd64",


### PR DESCRIPTION
Updating package fluxctl to release 1.21.1. 

# Release info 

 ### Fixes

- Fix shell completion [fluxcd/flux#3355][]
- Optional command timeout field in .flux.yaml [fluxcd/flux#3228][]

### Maintenance and documentation

- Add to list of production users [fluxcd/flux#3386][],
  [fluxcd/flux#3247][], [fluxcd/flux#3360][], [fluxcd/flux#3290][],
  [fluxcd/flux#3315][], [fluxcd/flux#3280][]
- Let productions users table reflow better [fluxcd/flux#3376][]
- Upgrade json-patch to v4.9.0 [fluxcd/flux#3373][]
- snap: move to core20 [fluxcd/flux#3371][]
- snap: update build to use go 1.15 [fluxcd/flux#3345][]
- Update engineerd/setup-kind to v0.5.0 [fluxcd/flux#3364][]
- Use fossa-contrib/fossa-action instead [fluxcd/flux#3331][]
- Fixup configmap in Git GPG documentation [fluxcd/flux#3311][]
- Add maintenance note to GitHub templates and README
  [fluxcd/flux#3321][], [fluxcd/flux#3333][]
- Move Fons to maintainer emeritus [fluxcd/flux#3319][]
- Point to Flagger website [fluxcd/flux#3391][]
- Specific documentation for HelmRelease Automation
  [fluxcd/flux#3144][]

### Thanks

Thanks to @SimonyanG, @alanjcastonguay, @alisondy, @austinbv,
@daniswoop, @demon, @dholbach, @douglasquintanilha, @gaffneyd4,
@joaovitor, @kingdonb, @lalyos, @marshallford, @mcanaves, @mewzherder,
@smorimoto, @squaremo and @stefansedich for their contributions to
this release.

[fluxcd/flux#3391]: https://github.com/fluxcd/flux/pull/3391
[fluxcd/flux#3386]: https://github.com/fluxcd/flux/pull/3386
[fluxcd/flux#3376]: https://github.com/fluxcd/flux/pull/3376
[fluxcd/flux#3373]: https://github.com/fluxcd/flux/pull/3373
[fluxcd/flux#3371]: https://github.com/fluxcd/flux/pull/3371
[fluxcd/flux#3364]: https://github.com/fluxcd/flux/pull/3364
[fluxcd/flux#3360]: https://github.com/fluxcd/flux/pull/3360
[fluxcd/flux#3355]: https://github.com/fluxcd/flux/pull/3355
[fluxcd/flux#3345]: https://github.com/fluxcd/flux/pull/3345
[fluxcd/flux#3333]: https://github.com/fluxcd/flux/pull/3333
[fluxcd/flux#3331]: https://github.com/fluxcd/flux/pull/3331
[fluxcd/flux#3321]: https://github.com/fluxcd/flux/pull/3321
[fluxcd/flux#3319]: https://github.com/fluxcd/flux/pull/3319
[fluxcd/flux#3315]: https://github.com/fluxcd/flux/pull/3315
[fluxcd/flux#3311]: https://github.com/fluxcd/flux/pull/3311
[fluxcd/flux#3290]: https://github.com/fluxcd/flux/pull/3290
[fluxcd/flux#3280]: https://github.com/fluxcd/flux/pull/3280
[fluxcd/flux#3247]: https://github.com/fluxcd/flux/pull/3247
[fluxcd/flux#3228]: https://github.com/fluxcd/flux/pull/3228
[fluxcd/flux#3144]: https://github.com/fluxcd/flux/pull/3144
