### PR TITLE
fluxctl 1.21.2

### DIFF
--- a/Food/fluxctl.lua
+++ b/Food/fluxctl.lua
@@ -1,7 +1,7 @@
 local name = "fluxctl"
 local org = "fluxcd"
-local release = "1.21.1"
-local version = "1.21.1"
+local release = "1.21.2"
+local version = "1.21.2"
 food = {
     name = name,
     description = "The GitOps Kubernetes operator",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_darwin_amd64",
-            sha256 = "70f9779cfdc38fae844d92d5504d12dff4edb47c03f5f87f39cc602d8268c2df",
+            sha256 = "42c974ae6588a1bd1e4435399fa584934956061a090cc34535ceb5f579b1a4dd",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_linux_amd64",
-            sha256 = "29f55ca6fc528d2064191071b18d7fa26f56a53fa3e1316dc4d896465c58bf72",
+            sha256 = "b92523a143a3e623ad4eeeff87bce6f6fe1a884f341c40f7d64ff592470b1d7f",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux/releases/download/" .. release .. "/" .. name .. "_windows_amd64",
-            sha256 = "fd8c3b2330585691f56c58b7a5e429bd71d156fea6f33af4e06bb5a1f10881a5",
+            sha256 = "f77437b351ac2ed490f56ca5d07b50969da9095486248d57612f49bc5d7a5235",
             resources = {
                 {
                     path = name .. "_windows_amd64",


### PR DESCRIPTION
Updating package fluxctl to release 1.21.2. 

# Release info 

 This patch release surfaces a notice from https://docs.fluxcd.io/en/latest/ declaring that "Flux v1 is in maintenance mode" into the Flux v1 stable docs, as well as pointing users from as many places as possible to the new Flux v2.

### Fixes

- Update AWS SDK and SOPS [fluxcd/flux#3401][]
- Set Rollout strategy type: Recreate (Fixes for chart 1.6.2) [fluxcd/flux#3325][]

### Maintenance and documentation

- Point to Flux v2 from docs [fluxcd/flux#3419][], [fluxcd/flux#3423][]
- Point to new community resources at [fluxcd.io](https://fluxcd.io), [fluxcd/flux#3403][]
- Update issue/PR templates to mention Flux v2 [fluxcd/flux#3415][], [fluxcd/flux#3414][]
- Add NetHunt to list of production users [fluxcd/flux#3399][]

### Thanks

Thanks to @nairb774, @ViBiOh, @SvitlanaTsupryk-jul18, @dholbach, @drewfreyling, @stefanprodan, @hiddeco, @kingdonb and @squaremo for their contributions to this release.

[fluxcd/flux#3423]: https://github.com/fluxcd/flux/pull/3423
[fluxcd/flux#3419]: https://github.com/fluxcd/flux/pull/3419
[fluxcd/flux#3416]: https://github.com/fluxcd/flux/pull/3416
[fluxcd/flux#3415]: https://github.com/fluxcd/flux/pull/3415
[fluxcd/flux#3414]: https://github.com/fluxcd/flux/pull/3414
[fluxcd/flux#3403]: https://github.com/fluxcd/flux/pull/3403
[fluxcd/flux#3401]: https://github.com/fluxcd/flux/pull/3401
[fluxcd/flux#3400]: https://github.com/fluxcd/flux/pull/3400
[fluxcd/flux#3399]: https://github.com/fluxcd/flux/pull/3399
[fluxcd/flux#3358]: https://github.com/fluxcd/flux/pull/3358
[fluxcd/flux#3325]: https://github.com/fluxcd/flux/pull/3325