### PR TITLE
aks-engine 0.60.0

### DIFF
--- a/Food/aks-engine.lua
+++ b/Food/aks-engine.lua
@@ -1,5 +1,5 @@
 local name = "aks-engine"
-local version = "0.59.0"
+local version = "0.60.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "3a48ffc4111d6a8fd2e56874b6eb1f753d1dda61eadd957dd72ce6cda715990c",
+            sha256 = "bcdc0edfe0c81636e7073d7ced70b61063286cff41ce5897fb79f8f829b13659",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "c555e44d2143d023e5a4a71550546907bb950c7188cda7f66e737cc438d31ffa",
+            sha256 = "a30a425d502dbfc86d15018cc448f52475b2151d7d5b965557e2181576c71508",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "e7e53c087649af91384913a418abce64f3e4cf7009979e2c6aa1e2c3529f8f9b",
+            sha256 = "e11099283a14fbb3a9fef337e65eb4b0d87f0b71e336cd0132ea42c2679a9cf4",
             resources = {
                 {
                     path = name .. "-v" .. version .. "-windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package aks-engine to release v0.60.0. 

# Release info 

 <a name="v0.60.0"></a>
# [v0.60.0] - 2021-02-03
### Bug Fixes 🐞
- use curl.exe and add retries when downloading artifacts to Windows VHD ([#4206](https://github.com/Azure/aks-engine/issues/4206))
- update nodecustomdata to enable portmapper for kubenet+containerd ([#4191](https://github.com/Azure/aks-engine/issues/4191))
- fix network cleanup code on windows for contianerd nodes ([#4154](https://github.com/Azure/aks-engine/issues/4154))

### Continuous Integration 💜
- update dev image to deis/docker-go-dev v1.29.0 ([#4195](https://github.com/Azure/aks-engine/issues/4195))
- remove KMS test from everything cluster config ([#4194](https://github.com/Azure/aks-engine/issues/4194))

### Documentation 📘
- add dual-stack iptables api model ([#4185](https://github.com/Azure/aks-engine/issues/4185))
- aad not supported on AZs ([#4182](https://github.com/Azure/aks-engine/issues/4182))
- fix broken link in AAD docs ([#4180](https://github.com/Azure/aks-engine/issues/4180))

### Features 🌈
- run accelerated unattended-upgrade at node creation time ([#4217](https://github.com/Azure/aks-engine/issues/4217))
- reworked rotate-certs command ([#4214](https://github.com/Azure/aks-engine/issues/4214))
- add support for Kubernetes v1.16.15 and v1.18.15 on Azure Stack ([#4187](https://github.com/Azure/aks-engine/issues/4187))
- add support for Kubernetes v1.17.17 on Azure Stack ([#4188](https://github.com/Azure/aks-engine/issues/4188))
- add support for Kubernetes 1.20.2 ([#4192](https://github.com/Azure/aks-engine/issues/4192))
- create kms key as part of cluster bootstrap ([#4170](https://github.com/Azure/aks-engine/issues/4170))
- add support for Kubernetes v1.21.0-alpha.1 ([#4178](https://github.com/Azure/aks-engine/issues/4178))
- add support for Kubernetes v1.18.15 ([#4166](https://github.com/Azure/aks-engine/issues/4166))
- add support for Kubernetes v1.17.17 ([#4167](https://github.com/Azure/aks-engine/issues/4167))
- add support for Kubernetes v1.19.7 ([#4165](https://github.com/Azure/aks-engine/issues/4165))

### Maintenance 🔧
- add new Azure VM SKUs, brazilsoutheast, westus3 regions ([#4224](https://github.com/Azure/aks-engine/issues/4224))
- block container traffic to 168.63.129.16 ([#4212](https://github.com/Azure/aks-engine/issues/4212))
- rev Linux VHDs to 2021.01.28 ([#4223](https://github.com/Azure/aks-engine/issues/4223))
- update aks-engine VHD Windows VHD ([#4218](https://github.com/Azure/aks-engine/issues/4218))
- update csi-secrets-store to v0.0.19 and akv provider to 0.0.12 ([#4203](https://github.com/Azure/aks-engine/issues/4203))
- update policy addon deployment ([#4201](https://github.com/Azure/aks-engine/issues/4201))
- update adal to v0.9.10 ([#4200](https://github.com/Azure/aks-engine/issues/4200))
- updating windows provisioing scripts to v0.0.10 ([#4184](https://github.com/Azure/aks-engine/issues/4184))
- Update Azure CNI to v1.2.2 ([#4183](https://github.com/Azure/aks-engine/issues/4183))
- Add windowsnodelabelsync.ps1 ([#4163](https://github.com/Azure/aks-engine/issues/4163))
- install Jan 2021 security updates in Windows VHD ([#4168](https://github.com/Azure/aks-engine/issues/4168))
- bump kms keyvault to v0.0.10 ([#4169](https://github.com/Azure/aks-engine/issues/4169))
- Use signed scripts package 0.0.9 on Windows nodes ([#4162](https://github.com/Azure/aks-engine/issues/4162))

### Testing 💚
- incorporate kured + auto mode into kamino vmss-prototype tests ([#4221](https://github.com/Azure/aks-engine/issues/4221))
- add timestamps to E2E pod logs output ([#4216](https://github.com/Azure/aks-engine/issues/4216))
- enable kamino vmss-prototype dry run tests ([#4215](https://github.com/Azure/aks-engine/issues/4215))
- increase timeout tolerance for vmss-prototype SIG publishing ([#4211](https://github.com/Azure/aks-engine/issues/4211))
- add more stdout to kamino vmss-prototype E2E tests ([#4210](https://github.com/Azure/aks-engine/issues/4210))
- print helm command for vmss-prototype test ([#4207](https://github.com/Azure/aks-engine/issues/4207))
- correct E2E message during vmss-prototype test ([#4205](https://github.com/Azure/aks-engine/issues/4205))
- kamino E2E errata ([#4204](https://github.com/Azure/aks-engine/issues/4204))
- remove dangling fmt.Println ([#4202](https://github.com/Azure/aks-engine/issues/4202))
- enable testing custom kamino vmss prototype images ([#4198](https://github.com/Azure/aks-engine/issues/4198))
- updated kamino vmss-prototype integration E2E ([#4153](https://github.com/Azure/aks-engine/issues/4153))
- ensure hostPort routing ([#4186](https://github.com/Azure/aks-engine/issues/4186))

#### Please report any issues here: https://github.com/Azure/aks-engine/issues/new
[Unreleased]: https://github.com/Azure/aks-engine/compare/v0.60.0...HEAD
[v0.60.0]: https://github.com/Azure/aks-engine/compare/v0.59.0...v0.60.0