### PR TITLE
aks-engine 0.59.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.58.0"
+local version = "0.59.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "2239bfed4613d7dfdae0c1fd5bf0f764473f566e3c402b9d17a73db4a752dbfc",
+            sha256 = "3a48ffc4111d6a8fd2e56874b6eb1f753d1dda61eadd957dd72ce6cda715990c",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "a7481b603c68c32ae57b5ac376e1205fd69bfa784184dc0a67c8e1bcc704643e",
+            sha256 = "c555e44d2143d023e5a4a71550546907bb950c7188cda7f66e737cc438d31ffa",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "fcfa985180116fa2c842951a428f76dea97bc38d9a8765498df24a862e8195b6",
+            sha256 = "e7e53c087649af91384913a418abce64f3e4cf7009979e2c6aa1e2c3529f8f9b",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.59.0. 

# Release info 

 <a name="v0.59.0"></a>
# [v0.59.0] - 2021-01-13
### Bug Fixes 🐞
- update error code for vhd not found ([#4150](https://github.com/Azure/aks-engine/issues/4150))
- fix that kubeproxy cannot parse featuregates ([#4145](https://github.com/Azure/aks-engine/issues/4145))
- Fixing URl for azure-cni v1.20_hotfix package in Windows VHD ([#4136](https://github.com/Azure/aks-engine/issues/4136))
- ensure we wait for the right CRI service name ([#4115](https://github.com/Azure/aks-engine/issues/4115))
- honor user-defined feature gates before applying defaults ([#4113](https://github.com/Azure/aks-engine/issues/4113))
- typo in upgrade log message ([#4109](https://github.com/Azure/aks-engine/issues/4109))

### Continuous Integration 💜
- add manual dispatch trigger to nightly build ([#4123](https://github.com/Azure/aks-engine/issues/4123))

### Documentation 📘
- support FAQ ([#4148](https://github.com/Azure/aks-engine/issues/4148))
- remove warning about Windows + custom VNET ([#4147](https://github.com/Azure/aks-engine/issues/4147))
- Clarify README for Azure Stack Hub ([#4128](https://github.com/Azure/aks-engine/issues/4128))
- Added references to capz ([#4124](https://github.com/Azure/aks-engine/issues/4124))
- clarify msi as default, and requirements ([#4122](https://github.com/Azure/aks-engine/issues/4122))
- update dualstack docs to 1.20 ([#4101](https://github.com/Azure/aks-engine/issues/4101))

### Features 🌈
- setting a default containerd package for Windows ([#4149](https://github.com/Azure/aks-engine/issues/4149))
- add support for Kubernetes v1.18.14 ([#4139](https://github.com/Azure/aks-engine/issues/4139))
- add support for Kubernetes v1.19.6 ([#4140](https://github.com/Azure/aks-engine/issues/4140))
- add support for Kubernetes v1.17.16 ([#4138](https://github.com/Azure/aks-engine/issues/4138))
- add support for Kubernetes v1.20.1 ([#4141](https://github.com/Azure/aks-engine/issues/4141))
- Add WinDSR support ([#4104](https://github.com/Azure/aks-engine/issues/4104))
- Updating kubelet/kube-proxy to run with as high priority processes ([#4073](https://github.com/Azure/aks-engine/issues/4073))
- Add support for specifying linux moby url ([#4120](https://github.com/Azure/aks-engine/issues/4120))
- Updating Windows VHDs to include Dec 2012 patches ([#4118](https://github.com/Azure/aks-engine/issues/4118))
- add support for Kubernetes v1.18.13 ([#4111](https://github.com/Azure/aks-engine/issues/4111))
- add support for Kubernetes v1.19.5 ([#4110](https://github.com/Azure/aks-engine/issues/4110))
- add support for Kubernetes v1.20.0 ([#4102](https://github.com/Azure/aks-engine/issues/4102))

### Maintenance 🔧
- release Windows VHD for v0.59.0 aks-engine release ([#4158](https://github.com/Azure/aks-engine/issues/4158))
- rev Linux VHDs to 2021.01.08 ([#4159](https://github.com/Azure/aks-engine/issues/4159))
- simplify upgrade templates ([#4135](https://github.com/Azure/aks-engine/issues/4135))
- reinforce upgrade warnings/errors ([#4074](https://github.com/Azure/aks-engine/issues/4074))
- Use signed scripts v0.0.8 for Windows deployments ([#4134](https://github.com/Azure/aks-engine/issues/4134))
- simplify scale templates ([#4131](https://github.com/Azure/aks-engine/issues/4131))
- update Azure CNI to v1.2.0_hotfix ([#4129](https://github.com/Azure/aks-engine/issues/4129))
- update vendor deps ([#4125](https://github.com/Azure/aks-engine/issues/4125))
- rev metrics-server to v0.4.1 for all k8s versions ([#4127](https://github.com/Azure/aks-engine/issues/4127))
- Update moby/containerd versions ([#4119](https://github.com/Azure/aks-engine/issues/4119))
- update csi-secrets-store to v0.0.18 and akv provider to 0.0.11 ([#4126](https://github.com/Azure/aks-engine/issues/4126))
- updating azure-npm to 1.2.1 version ([#4094](https://github.com/Azure/aks-engine/issues/4094))
- Installing Dec 2020 cumulative updates for Windows VHDs ([#4103](https://github.com/Azure/aks-engine/issues/4103))
- update adal to v0.9.6 ([#4093](https://github.com/Azure/aks-engine/issues/4093))
- limit number of upgrade retries if new CP nodes bootstrap fails ([#4068](https://github.com/Azure/aks-engine/issues/4068))
- faster rolling updates for daemonset addons ([#4090](https://github.com/Azure/aks-engine/issues/4090))
- update csi-secrets-store addon manifest and images (v0.0.10) ([#4084](https://github.com/Azure/aks-engine/issues/4084))

### Testing 💚
- enable configurable node prototype tests ([#4100](https://github.com/Azure/aks-engine/issues/4100))
- enable GINKGO_SKIP_AFTER_UPGRADE param in e2e test ([#4089](https://github.com/Azure/aks-engine/issues/4089))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.59.0...HEAD
[v0.59.0]: https://github.com/Azure/aks-engine/compare/v0.58.0...v0.59.0