### PR TITLE
golangci-lint 1.36.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.35.2"
+local version = "1.36.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "1f4666e6a303ba76f5c1ab0592390946668dc83607df96c6caba9c10d58e976f",
+            sha256 = "921e22e9e04a9acb22203bce37cff94357b4ea137c8fd5b7a1759529edbc8582",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "8f9ede0ec40beca515b619e6aede57e59b86407e110882fbe3f947f1fa10032d",
+            sha256 = "9b8856b3a1c9bfbcf3a06b78e94611763b79abd9751c245246787cd3bf0e78a5",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "b122f3a4b9862d174f054e9393d1ef41a6b0fe55d155a18ed93111bf4e97e372",
+            sha256 = "de40246f14027edea21678a76c61b32b13d2a3881088fc1b5b25c5dff83d122c",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.36.0. 

# Release info 

 ## Changelog

750309d Add ifshort linter (#1587)
257eb95 Add issues.fix config to example configuration. (#1648)
638b070 Update docs for v1.35.2 (#1643)
ec46f42 Verify linter name in integration tests (#1595)
ea41793 build(deps): bump github.com/securego/gosec/v2 from 2.5.0 to 2.6.1 (#1665)
f049bfc build(deps): bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#1654)
4f648a7 build(deps): bump github.com/tetafro/godot from 1.3.2 to 1.4.3 (#1664)
6c25d06 fix: bump github.com/tommy-muehle/go-mnd/v2 to v2.3.1 (#1667)

