### PR TITLE
jcli 0.0.33

### DIFF
--- a/Food/jcli.lua
+++ b/Food/jcli.lua
@@ -1,18 +1,18 @@
 local name = "jcli"
-local release = "v0.0.32"
-local version = "0.0.32"
+local release = "v0.0.33"
+local version = "0.0.33"
 food = {
     name = name,
     description = "Jenkins CLI allows you manage your Jenkins as an easy way",
     license = "MIT",
-    homepage = "http://jcli.jenkins-zh.cn/",
+    homepage = "https://jenkins-zh.cn",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "aef8af57f87b002620ce46ac550dac2c85c7aa8172a2b5d20e96a61588d50887",
+            sha256 = "7967842e9c7eedec4c14ef9948cbb57738e3726c676442f4bf857c1d5eed0902",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "5b481d46ffdfb9ac9177c6b27360afedede1312b29c7cfed5a34605b23bd2a73",
+            sha256 = "fe7f5286e4229b2a691f1fe84575469622bfc738f123acb4f9f49c89fd2bf930",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "9d29ec7c082b5977cf83528481ea2ae5fee54d9687979af41a5bb71a8136cce3",
+            sha256 = "585b33d342065de2797f0079afcca60e039182cfd4711cd2a4d4536c0c20669a",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jcli to release v0.0.33. 

# Release info 

 ## What’s Changed

In some cases, we might need to add or remove parameters from Pipeline. It's terrible if you need to deal with too many Pipelines manually. You can add parameters via: `jcli job param init-job --add '[{"name":"name","value":"my name","desc":"this is a name"}]'`

Delete many job build history across different jobs is also very simple. See also: `jcli job history init-job -d 1`

Sometimes, it's very slow to download jenkins.war. From now, jcli can download it with multiple threads. For example:

```
# jcli center download -t 8
start to download with 8 threads, size: 67287051, unit: 8410881
```

Another big feature is that, jcli can start Jenkins in Docker with a single command:

`jcli center start -m docker --image kubespheredev/ks-jenkins --version 2.249.1 --c-user root --port 9090 --setup-wizard=false`

The star from [GitHub](https://github.com/jenkins-zh/jenkins-cli) is 234, star from [Gitee](https://gitee.com/jenkins-zh/jenkins-cli) is 251. The download is [11,168](https://tooomm.github.io/github-release-stats/?username=jenkins-zh&repository=jenkins-cli).

## 🚀 Features

* Fix the random web for center start do not work (#520) @LinuxSuRen
* Add support to delete job history (#519) @LinuxSuRen
* Add support to add or remove pipeline parameters (#513) @LinuxSuRen
* Allow user put shell into config data (#518) @LinuxSuRen
* Add an option to download jenkins.war with multi-thread (#517) @LinuxSuRen
* Add an option to clean the JENKINS_HOME before start run plugin (#506) @LinuxSuRen
* Add an option to force pull image before start it (#503) @LinuxSuRen
* Sperate code into another project (#500) @LinuxSuRen
* Fix cannot upgrade itself on linux (#495) @LinuxSuRen
* Refactory with computer launch command (#491) @LinuxSuRen
* Add command alias support (#494) @LinuxSuRen
* Sperate cli plugin into a single git repo (#492) @LinuxSuRen
* Support run golang image as JNLP agent (#489) @LinuxSuRen
* Support run Jenkins agent as docker (#488) @LinuxSuRen

## 👻 Maintenance

* Fix the unavailable GitHub release stats service (#512) @LinuxSuRen
* Bump upx version (#516) @LinuxSuRen
* Bump github.com/magiconair/properties from 1.8.1 to 1.8.4 (#482) @dependabot
* Bump github.com/linuxsuren/http-downloader from 0.0.2 to 0.0.10 (#515) @dependabot
* Bump github.com/linuxsuren/cobra-extension from 0.0.5 to 0.0.10 (#514) @dependabot
* Bump golang.org/x/text from 0.3.4 to 0.3.5 (#508) @dependabot
* Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#509) @dependabot
* Improve the jcli completion document (#507) @LinuxSuRen
* Add more labels (#505) @LinuxSuRen
* Bump github.com/AlecAivazis/survey/v2 from 2.2.2 to 2.2.7 (#502) @dependabot
* Bump github.com/linuxsuren/cobra-extension from 0.0.3 to 0.0.5 (#497) @dependabot
* Bump github.com/linuxsuren/go-cli-alias from 0.0.3 to 0.0.4 (#498) @dependabot
* Bump goreleaser/goreleaser-action from v2.4.0 to v2.4.1 (#490) @dependabot
* Bump github.com/linuxsuren/cobra-extension from 0.0.1 to 0.0.3 (#496) @dependabot
* Bump goreleaser/goreleaser-action from v2.3.0 to v2.4.0 (#486) @dependabot
* Bump goreleaser/goreleaser-action from v1 to v2.3.0 (#480) @dependabot
* Update actions/checkout requirement to v2.3.4 (#478) @dependabot
* Bump actions/setup-go from v1 to v2.1.3 (#479) @dependabot
* Bump jenkins-zh/git-backup-actions from v0.0.3 to v0.0.4 (#477) @dependabot
