### PR TITLE
jcli 0.0.34

### DIFF
--- a/Food/jcli.lua
+++ b/Food/jcli.lua
@@ -1,6 +1,6 @@
 local name = "jcli"
-local release = "v0.0.33"
-local version = "0.0.33"
+local release = "v0.0.34"
+local version = "0.0.34"
 food = {
     name = name,
     description = "Jenkins CLI allows you manage your Jenkins as an easy way",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "7967842e9c7eedec4c14ef9948cbb57738e3726c676442f4bf857c1d5eed0902",
+            sha256 = "1875a8e4430fa446ebb95bf91f791c9f3f3695f4ad2eb81da2afcab20e3c1689",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "fe7f5286e4229b2a691f1fe84575469622bfc738f123acb4f9f49c89fd2bf930",
+            sha256 = "018bb3fd3a4db434d84f816b4eab818aaafe27ccc776f466c742c678991115ea",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/jenkins-zh/jenkins-cli/releases/download/" .. release .. "/" .. name .. "-windows-amd64.zip",
-            sha256 = "585b33d342065de2797f0079afcca60e039182cfd4711cd2a4d4536c0c20669a",
+            sha256 = "3256bbb5d82b382dbde8860c78971ee04d8b81e00d513c633c596f22c90146ff",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package jcli to release v0.0.34. 

# Release info 

 ## What’s Changed

## 🐛 Bug Fixes

* Fix the error usage of version (#525) @LinuxSuRen

## 👻 Maintenance

* Bump github.com/onsi/ginkgo from 1.14.2 to 1.15.0 (#524) @dependabot
* Bump github.com/linuxsuren/http-downloader from 0.0.10 to 0.0.15 (#526) @dependabot
