### PR TITLE
eksctl 0.39.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.38.0"
+local version = "0.39.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "67e0be677db8c2dc3002ab4fceb14e60ca8a8aa10b3726ca1acddcae6cbb2008",
+            sha256 = "a6a63ada4aabe1e6e404813b5a91b2c5dfa6b4ac0423a0cd8a4ad46ad717f593",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "e7d300b3beb9d488e654a36a3c166998fa1a0c0e2237622f341bacfa2b06666e",
+            sha256 = "68696ce4b1062f5a35baf229a31d59b45eac995778010b5f1ab4a35dd1323b2b",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "f89edf01874a5cbfc22bdb4b2d4be1b7da30abecaff95072c3cfae779eb4195f",
+            sha256 = "8eb9efd65c4028845f9b869c285cf99d18c351021d49f5b0b648ae68ffb525f7",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.39.0. 

# Release info 

 # Release 0.39.0

## Features

- Support enabling KMS encryption for existing clusters (#3364)
- add permission boundary to addon role (#3276)
- support delete addon when only the addon stack exists (#3280)

## Improvements

- bump EKS 1.19 coredns to 1.8.0 (#3319)
- bump upgrade cluster timeout to 65 (#3310)
- Make nodegroup CloudFormation stack slimmer (#3277)

## Bug Fixes

- Fix specifying subnets by AZ (#3301)
- Fix support for specifying subnets without ID (#3229)

## Acknowledgments
Weaveworks would like to sincerely thank:
    @hiraken-w and @morancj

