### PR TITLE
polaris 3.1.0

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,5 +1,5 @@
 local name = "polaris"
-local version = "3.0.3"
+local version = "3.1.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "f7444d181a511a0486e8b9df5526b477d01cad8d0ee4c7888e0e30d75676e636",
+            sha256 = "8cbf652b032c31ab72787ed2679c239c5180adb31fe468698e36daf52b88bf57",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "7b9ecc5c60c3a580df3d38e0dff03ddc0cba0bc6ec8dc772050f078a8ca5c7d7",
+            sha256 = "7d7cdcbd61e1292feacf6cf7d444284da7902641159ddcc6ec75de224e4d6e3d",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 3.1.0. 

# Release info 

 

## Changelog

272e06bb Add ContainerNames to Exemption struct
381c24e9 Add Swaroop as Codeowner (#475)
9dd7f094 Add a comma
5f793beb Add architecture diagram (#458)
ba53a2b8 Add ingress nil check test
fc368485 Add ingress schema checks
5ab9f0b2 Add ingress tls check
8f510a1b Add ingress to resource provider
e4d6fb9b Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#478)
09d5fdcd Bump k8s.io/client-go from 0.20.1 to 0.20.2 (#482)
55044723 ControllerResult to Result
0c398d21 Fix grammar for exemption doc
564803c9 Fix instructions
e57668fc Fix typos
17d19cac Fix up zero-score issues (#468)
dd297679 Implement namespace and container exemptions. Also refactoring according to gofmt
93a80e44 Manually set Ingress object Kind
f5a1ad61 Merge branch 'master' into jd/out-of-control
ee876859 Merge branch 'master' into jd/out-of-control
bc866a4d Merge branch 'master' into jd/out-of-control
a1c131f9 Merge branch 'master' of github.com:FairwindsOps/polaris into ssk/container-exemptions
a4e45a0e Merge branch 'master' of github.com:FairwindsOps/polaris into ssk/container-exemptions
ef4f5aea Merge pull request #463 from FairwindsOps/ssk/container-exemptions
a8e90163 Merge pull request #469 from FairwindsOps/jd/out-of-control
613c4b9e Merge pull request #486 from FairwindsOps/bm/listerning-address
9d68ee23 Merge remote-tracking branch 'origin/master' into jd/out-of-control
717d9b26 PodResult to pointer
3a2fb358 Refactor common code
3f62126b Refactor resolveCheck
8840f0dc Remove last ControllerResult reference
f1957631 Remove unsued import
fdd30717 Remove unused parameter
ca6e4b43 Rename to receivers to same name
86b3ab51 Revert nil slice declarations
54aacb78 Revert version information
4cee8b7e Some nil pointer dereference fixes
a540a735 Update README.md (#464)
6e93b799 Update UI for non-controller types
ec557f7c Update dependencies (#470)
c11b8390 Update docs (#472)
a79260a3 Update exemption documentation and unit test
3a8655de Update validate ingress test
5fd9e014 Update version and changelog
23d76594 added listening address
f421d7e5 always build website
3f7fccf5 bump version to 3.1.0 (#490)
d9e148c0 fix html tag (#489)
2e148546 remove 127.0.0.1 and let it remain empty as before
6cda7cd7 remove details links (#473)
512a5f28 update docs from template (#477)
7b428fe2 update flag information for listening address


