### PR TITLE
skaffold 1.19.0

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,5 +1,5 @@
 local name = "skaffold"
-local version = "1.17.2"
+local version = "1.19.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "1e9ad5ed0ba3b277c582dbdb7e13c3307ff1dc21887bf18d4c5aece486e0518c",
+            sha256 = "049ea7903ad3b8e1f481fd417452ae367c5f6e4e6815c8d949e87742ee0e9e29",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "55dea8be16fa3abd81820a6a03f5d708beb5e152fe71e00f00744a4dd321c55a",
+            sha256 = "d1e508dae168ea546435d177469d9d90344f057f58fe9faf3d210d83d42ec1bb",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "65f107d8fec1b5848c0eb144c3869fd253193b2450cf1f67df9e7c51786fc860",
+            sha256 = "7d62088e24f2a7c2cc3e2da8d292b9d6a0b0f16e9b9f39765034f240e5a24846",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.19.0. 

# Release info 

 # v1.19.0 Release - 01/28/2021

**Linux**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.19.0/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**macOS**
`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.19.0/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**Windows**
 https://storage.googleapis.com/skaffold/releases/v1.19.0/skaffold-windows-amd64.exe

**Docker image**
`gcr.io/k8s-skaffold/skaffold:v1.19.0`

From release v1.19.0, skaffold will collect anonymized Skaffold usage data.

This data will be used to help prioritize features and work on improving Skaffold.  Usage data does not include any argument values or personal information and is strictly anonymized 

You are **opted-in** by default and you can opt-out at any time with the skaffold config command. 

Learn more on what data is reported [here](https://skaffold.dev/docs/resources/telemetry/#example)
and [how to disable usage collection](https://skaffold.dev/docs/resources/telemetry)

Note: This is a small release with few improvements to `skaffold init` and skaffold documentation.

Huge thanks goes out to all of our contributors for this release:

- Brian de Alwis
- Isaac Duarte
- Jeff Wu
- Marlon Gamez
- Medya Ghazizadeh
- Priya Modali
- Sangeetha A