### PR TITLE
minikube 1.18.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.17.1"
-local version = "1.17.1"
+local release = "v1.18.0"
+local version = "1.18.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "c9361152a0a4aaed23d212b792f1907454f5fdd950f0cf9ac65c789744acf5ac",
+            sha256 = "a8c78a01fb129a7c66bad25bace89dc59e912b7fc0a8456de3321f9adce7a01e",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "0083b48e6119865846e305cc72359a0b1894111a632e4f09c95d2cc62d0e4474",
+            sha256 = "1e08b75c6f62138d5d626c5e2e18924047df48c69a937dce9700b3b6b18aeaf2",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "03a6d6cccecb7a33a09afc6dae40d8d76ccfe168aa4aba1a18c1f45bbab120c2",
+            sha256 = "7a330bcd45c96633c14aabcae74b3308eacf6e552a5f6ccd565a03e2f293785f",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "8346947625cd6607eb7d0be4fe0c8b76ee9f9bce6ab1dbb433dcd2006067bb8e",
+            sha256 = "4793023daf9c02c64a777061da55621a770c7e7d97fadbf6f740b37b6d4ec84d",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "5e1d57379aa729b0a9247d5be6617906ebb7e934105df06eb6b24dda08899d3e",
+            sha256 = "264b8bd9062d73b7570a26455f646fbfbce9b7bfaf375cf5642ae17937e1f79a",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -77,7 +77,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "a143f6e8d5eb2dd9ef3039635b37f3916d3e08071467fc9d959234f7c9a2bc2f",
+            sha256 = "6b83cf0ece0bc77301c9f8e4b02c652ef1e4c7e1e0c6234272e5e09af83f3ce1",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minikube to release v1.18.0. 

# Release info 

 📣😀 **Please fill out our [fast 5-question survey](https://forms.gle/Gg3hG5ZySw8c1C24A)** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.18.0 - 2021-03-01

Bug Fixes:

* fix: metric server serve on all ipv4 interfaces [#10613](https://github.com/kubernetes/minikube/pull/10613)

Thank you to our contributors for this release!

- Medya Ghazizadeh
- Predrag Rogic
- Priya Wadhwa
- Sharif Elgamal
- liuwei10

## Installation

See [Getting Started](https://minikube.sigs.k8s.io/docs/start/)

## ISO Checksum

`1a7960b845301107cb6a0c29001c8df310d7bce586cf88ceacfc78f22b622ba5`