### PR TITLE
tilt 0.18.9

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.18.4"
+local version = "0.18.9"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "c14fb45d8b4f847a59b7cb82c1f380d698381389a910f834f214c494d7184269",
+            sha256 = "0640a0a5132a863f702f8cced8b95219c0e9d1533becbf6a2370b970740e99de",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "b961fa575754985539a684f507424763662b31b90ab3d79d7e367bf938769a05",
+            sha256 = "130b49a7600975fbb2a7513a8e27d3790c2b0c42a1396761b18c4cf4bdb0ed6b",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "7ced252b464696856e01cf9424cb234862bf272996c389d87e87b83342ff8333",
+            sha256 = "827114de23b4bd3e08ab79a16c5ee5b85e879b6a1f3b7a21735f636fb7bf0024",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.18.9. 

# Release info 

 [Install Tilt](https://docs.tilt.dev/install.html) ⬇️ | [Upgrade Tilt](https://docs.tilt.dev/upgrade.html) ⬆️ | [Tilt Cloud](https://cloud.tilt.dev/) ⛅ | [Tilt Extensions](https://github.com/windmilleng/tilt-extensions/) 🧰

## Release Notes

- A "Clear logs" button lets you clear the logs on the current page (https://github.com/tilt-dev/tilt/issues/1885)
- Support for custom links in Docker Compose resources (thanks @ebenoist !)
- Fixes for inappropriately cached browser JS (https://github.com/tilt-dev/tilt/issues/4151)
- local_resource(readiness_probe) accepts 'None' for no probe (https://github.com/tilt-dev/tilt/issues/4160)
- Invalid local readiness probes cause dependent resources to never start (https://github.com/tilt-dev/tilt/issues/4156)

## Changelog

0e9f0bcca Update version numbers: 0.18.8
34cf0a867 assets: add the correct caching headers to the prod asset server. Fixes https://github.com/tilt-dev/tilt/issues/4151 (#4193)
facd4e6e9 circleci: upgrade some deps (#4165)
fb4bbeec8 cleanup: remove old opentracing (#4177)
25a1ae79d engine: Adds dc_resource link support (#4175)
164b08603 engine: do not start local resources with invalid probe specs (#4158)
183c445ef engine: log more readiness probe results (#4183)
27b451cbf server: fix local snapshot testing mode (#4174)
83f12eb12 store: even if a local_resource has no build command, it can still be pending (#4161)
e8edef361 tiltfile: Adds links to dc_resources (#4164)
1df413373 tiltfile: make probe types play nicer with None (#4163)
59acf4ae5 ui: test and resource sidebar toggles use onlick instead of onchange (#4179)
e4d9f183b ui: tests for AlertsOnTop toggle [ch11068] (#4180)
b6520fc66 vendor: pull in tilt-apiserver (#4189)
861a007e0 web: Add divider lines between sections in Overview (#4181)
7a8562647 web: Change OverviewResourceBar font size from smallester to smallest (#4173)
e6adc3b16 web: Fix Sidebar item layout bugs (#4191)
936184cff web: Update All Resources icon (#4166)
c162f6d27 web: Update tests icon (#4169)
1380b8f91 web: Use smallest font for log lines (#4162)
5e255a137 web: add keyboard shortcut for clear logs (#4188)
733f86e74 web: clear logs functionality (#4170)
203f5fb93 web: enable autoscroll in snapshots (#4159)
b54ef198b web: let users re-check resources filter when there are no tests (#4186)
b7aa6174d web: make js tests a test resource (#4187)
68871fc2f web: organize storybook sidebar (#4192)
195b56257 web: persist sidebar options in localStorage (#4157)
c1ca6f2cb web: remove some dependencies (#4149)
f0795ec75 web: show 'alerts on top' toggle even when there are no tests (#4182)
c0a79ca0d web: sidebar tests: default alertsOnTop to false (#4178)
78096367b web: use library for localstorage (#4155)



## Docker images

- `docker pull tiltdev/tilt`
- `docker pull tiltdev/tilt:v0.18.9`
