### PR TITLE
tilt 0.18.11

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.18.10"
+local version = "0.18.11"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "cd4e654e8f69453bd163fcb9c69cc130eabd3f064cea7749ed6c1f37e089c396",
+            sha256 = "97369e0a128dd891f95e67087c60cbe8b3ea169fdc16fcb88a0eeac3b6a76166",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "c208cf329dbb0352f9ef0f27866ac3fded70d3551e8587a99afdd5160e4424a3",
+            sha256 = "d5a8acc2082d0484eb4797961dbcbc16a7b981702c7cd8bb9e6f665756ab2770",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "05bbe17223ff9641c1588431e2c7e0be6e34a210c3ca4085cbe93ba5e353126c",
+            sha256 = "981d928fae39056a009210e770e227da4fb25c34aa7d9f7ee2858a08e69ac74a",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.18.11. 

# Release info 

 [Install Tilt](https://docs.tilt.dev/install.html) ⬇️ | [Upgrade Tilt](https://docs.tilt.dev/upgrade.html) ⬆️ | [Tilt Cloud](https://cloud.tilt.dev/) ⛅ | [Tilt Extensions](https://github.com/windmilleng/tilt-extensions/) 🧰

## Release Notes

- UI improvements
- fix a bug where services sometimes attached to the wrong resources (#4237)
- fix a bug where we didn't check k8s context like we ought to (#4234)
- groundwork for the Tilt architecture of ✨ the future ✨

## Changelog

cd5e52ad7 Update version numbers: 0.18.10
b720d5949 apis: add a Cmd type for local commands (#4243)
b7dcc160b apis: fork probe data model (#4254)
c5e7669d3 engine: switch from Kubernetes Probe API to our fork (#4255)
d7fd678b4 k8s: don't attach a service to a workload if it has no selectors [ch11448] (#4237)
8faa02e77 lint: run goimports, remove dead code (#4235)
802d625e0 scripts: fix api-new-type to compute resource names properly (#4242)
4f2e1e611 scripts: update release image to go 1.14 (#4230)
4e8d5402e server: add controller manager (#4246)
8fbbddcb1 server: add support for finalizers and in-memory connections (#4248)
c3464160a server: demonstrate tilt API clients and add tests (#4244)
7f19c8b72 server: make sure the API server boots first (#4236)
d144a110a tiltfile: check if the k8s context is allowed even when there are no k8s workloads, only uncategorized (fixes #4234) [ch11467] (#4241)
317c946f1 tiltfile: send analytics on extensions loaded (take 2) (#4229)
d5357d9fe tiltfile: tests for extensions analytics [ch11447] (#4252)
ea556378e vendor: remove accidental dep on apiserver-runtime (#4251)
8689e8752 vendor: update tilt-apiserver (#4253)
d6a627a4c web: fix duplicate attribute in svg (#4231)
f2ca16ba5 web: import css for line colors (#4245)
943edcd56 web: remove blue outlines on clicks (#4239)
a2b5c04e3 web: update the page metadata with the resource bar summary (#4227)



## Docker images

- `docker pull tiltdev/tilt`
- `docker pull tiltdev/tilt:v0.18.11`
