### PR TITLE
yaegi 0.9.14

### DIFF
--- a/Food/yaegi.lua
+++ b/Food/yaegi.lua
@@ -1,5 +1,5 @@
 local name = "yaegi"
-local version = "0.9.8"
+local version = "0.9.14"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/traefik/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_v" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "82a7616a46accd7bd1d1e368ab968478159e1ea27cef144f69a5dc1c10a925ac",
+            sha256 = "9775fd944ce64cc5f5aaf62cadb80d5b586dcaad47fd397d87e25ba0227862b7",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/traefik/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_v" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "c91634ba8dcba9cfb980a14b4ff9b227e9885ad6dd9c09310ff404cc531efcf2",
+            sha256 = "afb1adb0e26d0b7ff23d1c2135a06e656d7bf6915e9afea01906346843f039d8",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package yaegi to release v0.9.14. 

# Release info 

 ## Changelog

8bb5daf feat: update stdlib mapping for go1.16
eb06aee fix: use portable path manipulation for choosing package names

