### PR TITLE
golangci-lint 1.35.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.34.1"
+local version = "1.35.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "6c3d87f9f6bccd5954de9954c1e75d7b521abdcc956e0643929a75cbf4c00aad",
+            sha256 = "3d6b79a3386728c524e95390c3b564e6de33e6d67d33b8dcdf361f0a79596d57",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "23e4a9d8f89729007c6d749c245f725c2dbcfb194f4099003f9b826f1d386ad1",
+            sha256 = "d0c0793fe4a6e752c724eb13e01b27aa4ab37e32c5e99a4d8a4b8594cb5d77bd",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "04473b63ee17374e7a55fd7ebe7fe97bc510ae9883e9214798dae8e67de4ba48",
+            sha256 = "b64a240ba7919c45b2dab0ff26c47900033e406b54b94ac2abeffe15a54a5276",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.35.0. 

# Release info 

 ## Changelog

b3491fd Update docs for v1.34.1 release  (#1591)
62710a8 Validate gocritic settings. Return error if settings includes a unsupported gocritic checker (#1563)
76c4521 add 'predeclared' linter (#1606)
c0ad76f build(deps): bump @emotion/core from 10.0.35 to 10.1.1 in /docs (#1625)
5521750 build(deps): bump @mdx-js/mdx from 1.6.18 to 1.6.22 in /docs (#1624)
75a29b7 build(deps): bump gatsby from 2.29.2 to 2.29.3 in /docs (#1627)
8a87f77 build(deps): bump gatsby-plugin-canonical-urls in /docs (#1619)
da67d3e build(deps): bump gatsby-plugin-catch-links in /docs (#1603)
7b070ed build(deps): bump gatsby-plugin-google-analytics in /docs (#1604)
4bdd488 build(deps): bump gatsby-plugin-manifest from 2.4.27 to 2.9.1 in /docs (#1607)
04b4943 build(deps): bump gatsby-plugin-mdx from 1.2.43 to 1.7.1 in /docs (#1615)
cfbbead build(deps): bump gatsby-plugin-netlify from 2.3.13 to 2.8.0 in /docs (#1628)
81bf16c build(deps): bump gatsby-plugin-offline from 3.2.27 to 3.7.1 in /docs (#1613)
4adc65e build(deps): bump gatsby-plugin-react-helmet in /docs (#1621)
c7f10f4 build(deps): bump gatsby-plugin-sharp from 2.6.40 to 2.11.2 in /docs (#1609)
986732a build(deps): bump gatsby-plugin-sitemap from 2.4.14 to 2.9.0 in /docs (#1605)
8fa1ae3 build(deps): bump gatsby-remark-autolink-headers in /docs (#1611)
a39435d build(deps): bump gatsby-remark-copy-linked-files in /docs (#1620)
a4050b3 build(deps): bump gatsby-remark-embedder from 4.0.0 to 4.1.0 in /docs (#1616)
da560fe build(deps): bump gatsby-remark-images from 3.6.0 to 3.8.1 in /docs (#1601)
9959e5f build(deps): bump gatsby-remark-responsive-iframe in /docs (#1610)
571a477 build(deps): bump gatsby-source-filesystem from 2.3.30 to 2.8.1 in /docs (#1617)
e84a8d0 build(deps): bump gatsby-transformer-remark in /docs (#1612)
b45dffa build(deps): bump gatsby-transformer-sharp from 2.5.15 to 2.9.0 in /docs (#1608)
fdb4e86 build(deps): bump gatsby-transformer-yaml from 2.4.11 to 2.8.0 in /docs (#1622)
5c9e386 build(deps): bump github.com/go-critic/go-critic from 0.5.2 to 0.5.3 (#1631)
1221939 build(deps): bump github.com/kulti/thelper from 0.1.0 to 0.2.0 (#1630)
eb28c6a build(deps): bump polished from 4.0.3 to 4.0.5 in /docs (#1602)
a64afd8 build(deps): bump puppeteer from 5.4.1 to 5.5.0 in /docs (#1614)
aa6b9fa build(deps): bump react-dom from 16.13.1 to 16.14.0 in /docs (#1618)
13698dc build(deps): bump react-headroom from 3.0.1 to 3.1.0 in /docs (#1629)
90a6919 build(deps): bump react-icons from 3.11.0 to 4.1.0 in /docs (#1626)
1e5ba1e fix: modules-download-mode support (#1593)

