### PR TITLE
helmfile 0.138.3

### DIFF
--- a/Food/helmfile.lua
+++ b/Food/helmfile.lua
@@ -1,5 +1,5 @@
 local name = "helmfile"
-local version = "0.138.2"
+local version = "0.138.3"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_amd64",
-            sha256 = "cfd9b624392e01d522169e8251290af40ad508a7e10888d9c1a76c5ce962d233",
+            sha256 = "daf0d2e80052c5369eebdd3ace04412b7aa8415e0b80ce0016a8d6eaed54030f",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_darwin_386",
-            sha256 = "2e98aaeadd3f9cb72b0c6ac27532c9d3150449b23b1f949f39a56735157b1004",
+            sha256 = "fd9cd94d6ccf568485bd24c026f392e318c0f5daa489aa1f01bfdf98ecaed4c0",
             resources = {
                 {
                     path = name .. "_darwin_386",
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_amd64",
-            sha256 = "a13312e11092e8523f3f663f48863e660d0bfbcc4b9c726ad8c7a6788a2ff481",
+            sha256 = "6567b42fcb8e930f71365e7c0f6700053aff1418c992478d06136ebdbc16eb0b",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_linux_386",
-            sha256 = "e7323e62be3e09b92ae6256b7bdfb19d4d1313a788ad6a6711638e936b59e2e5",
+            sha256 = "8e4fda354f180462369759319f482d89361e66a162ad752249152b847ad91638",
             resources = {
                 {
                     path = name .. "_linux_386",
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_amd64" .. ".exe",
-            sha256 = "fce08b942fdbf35aaf55d7263ade28148f7e35e9b8b134503b4cf8508ec25ccd",
+            sha256 = "ff220f56d1c5dc2e4dc0004447c7706a5f0cc4c74f45d879acde5968ff3f3829",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",
@@ -76,7 +76,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/roboll/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_windows_386" .. ".exe",
-            sha256 = "470239d2b46caabdc5cddd5dde6dd87286c9ca7b104196927d8f9e88a9128b20",
+            sha256 = "71db077537482eef58c3b933a1ff375c728d582723e83a659c22a8814e95cd81",
             resources = {
                 {
                     path = name .. "_windows_386.exe",


### PR DESCRIPTION
Updating package helmfile to release v0.138.3. 

# Release info 

 257c1f6 (HEAD, tag: v0.138.3, origin/master, origin/HEAD, master) Fix OCI support (#1667)
4e1ecb5 Bump variantdev/vals to 0.13.0 (#1666) 
### [Build Info](https://circleci.com/gh/roboll/helmfile/7830)