### PR TITLE
tilt 0.18.10

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.18.9"
+local version = "0.18.10"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "0640a0a5132a863f702f8cced8b95219c0e9d1533becbf6a2370b970740e99de",
+            sha256 = "cd4e654e8f69453bd163fcb9c69cc130eabd3f064cea7749ed6c1f37e089c396",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "130b49a7600975fbb2a7513a8e27d3790c2b0c42a1396761b18c4cf4bdb0ed6b",
+            sha256 = "c208cf329dbb0352f9ef0f27866ac3fded70d3551e8587a99afdd5160e4424a3",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "827114de23b4bd3e08ab79a16c5ee5b85e879b6a1f3b7a21735f636fb7bf0024",
+            sha256 = "05bbe17223ff9641c1588431e2c7e0be6e34a210c3ca4085cbe93ba5e353126c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.18.10. 

# Release info 

 [Install Tilt](https://docs.tilt.dev/install.html) ⬇️ | [Upgrade Tilt](https://docs.tilt.dev/upgrade.html) ⬆️ | [Tilt Cloud](https://cloud.tilt.dev/) ⛅ | [Tilt Extensions](https://github.com/windmilleng/tilt-extensions/) 🧰

## Release Notes

- [`os.path.relpath`](https://github.com/tilt-dev/tilt/pull/4207)
- [Improved filtering in sidebar](https://github.com/tilt-dev/tilt/pull/4201) to explain resources versus tests

## Changelog

b847110db Update version numbers: 0.18.9
6f6271ba8 cli: add a helper for querying the tilt server (#4218)
13c599216 containerupdate: improved error messaging when the file system isn't writable (#4213)
04eef98a9 engine: remove the apiserver controller (#4209)
7981294d4 logstore: truncate chatty resources before non-chatty resources (#4202)
d29ebb5df scripts: add helpers for generating new api types and their clients (#4217)
967d25498 server: Merge an apiserver into the tilt webserver (#4211)
1aa3a1664 tiltfile: add os.path.relpath (#4207)
f7f9bc19f ui/sidebar: change filter naming and behavior to make it clear that tests are a type of resource [ch11349] (#4201)
3bb32e99c ui: don't bother specifying tests as 'local' for now (#4205)
791aee9c8 web: client-side log truncation (#4215)
e425fdd21 web: filter out tabs that aren't in the resource list anymore (#4214)
58981a1a8 web: fix overflow on build fallback lines (#4212)
b807a7a0e web: refine Toggle Mode button design (#4221)
bb40f0cf8 web: remove facets. Fixes https://github.com/tilt-dev/tilt/issues/4219 (#4225)
f51018520 web: remove old UI from HUD (#4224)
39183ad7e web: remove old UI/new UI switch (#4223)



## Docker images

- `docker pull tiltdev/tilt`
- `docker pull tiltdev/tilt:v0.18.10`
