### PR TITLE
golangci-lint 1.37.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.36.0"
+local version = "1.37.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "921e22e9e04a9acb22203bce37cff94357b4ea137c8fd5b7a1759529edbc8582",
+            sha256 = "26447a0b08958437dc0e32c5ddb79b0c2273654d717aac1aab42d03e6aea7896",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "9b8856b3a1c9bfbcf3a06b78e94611763b79abd9751c245246787cd3bf0e78a5",
+            sha256 = "5fe9852e754b621c5264fb8ac810a75033e7f18e972315a60c5c3f8a37b3cb88",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "de40246f14027edea21678a76c61b32b13d2a3881088fc1b5b25c5dff83d122c",
+            sha256 = "4b72c442d78a80bdfb7a775a55a9296beecc80afff6ef6ce9c727a573031278d",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.37.0. 

# Release info 

 ## Changelog

89367aee Add "exclude" option for godot linter (#1669)
35b6f354 Add "revive" linter (#1729)
123da8e6 Add go1.16 support (#1740)
3ef13a80 Add plugin option for Goland (#1720)
6038573c Compile binaries with -trimpath enabled (#1688)
9e0c9f39 Expose more config options for forbidigo (#1677)
443e5b6c Print error message and exit with non-zero status when ruleguard parse error occurs (#1666)
af6842c5 Remove gometalinter comparison (#1731)
5d75889c Update docs for v1.36.0 (#1668)
0a474a26 Update ifshort to v1.0.1 (#1671)
34e5fc63 Use upstream gocyclo. (#1739)
2121370f add 'cyclop' linter (#1738)
7dc0f311 build(deps): bump actions/cache from v2 to v2.1.4 (#1721)
cb028491 build(deps): bump gatsby from 2.29.3 to 2.32.3 in /docs (#1716)
683dbea7 build(deps): bump gatsby-plugin-canonical-urls in /docs (#1713)
db8ebb2b build(deps): bump gatsby-plugin-catch-links in /docs (#1710)
28058d61 build(deps): bump gatsby-plugin-google-analytics in /docs (#1715)
2ec034da build(deps): bump gatsby-plugin-manifest from 2.9.1 to 2.12.0 in /docs (#1704)
32c44df1 build(deps): bump gatsby-plugin-mdx from 1.7.1 to 1.10.0 in /docs (#1706)
c3eb769c build(deps): bump gatsby-plugin-netlify from 2.8.0 to 2.11.0 in /docs (#1700)
ea76542d build(deps): bump gatsby-plugin-offline from 3.7.1 to 3.10.0 in /docs (#1701)
dfa7ab59 build(deps): bump gatsby-plugin-react-helmet in /docs (#1709)
2982b131 build(deps): bump gatsby-plugin-sharp from 2.11.2 to 2.14.1 in /docs (#1699)
eb326949 build(deps): bump gatsby-plugin-sitemap from 2.9.0 to 2.12.0 in /docs (#1703)
32487526 build(deps): bump gatsby-remark-autolink-headers in /docs (#1674)
8ff2b391 build(deps): bump gatsby-remark-autolink-headers in /docs (#1711)
2c1dbb9a build(deps): bump gatsby-remark-copy-linked-files in /docs (#1705)
8deb0ca6 build(deps): bump gatsby-remark-images from 3.8.1 to 3.11.0 in /docs (#1702)
3505128b build(deps): bump gatsby-remark-responsive-iframe in /docs (#1698)
3790d440 build(deps): bump gatsby-source-filesystem from 2.8.1 to 2.11.0 in /docs (#1714)
aafdee85 build(deps): bump gatsby-transformer-remark in /docs (#1719)
6c1c9ccb build(deps): bump gatsby-transformer-sharp from 2.9.0 to 2.11.0 in /docs (#1673)
8bfdb1ff build(deps): bump gatsby-transformer-sharp in /docs (#1712)
20402078 build(deps): bump gatsby-transformer-yaml from 2.8.0 to 2.11.0 in /docs (#1718)
3096f8ae build(deps): bump github.com/ashanbrown/forbidigo from 1.0.0 to 1.1.0 (#1678)
ed9480c4 build(deps): bump github.com/kulti/thelper from 0.3.0 to 0.3.1 (#1722)
5694c501 build(deps): bump github.com/mbilski/exhaustivestruct from 1.1.0 to 1.2.0 (#1680)
4dc0dc32 build(deps): bump github.com/spf13/cobra from 1.1.1 to 1.1.3 (#1736)
55eed969 build(deps): bump github.com/tetafro/godot from 1.4.3 to 1.4.4 (#1679)
80ebe524 build(deps): bump golangci/golangci-lint-action from v2.3.0 to v2.4.0 (#1735)
98a9b02a build(deps): bump polished from 4.0.5 to 4.1.0 in /docs (#1708)
37f3b009 build(deps): bump puppeteer from 5.5.0 to 7.0.1 in /docs (#1707)
0c28299c build(deps): bump react-icons from 4.1.0 to 4.2.0 in /docs (#1717)
cc152be1 bump thelper linter version to v0.3.0 (#1696)
65369cb3 docs(clean): replace `govet` example with `nakedret`. (#1647)
b0b2dc6b feat: add durationcheck linter. (#1734)
1f79767c fix MIPS release (#1697)
000a8156 fix(cmd/linters): truncate multiline descriptions (#1663)
60455b50 fix: add missing ifshort configuration. (#1672)
ce2e7782 fix: new-from-rev for large repository. (#1723)
1b30a171 fix: wrong load mode (#1733)
2a5b42ce prealloc: Use upstream version (#1694)
839dd744 rowserrcheck: fix reports false positive (#1670)

