### PR TITLE
clusterctl 0.3.13

### DIFF
--- a/Food/clusterctl.lua
+++ b/Food/clusterctl.lua
@@ -1,5 +1,5 @@
 local name = "clusterctl"
-local version = "0.3.12"
+local version = "0.3.13"
 local release = "v" .. version
 local org = "kubernetes-sigs"
 local repo = "cluster-api"
@@ -16,7 +16,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
             -- shasum of the release archive
-            sha256 = "4d6e5882588f2369e599b3b0d7673ab152215853832c70264ef6707dcf98c62a",
+            sha256 = "4f86a05d4306222efa2ca879f689f5091cf71c2ea63c1611b2efc421a11b623c",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -30,7 +30,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
             -- shasum of the release archive
-            sha256 = "26a6247e73bab4c113114e7c88368abdaaaf67522955a3024731cd12544b326d",
+            sha256 = "44f7344bb169ddfafa27c602dbaf2e2c51f3a71ae78168d583b2f43ca08bb927",
             resources = {
                 {
                     path = name .. "-linux-amd64",


### PR DESCRIPTION
Updating package clusterctl to release v0.3.13. 

# Release info 

 Changes since v0.3.12
---
## :sparkles: New Features
- Allow KubeadmControlPlane spec mutation for ApiServer, ControllerManager, and Scheduler (#4080)
- Add support for marking a preferred KubeadmControlPlane machine for scale down with a delete annotation  (#4019)
- Add clusterctl describe cluster command (#4088)

## :bug: Bug Fixes
- Set error_exit code arg in kubeadm bootstrap script (#4106)
- Fix APIEndpoint for IPv6 (#4066)
- KubeadmControlPlane should adopt v1alpha2 kubeconfig secrets (#4050)

## :book: Documentation
- Add envsubst as prerequisite in developer guide (#4025)

## :seedling: Others
- Add optional parameter for using repolist (#4102)

_Thanks to all our contributors!_ 😊
