### PR TITLE
kubeseal 0.15.0

### DIFF
--- a/Food/kubeseal.lua
+++ b/Food/kubeseal.lua
@@ -1,7 +1,7 @@
 local name = "kubeseal"
 local org = "bitnami-labs"
-local release = "v0.14.1"
-local version = "0.14.1"
+local release = "v0.15.0"
+local version = "0.15.0"
 food = {
     name = name,
     description = "A Kubernetes controller and tool for one-way encrypted Secrets",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "0a2c6bc1c4772341b377a0b745db908b3360e0a87e46b16a5314223fe2cc3ede",
+            sha256 = "78b8626bacf6754d0872cc829dbf4eec9dc7b0a0ffa27c76ee324b8b84ad2d3c",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "6887664409a5c2339ab7143356bdb6c220a4cf928568d01745e1e668d8f3fed6",
+            sha256 = "77aeecf4f90f7d8512058a230e416bf7047048c0380192be12e76cc4e73e489d",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/bitnami-labs/sealed-secrets/releases/download/" .. release .. "/" .. name .. ".exe",
-            sha256 = "c4caba9afd459282d6a8f23a7cb0511640c9f546553dccda33b2ba231e2d47da",
+            sha256 = "3a361da61f20e62a599a6961c55ef9603461b32baecae96ce60237c56d47f222",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package kubeseal to release v0.15.0. 

# Release info 

 ## Release Notes

Please read the [RELEASE_NOTES](https://github.com/bitnami-labs/sealed-secrets/blob/master/RELEASE-NOTES.md#v0150) which contain among other things important information for who is upgrading from previous releases.

## Install

### Client side

Install client-side tool into `/usr/local/bin/`:

* **Linux x86_64:**

```bash
wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.15.0/kubeseal-linux-amd64 -O kubeseal
sudo install -m 755 kubeseal /usr/local/bin/kubeseal
```



* **Macos:** (might lag a few hours behind a new release, this icon will reflect that latest release)

[![](https://img.shields.io/homebrew/v/kubeseal)](https://formulae.brew.sh/formula/kubeseal)

```bash
brew install kubeseal
```

* **Other OS/arch:** you might find binaries for your OS/arch combo attached to this release below.

### Cluster side

Install SealedSecret CRD, server-side controller into kube-system namespace.

```sh
$ kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.15.0/controller.yaml
```

NOTE: If you can't (or don't want) to use the `kube-system` namespace, please consider [this approach](https://github.com/bitnami-labs/sealed-secrets#kustomize) 

NOTE: if you want to install it on a GKE cluster for which your user account doesn't have admin rights, please read [this](https://github.com/bitnami-labs/sealed-secrets/blob/master/docs/GKE.md)

NOTE: since the helm chart is currently maintained elsewhere (see https://github.com/helm/charts/tree/master/stable/sealed-secrets) the update of the helm chart might not happen in sync with releases here.
