### PR TITLE
osm 0.7.0

### DIFF
--- a/Food/osm.lua
+++ b/Food/osm.lua
@@ -1,21 +1,34 @@
 local name = "osm"
-local version = "0.3.0"
-
+local release = "v0.7.0"
+local version = "0.7.0"
 food = {
     name = name,
     description = "Open Service Mesh (OSM) is a lightweight, extensible, cloud native service mesh that allows users to uniformly manage, secure, and get out-of-the-box observability features for highly dynamic microservice environments.",
+    license = "Apache-2.0",
     homepage = "https://openservicemesh.io/",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
-            -- shasum of the release archive
-            sha256 = "454b3be1c65ca2a26a1a6ae4fcfaa541fd8a89c15f9459a1acf5bc679fe60f15",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
+            sha256 = "7560a693aa079ca5c5a3db8b8e49293e7a6d9eea2c7f4e99b50b3be9802610ee",
             resources = {
                 {
-                    path = "darwin-amd64/" .. name,
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-darwin-amd64.zip",
+            sha256 = "a567ed1a9707787f7ed8035b4a602d16491823462fa8ef8660cd21f5cd34b406",
+            resources = {
+                {
+                    path = name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -24,12 +37,24 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
-            -- shasum of the release archive
-            sha256 = "541dc7b9efc62268192e4a92155842d1dd8f3ae22953274da364d921ff99d066",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
+            sha256 = "158ab320644fa58362ed84c80ff878dcf6810ca813ba0d9fc8e20ecce74eea7e",
             resources = {
                 {
-                    path = "linux-amd64/" .. name,
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-linux-amd64.zip",
+            sha256 = "2e15a7a7e95dd0542436b0d1825427b0d875d93aec2f366bd365b587e612b866",
+            resources = {
+                {
+                    path = name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -38,12 +63,23 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "windows-amd64.zip",
-            -- shasum of the release archive
-            sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
+            sha256 = "f9d8e073506143b5d19943ad0c358b39f1b698954300c682f5b26c1cb85b780c",
             resources = {
                 {
-                    path = "windows-amd64" .. name .. ".exe",
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-windows-amd64.zip",
+            sha256 = "16d379c00aeae4dce7f19768ebdfb3d5f5f0e754ea9ef45b73280eed521bd49b",
+            resources = {
+                {
+                    path = name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }

--- a/Food/osm.lua
+++ b/Food/osm.lua
@@ -1,34 +1,21 @@
 local name = "osm"
-local release = "v0.7.0"
 local version = "0.7.0"
+
 food = {
     name = name,
     description = "Open Service Mesh (OSM) is a lightweight, extensible, cloud native service mesh that allows users to uniformly manage, secure, and get out-of-the-box observability features for highly dynamic microservice environments.",
-    license = "Apache-2.0",
     homepage = "https://openservicemesh.io/",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
+            -- shasum of the release archive
             sha256 = "7560a693aa079ca5c5a3db8b8e49293e7a6d9eea2c7f4e99b50b3be9802610ee",
             resources = {
                 {
-                    path = name,
-                    installpath = "bin/" .. name,
-                    executable = true
-                }
-            }
-        },
-        {
-            os = "darwin",
-            arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-darwin-amd64.zip",
-            sha256 = "a567ed1a9707787f7ed8035b4a602d16491823462fa8ef8660cd21f5cd34b406",
-            resources = {
-                {
-                    path = name,
+                    path = "darwin-amd64/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -37,24 +24,12 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
+            -- shasum of the release archive
             sha256 = "158ab320644fa58362ed84c80ff878dcf6810ca813ba0d9fc8e20ecce74eea7e",
             resources = {
                 {
-                    path = name,
-                    installpath = "bin/" .. name,
-                    executable = true
-                }
-            }
-        },
-        {
-            os = "linux",
-            arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-linux-amd64.zip",
-            sha256 = "2e15a7a7e95dd0542436b0d1825427b0d875d93aec2f366bd365b587e612b866",
-            resources = {
-                {
-                    path = name,
+                    path = "linux-amd64/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -63,23 +38,12 @@ food = {
         {
             os = "windows",
             arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "f9d8e073506143b5d19943ad0c358b39f1b698954300c682f5b26c1cb85b780c",
-            resources = {
-                {
-                    path = name .. ".exe",
-                    installpath = "bin\\" .. name .. ".exe"
-                }
-            }
-        },
-        {
-            os = "windows",
-            arch = "amd64",
-            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-v" .. version .. "-windows-amd64.zip",
+            url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.zip",
+            -- shasum of the release archive
             sha256 = "16d379c00aeae4dce7f19768ebdfb3d5f5f0e754ea9ef45b73280eed521bd49b",
             resources = {
                 {
-                    path = name .. ".exe",
+                    path = "windows-amd64" .. name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }


### PR DESCRIPTION
Updating package osm to release v0.7.0. 

# Release info 

 ## Notable Changes

* TCP traffic filtering and routing support with SMI policies and in permissive mode
* Ability to program outbound IP range exclusion list to bypass sidecar interception
* Tracing with Jaeger is now disabled by default
* CPU and memory resources for the OSM control plane can now be configured via chart values.
* Add experimental routes v2 functionality which modifies how RDS is programmed in Envoy proxies
* Documentation is now rendered on the Web at https://docs.openservicemesh.io
* CONTRIBUTING.md has been updated to describe OSM's new pull request workflow
* Documentation now includes how to upgrade an OSM control plane with Helm
* Support for gRPC as an application protocol (#2354)
* Updated SMI Traffic Access Control to v1alpha3 and Traffic Specs to v1alpha4
* Logging has been audited for security
* Fixed bug where setting the weight in a Traffic Split to 0 had no effect
* OSM control planes now emit their own Prometheus metrics like number of pods and namespaces in the mesh, XDS statistics, and more
* Updated Envoy used in injected sidecar containers to v1.17
* A validating webhook has been added to verify changes to the `osm-config` ConfigMap

## CRD Updates

charts/osm/crds/access.yaml
charts/osm/crds/specs.yaml

## Changelog

* Update versions to v0.7.0 a2166cfa6b740a6f7d5519dba9e2b5915f30a222 (Jon Huhn)
* fix(release): remove merge commit lines from generated changelog 3ef9857a3a5034e4ed9f5a9c79fdcc860735e33f (Jon Huhn)
* ref(docs): rm unnecessary label from bookstore manifest 1311af3f362e3f0640f7d42bb9ee99cf7165abec (Michelle Noorali)
* chore(docs): update manual demo manifest images acbb34a6c5706a6da1f176e19d247a8c88124751 (Michelle Noorali)
* docs(release): add patch release instructions ee48ed476c1334fff919ec44bb0950b263b2d58e (Jon Huhn)
* docs/examples: document traffic policy modes and update example workflow 4c91215487802fa422ef0d71f0ef87bd23415384 (Shashank Ram)
* tests/e2e: fix default expectations in Helm install test a6f634d3afd8fdaa8e269f2d2ad2ebbb77c023e6 (Shashank Ram)
* tests/e2e: Add a test to verify IP range exclusion ba2cb53024264666f47e612c3523c08dcd3ceef5 (Shashank Ram)
* configurator: remove tracing config keys from required list dcfe26ebe088e79b4b60a80ae52af0277c5d6a88 (Shashank Ram)
* Fixed e2e output 9a687f35e760d8e69d481922982fa3b6a2cd9554 (nshankar13)
* fix(docs/example/README.md): fix apply and move permissivemode c88160e64ba04750c426985e3c14f143bd79407b (Rita Zhang)
* Update readme and tags for 0.7.0-rc.1 2afceb768bb6260b956a9d851aef76fedac9d906 (Sanya Kochhar)
* Turn of tracing by default ea1d39ada0924ee909ecb3d4ff9f1a0af0416b4a (Eduard Serra)
* Update mesh-details dashboard a5412ef515927c686d9bcabcd1b37db5f4562226 (Eduard Serra)
* codecov: enable on pull action and ignore demo/test code 84a1e725efa0787d35d11dcd2f9a07677dae1cf6 (Shashank Ram)
* fix(ci): skip codecov update on PRs 085a6847979f245367d18e4270b2efb95f93752f (Jon Huhn)
* feat(charts/): parameterize resource configuration 5e1b4d38c39a007f639f696f7359cd9c0d2f2e30 (Michelle Noorali)
* metricstore: remove high cardinality labels from metrics osm metrics e206a09b660fedcb6383ec01a62263d8c1307812 (Eduard Serra)
* charts/osm: make IP range exclusion configurable c635b6b2b69d93c680354f1e86171707f23067cf (Shashank Ram)
* charts/osm: update README and remove trailing whitespace d029103a6f0f8994ded95ee64a0c1466f03a32f7 (Shashank Ram)
* test: verify service port's appProtocol precedence over name 7f09a7a901a66512476f80a5a13304acac1e421b (Shashank Ram)
* configurator: validate outbound IP exclusion field 5f2445dad4a703f9002652a0caddf2b3e059c4c4 (Shashank Ram)
* Allow named service ports to specify application protocol b9667c772ea0470d690305b22367019ccb81db88 (Shashank Ram)
* injector: allow outbound IP range exclusions f2b87647dfb4ee9ea83e2b23f14872e46a7b8b10 (Shashank Ram)
* docs(upgrade): Include steps to recreate CRDs 1ea7d27ec48cfa796502b1070f7fe2ba57a7b7e1 (Kalya Subramanian)
* configurator/test: fix test pollution issue 5b38112839b6ff90916b8c4fcbffe7e72d09ce4b (Shashank Ram)
* docs(upgrade): Document mapping of ConfigMap and values file 0a1081a29a412ac3ca015ffb1727d2edcf686b99 (Kalya Subramanian)
* docs: redirect for landing page aaca0166a2eb8cf4215b2773ee908cb30934daf3 (flynnduism)
* feat(*): add routes v2 functionality 94f27be47b7b5e3a1c51500611666a086ad7badb (Michelle Noorali)
* docs: organize markdown content to serve as a website 31f83d6f46e3a3a6902e1ed0827737389359f927 (flynnduism)
* tests(*): fixing labels and fixtures while creating pods 1d88175bb0ff5cfada2d761fe46c39adf5b352bd (Sneha Chhabria)
* docs(upgrade): Add upgrade troubleshooting guide (#2377) 853b99576b4bc325a0c927726385f9d6324984a8 (Kalya Subramanian)
* Make image tag immutable for releases d06015cbd70b86b9ae8097f95c341cc5c42445ad (Shalier Xia)
* fix(make): update e2e kind cluster flag bfdfc0f3dccc057ce54d3e348688e8d95c72e7bb (Jon Huhn)
* injector: Correct error log message (#2382) 2316bdc8e0003e935d5b3c03490783c833e190af (Delyan Raychev)
* tresor: Change log level for a statement from Info to Debug (#2383) ab76653a6128616c97b018aa45d37afb6847d6b5 (Delyan Raychev)
* configurator: Convert Info log messages to Debug (#2381) 4776cad493e868e1d54c8000ffa6b42b60669353 (Delyan Raychev)
* envoy/ads: Augment log messages with context (#2380) 262fd869c4b86f451d7970f3f308bfada4866e28 (Delyan Raychev)
* rds: Augment error log message with Pod UID (#2379) f88ca6e758183c2090ab51610f4d33b7d9065244 (Delyan Raychev)
* injector: Augmenting log line with missing variable (#2378) 377a47f6e1f82cb4cac9a125c28bdf1e074fd50b (Delyan Raychev)
* ads: Add more context with Envoy Pod UID to some log messages (#2376) bc6d52fe8ac370e9e27a9135c80e67acdf1afec8 (Delyan Raychev)
* ads: Adding a comment to a log line to remind us of the importance of logging ADS request/responses carefully (#2375) 3c6353d626d64dd6c6daeb436a2948a1d963591d (Delyan Raychev)
* envoy/route: Delete log line providing little info (#2374) 6b699b938f313c9807184fa44e2f5cbcf260787a (Delyan Raychev)
* catalog: Small tweak verbiage of log line; Delete unused function (#2373) 68bcfabdfe932d42ca50af0c6dd53e4eb4504f77 (Delyan Raychev)
* catalog: Tweak verbiage of log line (#2372) d8b7249545dbc49c9232e9db70f8e73f152393f4 (Delyan Raychev)
* lds/ingress: Tweak error log message for clarity (#2371) 5d7df9f29046f977588bf69442d7a7bd5da2e045 (Delyan Raychev)
* catalog: Augment log messages with Pod UID (#2360) 98a6c0536d967e5c8f16832ae63a46c900a19cf7 (Delyan Raychev)
* contributing: update guide to reflect new pull request workflow 3723c37c19589a43c2981e4e13125a04c6d2ad47 (Shashank Ram)
* docs(upgrade): Add docs for helm upgrade (#2340) 90c325967e903cdd5a2ef11b73324f2b39d49d4a (Kalya Subramanian)
* Fix typo on Prometheus enablement flag 3b9640080f3409b91330f7fbaea6b57f24b651eb (Chad Kittel)
* [tests] : Adding unit test for the entire envoy listener configuration (#2358) 1c00c3706111dea3168762737a01480f691d42ac (Sneha Chhabria)
* injector: Small correction to a log message (#2355) e109d6aaa7cb016242fe461dfc22d9e0bc77d222 (Delyan Raychev)
* reconciler: Tiny adjustment to a log message (#2357) 4e11b98994f42e002ea1265cde9df44dc894438f (Delyan Raychev)
* gRPC: allow specifying gRPC as appProtocol for service ports (#2354) b7b4c8d285bf2d81e24fd373809fbccf63cab975 (Shashank Ram)
* logs: Use Certificate SerialNumber instead of Subject CN (#2351) e59da65cf60c179dabd59356dc51fb663d308990 (Delyan Raychev)
* logging: remove SAN from logs (#2346) 1e6b29adcb53fa224efd35174f6a48025e0269f8 (Sanya Kochhar)
* docs(release): document release candidate process (#2341) 98d46755d6de16bf1d14055207d7dea2098382e3 (Jon Huhn)
* ci: Run Envoy + SMI scenario tests as part of CI (#2303) a0fd215dc7fcaf2ae33c1cff49593a797a88ef79 (Delyan Raychev)
* injector: Idiomatic logging of error messages with log.Error().Err(err) (#2349) 100375bc6916f8fcbe37bf1775db1199b60a6796 (Delyan Raychev)
* ads: Curate log messages when Envoys connect to xDS control plane (#2350) b21a1513c29a7a83de47cacc518187c975445261 (Delyan Raychev)
* ads: Do not log Envoy's XDS Certificate CN; log cert's SerialNumber instead (#2345) d6b003bba703a652266debbbb0b4f18adc7673b3 (Delyan Raychev)
* injector: Idiomatic logging of error messages with log.Error().Err(err) (#2348) bc1d7de24483389e4b039a84d0193ff4159bb574 (Delyan Raychev)
* injector/init: generate init-container commands within osm-controller (#2343) 05677b01808ab20239cf35973c706fd96eab2f55 (Shashank Ram)
* Proxy fields xDSCertificateCommonName and xDSCertificateSerialNumber can be private 2d72897d5e401cfd49d879fec9a9db1cbbccedef (Delyan Raychev)
* Rename CommonName and SerialNumber fields on the Proxy struct 08b5bdc4d343e94ec72363023a1c8170abfe5106 (Delyan Raychev)
* proxy: Add certificate SerialNumber UID to NewProxy() and Proxy{} 1c0637f819e14ce74d4b506400c6511f0803dba9 (Delyan Raychev)
* Change ValidateClient to return certificate SerialNumber for newly connected Envoy proxy da679d7145ff47302659dc5a38aa7f302874d4fe (Delyan Raychev)
* smi/traffic-access: update to v1alpha3 (#2336) edd9902793dbf4f34de2b5d25c8ad2b369704dc4 (Shashank Ram)
* Auditing the log levels in OSM (#2335) a0f936feb57e241b965652f56aa5f1e5b45a43da (Sneha Chhabria)
* Disable test temporarily e64c6b073ab65eec9c522286433aa078f7853849 (Delyan Raychev)
* proxy: Rename GetCommonName() to GetCertificateCommonName(); Add GetCertificateSerialNumber() e2edc7841f608fd7c1d0d96717cd769547509c3b (Delyan Raychev)
* doc(chart): Updated chart readme (#2322) 85b52172ba8c2a706fa2b9c6d3b07ed1ab85fad6 (Alessandro Vozza)
* smi: update to smi-sdk-go v0.5.0 and traffic-specs v1alpha4 (#2331) db184fcd88774f6f03ad18b4a22f4f12b4598004 (Shashank Ram)
* Update pkg/certificate/providers/vault/certificate_manager.go 2ca81ad3118c81e73f86b7300b1e3e832d61e240 (Delyan Raychev)
* Update pkg/certificate/providers/certmanager/types.go 42d0aea4c031b93ddf2546855511856006f2c6f3 (Delyan Raychev)
* Update pkg/envoy/ads/response.go 8c99a84dae02eb3fa32bf900b0f4af26b8dd1ccc (Delyan Raychev)
* Fixing typos in comments, variable names etc. 08f7152e3663c346510a21a37f4bb64178a02562 (Delyan Raychev)
* ref(release): Include CRD upgrade info in Release Notes (#2323) 50a62d37e3143645d37730c581a3b9e030db9a38 (Kalya Subramanian)
* Fix log messages 1c8e1112e12d3a4a33841afb140b9008ab6ec898 (Delyan Raychev)
* certificate: Delete unused functions (#2305) e75dddb0cf46e9957ecc3701e672ce621dc8a5b5 (Delyan Raychev)
* logging: remove request response from log (#2321) c11e26761a12bbf716d2eaba613262eb47860146 (Sanya Kochhar)
* logging: remove raw object from logs (#2326) 16b7727f33e31f4190e6dd0f41ebe3efe2b9224c (Sanya Kochhar)
* [Bugfix] : Handling services with weight 0 in traffic split (#2320) 8f85d4f2b34603a46d9df43b02b9bdb86af62e42 (Sneha Chhabria)
* sds: Correct comments and tests - remove mentions of non-existent requestedCertType function (#2298) d8697f896856946cc41a397c6168d24974d5b8c6 (Delyan Raychev)
* metrics: add metrics for pod and namespace count (#2324) 712cf95a874af938a932ab415af4ad4c6f778e44 (Shashank Ram)
* providers: Remove Azure endpoints provider (#2325) 966cb93d34dafae221376039084d555c2c99073c (Delyan Raychev)
* certificate: Implement GetSerialNumber() for all certificate issuers/providers (#2319) 0011cf99d7a97ca35a87858983593e2951de3a3e (Delyan Raychev)
* logging: change podIPs to UIDs (#2315) 57aad53279ed0a90e85e0ff13fe7544e7f4f9d1f (Sanya Kochhar)
* injector: fix bug where existing volumes in pod spec are not preserved (#2238) de5bd8de1ab33987e69aefd0debc818656887cbc (Addo.Zhang)
* debugger: refactor httpserver and debugger (#2308) 24c30d8edcb8fb00d127cf5ea46e238effe465fe (Edu Serra)
* certificate: Document kinds of certificates in OSM (#2301) 22d368e68d6d2208ae84b65521cff2cbb7b72f62 (Delyan Raychev)
* metrics : exposing metric for time take to issue xds certificates  (#2306) b9e56aa7fd0b7cff3436159ad1681ce695d92bd4 (Sneha Chhabria)
* changed from connectvault to certmanager in osm_deployment (#2307) 8d10b1018c186fba8999ffa50f0e2818d7ea9f8d (Niranjan Shankar)
* metrics : exposing metric for number for xds certificates issued (#2302) b7337ab144d0126fa44312bc3001f563183ffb76 (Sneha Chhabria)
* scenarios: Test that the apex service is removed in traffic split (#2274) 9cb32462fbd1837d5d2f084b1d0ee9638ffd50ee (Delyan Raychev)
* metrics: fix use of short XDS name, Grafan "mesh details" dashboard update (#2300) bfab45e76d38a2cc563adb17ba3223a63e384719 (Edu Serra)
* envoy/lds: build outound service filter chains per port (#2299) e8880c98217a461ed29648a3bb47ffe371a9c052 (Shashank Ram)
* s/SerivceAccount/ServiceAccount/g (#2297) d7f592ad3fdf7aae0c6f440e19e072c46afd777a (Delyan Raychev)
* ref(jaeger): Disable Jaeger by default (#2291) 6f4349a52e82323f5ea800d7d902efc7af54b5e0 (Kalya Subramanian)
* pkg/*: rename APIs used to retrieve protocol mapping for port and targetPort (#2296) 4c782b05b8bcc1693fb10c899695768a8fd5b95e (Shashank Ram)
* catalog: add api to retrieve port:protocol mapping (#2295) 92793eaa18bf7692363cf96b4b1b4db47dbc9769 (Shashank Ram)
* ads/metrics: implement xds path time metrics (#2292) ee1ce5e6ac4a445d4a4ebc35a1c725b0ba2d43f5 (Edu Serra)
* metrics: use event type value as the metric label (#2289) d737ac07b3c87abe0953dd233551dec4601bd673 (Shashank Ram)
* Adding scraping to OSM pod (#2288) 797e53f214871e9f39e8266a94acb703694861d0 (Edu Serra)
* envoy: update to v1.17 to leverage default_filter_chain (#2286) 88980a8e94b91842b60da873ee3feef53ef48b7e (Shashank Ram)
* metrics: add type and namespace label to k8s event metric (#2285) 65af7d64eb0f4075190d35eab9551f22bef6d819 (Shashank Ram)
* prometheus: limit scrapping to currently used metrics only (#2276) 9614eeebbfb8268d94a450d75299536d57c88160 (Edu Serra)
* metrics: add injector webhook metrics (#2284) 047154e40bf39a57785fc84c405ddefbd0a653fb (Edu Serra)
* Update debug server test (#2283) ac52c1fd7c381b8d65278cf19873db8a353b68f8 (Niranjan Shankar)
* Bump versions for 0.6.1 release 01a1dc44a55f964f81164a61454ffff3447d1dfd (Sanya Kochhar)
* metrics: expose metrics for number of connected proxies (#2278) 7a4e24a8ef500a64d2c9233063e69c9ac56ce390 (Shashank Ram)
* metricsstore: export prometheus metrics to clients (#2275) b1f24cd64943da411e6f2ff54ab80f5d8b06bc80 (Shashank Ram)
* webhooks: use separate service and port for validating webhook (#2273) a48de43463c99c03e3662670bf7f2b99166e1388 (Shashank Ram)
* metricsstore: integrate metrics store framework (#2270) e29193347597bfb3667c377c2b8ef84120be5aff (Shashank Ram)
* docs(release): clarify version update PR (#2272) dd659335345c7e2bec404d6deace847a725d3146 (Jon Huhn)
* docs(release): clarify main branch version update (#2202) 1898232c1b60aa3c35ce8d6d1bb2738b052c41aa (Jon Huhn)
* injector: Rewrite app health probes; pass through Envoy to payload (#2233) ef3366531807908a77b3dadd9c3acb921c680b6f (Delyan Raychev)
* Aliasing import testify/assert to tassert to avoid collision with variable (#2256) df7640e6f3fcda6462ce3b5ffad159113a898565 (Delyan Raychev)
* charts: disable validating webhook configuration (#2268) a1f00602701f2ff02f339fa21fe20c5f5c681701 (Shashank Ram)
* doc(uninstall): Document which resources are deleted by uninstall (#2267) d2a8f1f6cab39e835963a09d5e913de16d263912 (Kalya Subramanian)
* trafficpolicy: Remove conditional always evaluating to true (#2250) e11a19c175037faba5290db4eb7eb4c83928f4e8 (Delyan Raychev)
* kubernetes: Log the informer and provider names w/ debug log messages (#2255) 268b512e45ae175a28fffb5b7979646e71bf0137 (Delyan Raychev)
* catalog: simplify function isValidTrafficTarget() (#2246) d640c42c6cf339cd777170f2444394bbedfff096 (Delyan Raychev)
* cds: Remove conditional always evaluating to true (#2261) 46050682d594a9fc9533dde1382addb3c9a6ee33 (Delyan Raychev)
* rds: Rename variable colliding with imported package split (#2247) 6c8eac74589a73a03c951f4c1383277e71316c69 (Delyan Raychev)
* cli: Check for nil when getting OSM Controller Deployments (#2258) 4554d191de78b7da7a9a84d031e73e16ef344342 (Delyan Raychev)
* reconciler: Removing the + flag from %+s which will be ignored by verb in printf statement (#2257) b99e1ab9fa96e3b34a83e4178bff6fab8d1f371c (Delyan Raychev)
* eds: Remove unused variables and inline usage of meshCatalog.ListAllowedOutboundServicesForIdentity() in for loop (#2259) cf3ebf119d4cdf3e87e7e9e460cf0bf08c3a393f (Delyan Raychev)
* Fixing typo: s/taggic/tagging/g (#2249) f7bdec70605eb68ea9254a44ba2dc984e152a9f0 (Delyan Raychev)
* Removing redundant import aliases (#2251) 4d8175afdd51a3c392d2a68b4967029ddc8352a9 (Delyan Raychev)
* catalog: Add comment to explain what a bool return does (#2245) 7944a11844f2f01b97880e4369cc488cacc27e71 (Delyan Raychev)
* Fix typo s/namepace/namespace/g (#2248) 6cf6c28a88cb692393eb021d2452bfb96e120024 (Delyan Raychev)
* Remove duplicate lines from .gitignore (#2252) 34ce3c667fb61a4895b35bb6caa720373abd7cde (Delyan Raychev)
* utils: Delete unused UUID util functions (#2253) 710ad009790603ad54f35cd23914481dea349217 (Delyan Raychev)
* Use _ for unused function params (#2254) c4644ccbac63cca9541e07f241021b1adc2c990c (Delyan Raychev)
* Temp fix: Commenting out validating webhook, need to debug (#2265) c48acb9c61c8650a7ff0b4516de001c3d1728387 (Shalier Xia)
* charts/validatingwebhook: allow webhook deletion (#2262) 346546ee09fce9368049b8a25608510f20b4d7ee (Shashank Ram)
* Changing linear search function to mapset (#2241) e627efa5b172e6cc64ccde5f4f2493ce9ca19731 (Edu Serra)
* configurator: update validating webhook's port (#2242) 40528178960354060bf4166c7ae6e0c05a6b90a9 (Shashank Ram)
* fix(demo/README.md): Fixed the OSM controller debug port and broken links in README (#2240) 98725da5c7012e1d89ba25164c927c4690dbb75b (Aisuko)
* remove duplicated address_prefix (#2239) 459e35391648fd477c277bc11b91fc094f9ef1e4 (Addo.Zhang)
* fix(pkg): fix typo in health.go (#2236) 08efd2a2eb320ac955ad19c785a4d77d6a2682e7 (Sanya Kochhar)
* feat(*): add validating webhook for osm-config (#2213) f18bf91683dbe090ebc7042f4c59760459180b0f (Shalier Xia)
* fix(docs/Design.md): Fix the wrong title links of document contents (#2235) 4ec3225f88444213a1018c5f024526a6f73b9fef (Aisuko)
* fix(fluent bit): allow httpProxy or httpsProxy value to be empty (#2231) bf1f2b28f790adfa6cb8d49690aa61e1b40d6b57 (Sanya Kochhar)
* Fix race on event handler test (#2232) e111a4071d098e5dccdb6c5a5a49c1e675d1efc4 (Edu Serra)
* tests/e2e: add test for tcp egress (#2230) 28611876a0759a697f1302879fc2d6cc43ec0021 (Shashank Ram)
* Announcement Channels cleanup (#2228) 9eaec684ab40e1cd21032d44606463aec625fb67 (Edu Serra)
* tests/e2e: move tcp test to own file and test permissive mode (#2227) 932c6916a72ebed266ddd301dd3a5ca2bee128ee (Shashank Ram)
* injector: Simplify check for metrics annotations (#2205) 4defb020cf59c9103522b1bed4f8b3470065910a (Delyan Raychev)
* envoy/rbac: rename rbac policy helper functions (#2226) 23e0d2b7cbe25e100f5a1687914a40b7cb5cfc2b (Shashank Ram)
* rbac/tcp: support port based RBAC for tcp traffic (#2224) 498a4642ba1bdb9a24878b62e1f7446834da5ad2 (Shashank Ram)
* injector: Split Envoy bootstrap config generation into smaller functions (#2225) dfba804e10d21c526741398b235baec56c89bece (Delyan Raychev)
* demo: Adding /liveness, /readiness, /startup paths to the bookstore web server (#2223) 9b690073b76634b2a731cdc235425dd41eed31ff (Delyan Raychev)
* cds: Add comments and tweak getPrometheusCluster() and getTracingCluster() for readability (#2211) 0f3c5875079d2f9406823b4c8f7fc18c57cf8d7e (Delyan Raychev)
* catalog: update api to retrieve traffic targets (#2222) 7f1a775cdd0f01a70d9075cb4027812d0bb2438e (Shashank Ram)
* @configurator: add specific ConfigMap handler (#2220) 4aa08b7a5311a7cf9918a5a59754b831ce0ac8fc (Edu Serra)
* pkg/*: add api to list traffic targets composed of associated routes (#2221) 85f8810ab241f895fa8959348413fb613d4b7ff9 (Shashank Ram)
* configurator: clean private pubsub interface in favour of global one (#2219) b24f86bc4996a0a82b7249cc8623e8bc68ed3d30 (Edu Serra)
* injector: Use admission.PatchResponseFromRaw to create patches (#2215) a7666fb70af23054accd47b352cc88b99375ff63 (Delyan Raychev)
* ci: only run maestro once for tresor (#2217) 5d52737294d9bfa4eb607bb11a5ff68ff487b60e (Shashank Ram)
* tests/e2e: add connectivity test with osm-controller restart (#2212) c37caccdd98e993bfa42e4b25fb99fcb3c548bac (Shashank Ram)
* envoy/ads/stream.go: Force full config of an envoy when it connects (#2210) e36ec1f6bfd09f4ab8ddc1789b1f154f16f63e4a (Edu Serra)
* Typo fix s/annotion/annotation/g (#2204) dcfaf0678b787f95ebd922c650fdce321688dcdb (Delyan Raychev)
* tests/scale: pod/traffic split scaling test (#2186) 32fb0904b5fae9f19241565add738fe2d50af967 (Edu Serra)
* tests/e2e: set AppProto only if definition has it set (#2198) f1b74fa622069089b2eec2774c0e08c039e294ac (Edu Serra)
* demo: Tweaking join/unjoin demo scripts (#2196) c0fb7542d29e96cffab8554367623bb51c4a03a8 (Delyan Raychev)
* Update versions for release 0.6.0 (#2200) 23f20b35697bdbb281238ff684ea2da2b6fc5e96 (Sanya Kochhar)
* fluent bit: add identifier to help query logs in output  (#2195) 8f40c88d00f0500d1412745714fc01ccfd5f29b4 (Sanya Kochhar)
* tests/e2e: add e2e test for TCP traffic (#2194) 14b81042e865bbdd851da28ba4384d7bd848a009 (Shashank Ram)
* scripts: Add script to clean up leaked osm resources (#2193) 7647d125ac71c3868063ecef6401d28bf3fb4cbe (Kalya Subramanian)
* nit: Fix osmNamespace description in values schema (#2192) 196a62ab9c02e9598bc43fff515f9702ae39948a (Kalya Subramanian)
* fix(fluent bit): update filters to work for various k8s distros (#2170) 5f6e78599c5c4bd17bddf17f4f92ca6829e2f279 (Sanya Kochhar)
* feat(pkg/catalog): build inbound/outbound policies from traffic targets (#2187) ff5827399719532bcbc0952dacceae920740e90c (Michelle Noorali)
* endpoint/kube: Cleanup and move remaining caches to kubecontroller (#2191) 9907bcf132fd041670ef868c6bf4a68e9f22ef99 (Edu Serra)
* feat(util): add convenience funcs to get hostnames (#2189) ea43cfdf79268cd8e8f24df95c135da7c1067fbf (Michelle Noorali)
* feat(pkg/trafficpolicy): add constructor funcs (#2188) b3cd61caa2d06a5aeb41039d2918121634bbb5bf (Michelle Noorali)
* tests/framework/profile: allow mutliple results write descriptors (#2185) 9eb9a67bc4862728a0655e9ab124be688513ab46 (Edu Serra)
* feat(osm/install): Decouple releaseNamespace and osmNamespace (#2142) 25144a1b474ffe4a572b82477bf77ba44e9d928c (Kalya Subramanian)
* feat(*): add functions for merging traffic policies (#2181) 6e14677951991af17a0104dcb731f4c4e74db6eb (Michelle Noorali)
* pkg/*: use mutliple value case statement instead of fallthrough (#2184) c8244a23bd27f71e405c237654e4722e395721e8 (Shashank Ram)
* tcp: add outbound proxying support and update tcp demo (#2183) d906267e575e14f43ca9ca72bc69a6819f467d2c (Shashank Ram)
* fix(e2e): gracefully stop port forwarding to Prometheus/Grafana (#2182) 0fd1d1b2f02967fc4e579de1c7904027ff09251a (Jon Huhn)
* fix(e2e): fix typo in method name (#2180) 524e87a33d11425609767f830a298a6e9cde1d7f (Jon Huhn)
* doc(charts): doc why failurePolicy must be Fail (#2178) 4245abc8b77b74b0f46d32d2672623b286631ac3 (Michelle Noorali)
* ref(pkg/catalog): add ListMeshServices method (#2176) d0cd81409d53f9066e811f39ae621c7d42abf9fe (Michelle Noorali)
* pkg/*: use newer api to list outbound services (#2177) d05ceb2e4263152beeb88b02f4142c7bcfc51b7d (Shashank Ram)
* tests/frmwrk: Add testFolder and setOverrides (#2175) 99adfab8873d1a83eac75f8575ad7a969f69fc80 (Edu Serra)
* ref(pkg/envoy/cds): use proxy identity to build outbound services (#2174) eeb16004b28b8ac4b40c4d5279f016b1642a61fc (Michelle Noorali)
* Grafana/dashboards: change rate to irate (#2165) 3beb53e9b1e89a7cbfbea87354382ac4b11d4b04 (Edu Serra)
* tests/framework: framework monitoring/scale updates (#2163) 033ddeaa5cfab66508697a306286d96e65d924a2 (Edu Serra)
* ref(pkg/catalog): update ListAllowedOutboundServicesForIdentity (#2173) b64d9a538bae5a5870f9e59c4feeb025ab70b3c4 (Michelle Noorali)
* docs(release): clarify remotes in release guide (#2166) 0d40ccb737e2f6ff05e1ec1edc411f10b775dc25 (Jon Huhn)
* feat(pkg/catalog): list allowed outbound services for identity (#2169) 4b9e393c4a60143e3c05c82f1a6e191e10e6d216 (Michelle Noorali)
* add --set to the osm cli (#1654) f493bfa6e7e82b8704d4a1a05a37b3cdd1d86bac (Rajkumar Purushothaman)
* demo/tcp: adds simple tcp client server demo (#2161) 2349201581fe21b5afb7acc6b9afc3a284969adc (Shashank Ram)
* feat(pkg/trafficpolicy): add routes to outbound traffic policy (#2150) dff997555fa8867437b9354a22c0981384d23daf (Michelle Noorali)
