### PR TITLE
eksctl 0.36.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.35.0"
+local version = "0.36.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "6994ebe657f3c04141e0d243eee216e8738a5272d06efd7c4c225c71cf01c3e5",
+            sha256 = "cb5359d35271296ba547ee98d521d8726ac10bd84ba40c3e2a0f8601e4ffcc6c",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "e17d0a9ddfdf4e85a78eefcd8843d1926be9440de6540a8fc98f023523906dc7",
+            sha256 = "8bc1618ca343c92d65e879c0f824fe67bcb0c388515678e0068a206626a620b3",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "a98c8192a5b26d65c8556b0ba04c6feb8a189825b36c975f6090557112a864da",
+            sha256 = "4f16e8870d2efdffd41ba9df0ec245cf8348f5dfa2bedddb5fd6078a228eca15",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.36.0. 

# Release info 

 # Release 0.36.0

## Features

- Add support for upgrading non-eksctl-created nodegroups (#2953)
- Add support for deleting non-eksctl-created clusters (#2969)

## Improvements

- Do not fail NodeName check when VPC DNS Hostnames is Disabled on Fargate clusters (#2999)
- Fix bootstrap command in the examples (#3003)
- Treat p4d as a GPU instance (#2991)
- Add option to specify IAM role name (#2863)
- Show progress of cluster update (#3023)

## Bug Fixes

- Set cgroupdriver to systemd on GPU nodes (#3007)

## Acknowledgments
Weaveworks would like to sincerely thank:
 @Tolsto, @damerakd, @dbluxo and @samsamoa

