### PR TITLE
octant 0.17.0

### DIFF
--- a/Food/octant.lua
+++ b/Food/octant.lua
@@ -1,21 +1,21 @@
 local name = "octant"
-local release = "v0.17.0"
-local version = "0.17.0"
+local version = "0.15.0"
+
 food = {
     name = name,
-    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters.",
-    license = "Apache-2.0",
-    homepage = "https://octant.dev",
+    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters",
+    homepage = "https://github.com/vmware-tanzu/octant",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_macOS-64bit.tar.gz",
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS-64bit.tar.gz",
+            -- shasum of the release archive
             sha256 = "ca379e2680e1cf4a0b753fc389de6f700be985b63244ded6cc72d1e3b3f69730",
             resources = {
                 {
-                    path = name,
+                    path = "octant_" .. version .. "_macOS-64bit/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -24,11 +24,12 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz",
+	        url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz", 
+            -- shasum of the release archive
             sha256 = "9f10ef7a0ae7f4dffa18da66d608c63c0116c6709eab1e0db75a17da3f165d98",
             resources = {
                 {
-                    path = name,
+                    path = "octant_" .. version .. "_Linux-64bit/" .. name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -36,15 +37,17 @@ food = {
         },
         {
             os = "windows",
-            arch = "amd64",
-            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows-64bit.zip",
+	        arch = "amd64",
+	        url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Windows-64bit.zip",
+            -- shasum of the release archive
             sha256 = "5c5b10c2d97997a8c051f1c8625762a56603a708050f343098717480fed45c4f",
             resources = {
                 {
-                    path = name .. ".exe",
+                    path = "octant_" .. version .. "_Windows-64bit/" .. name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }
         }
     }
 }
+

--- a/Food/octant.lua
+++ b/Food/octant.lua
@@ -1,5 +1,5 @@
 local name = "octant"
-local version = "0.15.0"
+local version = "0.17.0"
 
 food = {
     name = name,

--- a/Food/octant.lua
+++ b/Food/octant.lua
@@ -1,21 +1,21 @@
 local name = "octant"
-local version = "0.15.0"
-
+local release = "v0.17.0"
+local version = "0.17.0"
 food = {
     name = name,
-    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters",
-    homepage = "https://github.com/vmware-tanzu/octant",
+    description = "Highly extensible platform for developers to better understand the complexity of Kubernetes clusters.",
+    license = "Apache-2.0",
+    homepage = "https://octant.dev",
     version = version,
     packages = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS-64bit.tar.gz",
-            -- shasum of the release archive
-            sha256 = "63d03320e058eab4ef7ace6eb17c00e56f8fab85a202843295922535d28693a8",
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_macOS-64bit.tar.gz",
+            sha256 = "ca379e2680e1cf4a0b753fc389de6f700be985b63244ded6cc72d1e3b3f69730",
             resources = {
                 {
-                    path = "octant_" .. version .. "_macOS-64bit/" .. name,
+                    path = name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -24,12 +24,11 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-	    url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz", 
-            -- shasum of the release archive
-            sha256 = "475c420c42f4d5f44650b1fb383f7e830e3939cbcc28e84ef49a6269dc3f658e",
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz",
+            sha256 = "9f10ef7a0ae7f4dffa18da66d608c63c0116c6709eab1e0db75a17da3f165d98",
             resources = {
                 {
-                    path = "octant_" .. version .. "_Linux-64bit/" .. name,
+                    path = name,
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -37,17 +36,15 @@ food = {
         },
         {
             os = "windows",
-	    arch = "amd64",
-	    url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Windows-64bit.tar.gz",
-            -- shasum of the release archive
-            sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
+            arch = "amd64",
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows-64bit.zip",
+            sha256 = "5c5b10c2d97997a8c051f1c8625762a56603a708050f343098717480fed45c4f",
             resources = {
                 {
-                    path = "octant_" .. version .. "_Windows-64bit/" .. name .. ".exe",
+                    path = name .. ".exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }
         }
     }
 }
-

--- a/Food/octant.lua
+++ b/Food/octant.lua
@@ -24,7 +24,7 @@ food = {
         {
             os = "linux",
             arch = "amd64",
-	        url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz", 
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Linux-64bit.tar.gz", 
             -- shasum of the release archive
             sha256 = "9f10ef7a0ae7f4dffa18da66d608c63c0116c6709eab1e0db75a17da3f165d98",
             resources = {
@@ -37,8 +37,8 @@ food = {
         },
         {
             os = "windows",
-	        arch = "amd64",
-	        url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Windows-64bit.zip",
+            arch = "amd64",
+            url = "https://github.com/vmware-tanzu/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_Windows-64bit.zip",
             -- shasum of the release archive
             sha256 = "5c5b10c2d97997a8c051f1c8625762a56603a708050f343098717480fed45c4f",
             resources = {


### PR DESCRIPTION
Updating package octant to release v0.17.0. 

# Release info 

 ## v0.17.0
#### 2021-2-11

### Download
 - https://github.com/vmware-tanzu/octant/releases/v0.17.0

### Highlights
  * Added dropdowns to breadcrumbs (#1212, @mklanjsek)
  * Redesigned left navigation (#1353, @mklanjsek)
  * Added tooltips, support for different segment colors and thickness to donut charts (#1465, @mklanjsek)
  * Added Preferences to the bottom of the Vertical Navigation (#1498, @mklanjsek)
  * Added dropdown component (#1562, @mklanjsek)
  * Added pods table to node overview (#1773, @zparnold)
  * Added official language for approver status (#1874, @wwitzel3)
  * Added version skew policy (#1896, @GuessWhoSamFoo)

### Bug Fixes
  * Fixed issues with incorrect paths on Windows (#1696, @mklanjsek)
  * Fixed issue with broken links created from plugin (#1723, @mklanjsek)
  * Fixed streamer test flake (#1797, @GuessWhoSamFoo)

### Electron
  * Added preferences to bottom of the left nav (#1538, @mklanjsek)
  * Updated electron for osx arm64 (#1822, @akhenakh)
  * Added build pipeline using electron-builder (#1827, @GuessWhoSamFoo)
  * Changed to use random port when running as electron (#1852, @GuessWhoSamFoo)
  * Added menu to open log files (#1889, @wwitzel)
  * Added forward and back buttons to electron build (#1902, @GuessWhoSamFoo)
  * Consolidated preferences storage (#1957, @mklanjsek)
  * Added developer preferences (#1986, @mklanjsek)

### All Changes
  * Added docs section to reference.octant.dev (#1079, @wwitzel3)
  * Normalize markdown styles to match other text in datagrids (#1503, @scothis)
  * Updated dependabot to automatically vendor go module updates (#1524, @scothis)
  * Added multi key table sort and added reverse method (#1566, @GuessWhoSamFoo)
  * Refactored dash.Runner startup (#1676, @jamieklassen)
  * Show only preferred versions of CRDs instead of all versions (#1737, @bryanl)
  * Added support for windows shells and bash (#1749, @GuessWhoSamFoo)
