### PR TITLE
gh 1.6.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "1.5.0"
+local version = "1.6.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "b33344fac099f81ad64b684fe0f7eef1eacace4c24c53fc767c64f950f499aff",
+            sha256 = "cfbf5e6477d666c32822da5fe89ae9b29685aba7fae8f8c27ea27ac1c87a4c64",
             resources = {
                 {
                     path = name .. "_" .. version .. "_macOS_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "6fe61b7364f91582fdb13c3ccc889e4b9bc81a75ed7b3aae56e6e1fb67b21315",
+            sha256 = "e7f5513633bad71a6a23a39bf57bebdd633fb8dca7514acc5210aa4f9447af93",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "63d9c1b6305a67f2244b30a6ed2cdb1e1013bae79012baad2184aa7b8fbae1e9",
+            sha256 = "4e7f72caa535f45203cb0bc05fc027c17e43200451be8a2e4f573956a1c95131",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v1.6.0. 

# Release info 

 This is a large release seeing a few major new features and a slew of fixes. In January we spent a week cleaning out the backlog of community pull requests -- thank you for your patience as we got all that merged!

# New Commands

## Edit Issues and Pull Requests

`gh issue edit` and `gh pr edit` allow you to modify existing issues and pull requests. Both versions accept arguments to edit non-interactively and running without flags allows you to interactively edit. (#2915, #2940, #2949)

## SSH Key Management

`gh ssh-key list` and `gh ssh-key add` are now live! You'll be prompted to refresh your auth token with increased scopes to use them. (#2990)

## Issue Deletion

Issues can now be permanently deleted with `gh issue delete` (#2839)

# New Features

## PR Auto-Merge Support

`pr merge` now supports `--auto`. Instead of merging the pull request right away, the pull request will be automatically met once all requirements are met (#2980)

## SSH Key Generation During Authentication

While running through the `gh auth login` flow, `gh` can now generate and upload SSH keys to GitHub on your behalf (#2892)

## @me Syntax for Self Assigning Issues

When using `gh issue create`, the string `@me` can be used to self assign (#2004)

## pr checkout Improvements

`pr checkout` now supports `--force` to force a checkout (#1953) and `--detach` to checkout a pull request in a detached head state (#2117)

## And More

- `repo fork`: support git flags (#2282)
- `pr merge`: edit commit body when merging (#2980, #2810)
- `pr merge`: alert about unpushed commits (#2255)
- `gist view`:  `--files` lists filenames in a gist (#2898)
- Configuration path can now come from environment (#2444)
- Display upgrade notice for brew users (#2929)
- Show whether or not branches are up to date with the default branch in `gh pr status` (#2952, #2988)
- Show progress while creating a new pull request (#2808)

# Fixes

- Minimized comments no longer appear in comment lists (#2859)
- Issue and Pull Request templates are now listed as per the API and not local file system (#2539)
- Gist description dropped from single file raw view (#2888)
- Restore fork rename behavior (#2825)
- Clarify handling of git tags during  release create (#2910)
- Explain how to link an issue in  pr create (#2909)
- Improve repo create docs (#2908)
- Add more examples to api docs (#2951)
- Only fetch default branch when adding upstream remote (#2588)
- Consistently use success icon (#2799)
- `write:org` scope is now recognized as satisfying `read:org` (#2965)
- `pr merge`: do not show invalid merge methods (#2224)
- `pr merge`: avoid prompting to enter editor after editing phase is chosen (#2989)  
- `repo create`: clarify prompt (#2962)
- `gist`: print friendly error when missing required argument (#2664)
- `auth status`: add fail message for non-existent hostname (#2785)
- `config`: refactor to use os.UserHomeDir() (#2740)
- `issue create` and `pr create`: project argument works alongside `--web` now (#2108)
- `secret set`: fix secret set --repos for repositories that have dashes #2844


# Development Changes

- `createrepo` is now run via docker until Ubuntu repackages it (#2856)
- Display output of build commands (#2926)
- Deprecate run.SetPrepareCmd (#2858)
- Deprecate test package (#2801, #2803, #2828)
- Freeze time in issue view test (#2843)

---

As always, a huge thank you to our contributors and users!

Have a good one~
