### PR TITLE
helm 3.5.1

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.5.0"
+local version = "3.5.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "53378d8de087395ece3876795111a8077f2451f080ec6150d777cc3105214520",
+            sha256 = "c9b09c7184d95ec6cb3eaddafdc5268688b54359e47d912b0c54068784d8c7eb",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "3fff0354d5fba4c73ebd5db59a59db72f8a5bbe1117a0b355b0c2983e98db95b",
+            sha256 = "cad8f2f55a87cfd4d79312625c6af62c1e22eb1dab750f00aa1d394c601a2e6b",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "17a8ff39684667436b43318d3078e15eac65dcc9d3d80370a0b197930a2b0ed3",
+            sha256 = "afda42c558f61854211fbbbd529b0954ae5b51fea85380f84f7927484dfdc418",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.5.1. 

# Release info 

 Helm v3.5.1 is a patch release. This release is the same Helm source as v3.5.0 but is built using Go 1.15.7. [Go 1.15.7 is a security release](https://groups.google.com/g/golang-dev/c/uYcPPYV2jLY). Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [GitHub/helm/charts](https://github.com/helm/charts)

## Installation and Upgrading

Download Helm v3.5.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.5.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-darwin-amd64.tar.gz.sha256sum) / c9b09c7184d95ec6cb3eaddafdc5268688b54359e47d912b0c54068784d8c7eb)
- [Linux amd64](https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-amd64.tar.gz.sha256sum) / cad8f2f55a87cfd4d79312625c6af62c1e22eb1dab750f00aa1d394c601a2e6b)
- [Linux arm](https://get.helm.sh/helm-v3.5.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-arm.tar.gz.sha256sum) / 0b86a5a68df7376484babb6d7ffe1bae36012b4d65f1bcddb4255fb3bbe811db)
- [Linux arm64](https://get.helm.sh/helm-v3.5.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-arm64.tar.gz.sha256sum) / d0ada80576f8016d1cc38a06d225a4379a53e88e3e26b417e6de5db05a090ce4)
- [Linux i386](https://get.helm.sh/helm-v3.5.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-386.tar.gz.sha256sum) / f446ed424de9a177a4d5bb4a81f5086738527ab6aaded10243f28af9fc4d52cb)
- [Linux ppc64le](https://get.helm.sh/helm-v3.5.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-ppc64le.tar.gz.sha256sum) / 10ba07fc773a241037e4f8d0b653000a357edd8e7819ae2e4101caa302c23426)
- [Linux s390x](https://get.helm.sh/helm-v3.5.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.5.1-linux-s390x.tar.gz.sha256sum) / c9b09c7184d95ec6cb3eaddafdc5268688b54359e47d912b0c54068784d8c7eb)
- [Windows amd64](https://get.helm.sh/helm-v3.5.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.5.1-windows-amd64.zip.sha256sum) / 793298194038eacce3b0a2e5cefcf104ae3f595740f03f5894e0484e2955d5a9)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.5.2 will contain only bug fixes and be released on February 10, 2021.
- 3.6.0 is the next feature release and will be released on May 26, 2021.