### PR TITLE
k3d 4.2.0

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "4.1.1"
+local version = "4.2.0"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "40fe273f567bad7e031636fe896a05637f173f047ee41f9566a6ad933e7da34f",
+            sha256 = "9d3ba7bde30651f5ff638d772c5d96fe7b795e0f6e9e0bf98e197183425473d2",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "4148b8035774a2765969898cc73066491ac718d1b2890415a4625931aaacd3ac",
+            sha256 = "745396701fb0ffaa832b02c5b734fd5b6bb042ac878b3ad16bb810ebbf02df0c",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "b5891997b3d800fd4bb6f55aed874f3e76e60a0edf53b78150faaedc9932663d",
+            sha256 = "d0e29b7e64c7c88a0520b3a88c501236254827afcf96fc4469018499e50f6030",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "ea0f29231039682811086e86c7c5d28bc69259b4bde359a5ca2a88fc4350bf87",
+            sha256 = "21a69922a2778acb00a62868fae2dc5d3ce252fa5b576d54e811eda7d3a4a1f5",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "9d44112543c801086ded64529e2721438bea45c1503f330043db4cf5029cfabb",
+            sha256 = "5077b74f9d6274eb4afeb7abbd8d4ae12496b33d9faf723d50c36e0c78b993cb",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "dc13acba412b473ab5b602420bf61cb2149a8b99cc24a0261574e3f965f03560",
+            sha256 = "372dc3f40830b47ada445d234bf2fc1b2037f5b4f205868e41df36cc2126dab2",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v4.2.0. 

# Release info 

 # v4.2.0

## Features / Enhancements

- add processing step for cluster config, to configure it e.g. for hostnetwork mode (#477, @konradmalik)
- allow proxying UDP ports via the load balancer (#488, @k0da)

## Fixes

- fix usage of `DOCKER_HOST` env var for Kubeconfig server ref (trim port)
- fix error when trying to attach the same node (e.g. registry) to the same network twice (#486, @kuritka)
- fix Kube-API settings in configg file got overwritten (#490, @dtomasi)

## Misc

- add `k3d.version` label to created resources
- add Pull-Request template
- docs: add hint on minimal requirements for multi-server clusters (#481, @Filius-Patris)