### PR TITLE
oras 0.10.0

### DIFF
--- a/Food/oras.lua
+++ b/Food/oras.lua
@@ -1,5 +1,5 @@
 local name = "oras"
-local version = "0.9.0"
+local version = "0.10.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/deislabs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "f8ebc8b18eafc6f468c8aa73d09c7083d72352742ca9ff8918a26c0a73b83b04",
+            sha256 = "ce52e36dcd78af3bc5cec7edd7a5a32879342ae37fbe70e70fbf09086a4139ac",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/deislabs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "3600b4a047fe77c4e9147f3b7f34214512f93032029abbceda4a26a38438eea3",
+            sha256 = "f621038a46ee445d7cc0deb079e2e3a2419e76b35fb46a0e2a404bda5d9f6b15",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/deislabs/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.tar.gz",
-            sha256 = "c68ddd2609e17608332cd215c77516fe4d83dd76371d5e584145ebb56bfacfb2",
+            sha256 = "a608316d07eced0059a275d36550d97d2dfb3ab5df65fb592bd58d648f87e82e",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package oras to release v0.10.0. 

# Release info 

 ## Changelog

- maint: bump internal version to 0.10.0 173c010570c48e4aa18ce186cae8cc812f8e8b6e (Josh Dolitsky)
- Bump github.com/docker/cli (#216) 84cf5877917361a626cb403b58c1bcab756a33ec (dependabot[bot])
- Fix OCIStore inconsistent state after AddReference (#215) b95c3226d26ae7c3822c89ffd972928f0ca98fe5 (Timofey Kirillov)
- multiwriteringester support (#214) b4a877c3a3d4be49e7089394af4291c9e5d19eda (Avi Deitcher)

## Notes

This release was signed with `E97F 9DA5 AE2E 39CF 48A1 42B7 852A 7470 A39F B81D` (@jdolitsky's GPG key) which can be found [here](https://github.com/jdolitsky.gpg).
