### PR TITLE
polaris 3.1.4

### DIFF
--- a/Food/polaris.lua
+++ b/Food/polaris.lua
@@ -1,5 +1,5 @@
 local name = "polaris"
-local version = "3.1.3"
+local version = "3.1.4"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "140642c2a0647e9eff789f35ff434f280f0a6cd196bc472e3b916076203b2cf8",
+            sha256 = "8cfb565d3e945d83df5ac100a082ea55bb55add34156e16f3e32a2ceb31c6344",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/FairwindsOps/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "d9a841629b7edb0f3478b53d01058196d18ea5474028e4a122bcd3797ef514ea",
+            sha256 = "f0c014a6ea87913c793e025eae588076b172596e452a3a4405d8fa4b518a9a90",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package polaris to release 3.1.4. 

# Release info 

 

## Changelog

dea71438 Bump github.com/sirupsen/logrus from 1.7.0 to 1.8.0 (#504)
3e49a3af Bump github.com/spf13/cobra from 1.1.1 to 1.1.3 (#497)
41d5f728 Bump k8s.io/api from 0.20.2 to 0.20.4 (#501)
89ff4a6d Fix a small typo in the README file where a sentence is repeated. (#483)
a5852f30 Make it easier to run webhook tests locally (#476)
16ffe1e1 Merge pull request #487 from FairwindsOps/only-failed-test-audit
4c3d0e06 Set full object ObjectMeta on new workload from Pod (#471)
fe0060af added test for score
1a025da6 bump version
8bbe13b6 document show only failed test flag
7f1c143d fix docs
f42af353 fix merge conflicts
0aa17378 refactor resultSet loop
714b7bfb trigger CI


