### PR TITLE
argocd 1.8.6

### DIFF
--- a/Food/argocd.lua
+++ b/Food/argocd.lua
@@ -1,5 +1,5 @@
 local name = "argocd"
-local version = "1.8.5"
+local version = "1.8.6"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/argoproj/argo-cd/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "478c7bbb05541e708664e6876ec9bb260d4755ccde3d953cef00635625eeb39f",
+            sha256 = "9c73eca53787fc30d131f7acd0287a28ca2493adc81bc3ec40f0c21aef418edd",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/argoproj/argo-cd/releases/download/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "603d503da3f1d473100164aad5855793acf25fbe05ddd36ee7a25551d181a4b9",
+            sha256 = "fc333aaf91abe35778c3e74406069dc71228904296ca285ecb9b3efd0e321928",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/argoproj/argo-cd/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "3aea99b74ecd42f1dd99044c1699bce85d7db80a086b5eea5f45e82dadaae47f",
+            sha256 = "cbfc82d16b6091f2e30d5b5d3c2ad628d1afbf7ad32fddeaad355abc74be834f",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package argocd to release v1.8.6. 

# Release info 

 ## Quick Start

### Non-HA:

```
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v1.8.6/manifests/install.yaml
```

### HA:

```
kubectl create namespace argocd
kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/v1.8.6/manifests/ha/install.yaml
```

#### Bug Fixes

* fix: Properly escape HTML for error message from CLI SSO (#5563)
* fix: API server should not print resource body when resource update fails (#5617)
* fix: fix memory leak in application controller (#5604)