### PR TITLE
eksctl 0.37.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.36.0"
+local version = "0.37.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "cb5359d35271296ba547ee98d521d8726ac10bd84ba40c3e2a0f8601e4ffcc6c",
+            sha256 = "e63349d961a5f9c7f13690b1915b8c6bd345d552673dae18b360d2a4b63cf5a8",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "8bc1618ca343c92d65e879c0f824fe67bcb0c388515678e0068a206626a620b3",
+            sha256 = "4ef5775f237fd9c5ea3f3984e9a1bd9e7fe1b8106634665b27153eb58c245437",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "4f16e8870d2efdffd41ba9df0ec245cf8348f5dfa2bedddb5fd6078a228eca15",
+            sha256 = "18f89acb25de8d000d79cc32591ecc61e81ec791a099bf1e781d2c3cdfacd349",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.37.0. 

# Release info 

 # Release 0.37.0

## Features

- Add support for scaling non-eksctl created nodegroups (#3132)
- Update iamserviceaccount role policies (#3064)
- Add create fargateprofile support for non-eksctl-managed clusters (#3080)
- Support for Bottlerocket as a custom AMI in managed node groups (#3033)
- Set gp3 as the default VolumeType (#3078)

## Improvements

- Update maxpods (#3125)
- Add needed parameter --cluster to eksctl utils update-* commands (#3103)
- Reduce cloudformation calls in eksctl get clusters (#3073)
- allow configuring node-volume-type via cli (#3090)
- Use the latest neuron-device-plugin (#2954)

## Bug Fixes

- Respect partition in load balancer IAM statements (#3069)

## Acknowledgments
Weaveworks would like to sincerely thank:
 @bt909 and @dLobatog

