### PR TITLE
golangci-lint 1.38.0

### DIFF
--- a/Food/golangci-lint.lua
+++ b/Food/golangci-lint.lua
@@ -1,5 +1,5 @@
 local name = "golangci-lint"
-local version = "1.37.1"
+local version = "1.38.0"
 local release = "v" .. version
 
 food = {
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "37893aa5f6c606d9c8348957e9f5cf30ef81a15e7e91bcae74f9723cb8e29520",
+            sha256 = "a9b5eb572ce55ae900a3935640fa5e199729e784a6f058e8077a9a2126e00857",
             resources = {
                 {
                     path = name .. "-" .. version .. "-darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "1929425d7733d136b342395c77f171d459aa89b198933465ec4c854aa34c41a2",
+            sha256 = "97be8342ac9870bee003904bd8de25c0f3169c6b6238a013d6d6862efa5af992",
             resources = {
                 {
                     path = name .. "-" .. version .. "-linux-amd64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/golangci/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows-amd64.zip",
-            sha256 = "a11b73bebd0ab6f2161d3677a5c63883001bf489aeebc494a6aaaead6addd161",
+            sha256 = "1d3ecd6d78ed956ab237911137443d87777d60213af79c8f15a8c622c70199b3",
             resources = {
                 {
                     path = name .. "-" .. version .. "-windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package golangci-lint to release v1.38.0. 

# Release info 

 ## Changelog

5698d46e Add ForceTypeAssert linter (#1789)
012559c5 Add linter wastedassign (#1651)
66fc7797 Add nilerr linter. (#1788)
f00da2c0 Add stringintconv and ifaceassert to govet (#1360)
a1e3749a Bump github.com/Djarvur/go-err113 to HEAD (#1760)
495a74f6 Bump github.com/timakin/bodyclose to HEAD (#1758)
b7aac3b1 Bump wsl to v3.2.0 (#1750)
251b205f Deprecate `Interfacer` linter (#1755)
42ff682f Deprecate maligned, add govet `fieldalignment` as replacement (#1765)
92d38e52 Exclude PR about doc dependencies from release changelog. (#1752)
89315e00 Fix go-header usage (#1785)
05836e48 Integrate ImportAs linter (#1783)
cdaf03d1 Remove outdated CVEs from .nancy-ignore (#1791)
856ffd16 Support RelatedInformation for analysis Diagnostic (#1773)
507703b4 Update Docs and Assets Github Actions (#1460)
5dcc3eaf Update dependencies that dependabot cannot (#1790)
2e7c389d Update staticcheck to v0.1.2 (2020.2.2) (#1756)
b77118fd Use errcheck from main repo instead of golangci-lint fork (#1319)
1a906bc1 Use go v1.14 in go.mod file (#1803)
34e46c74 Using a version instead of commit id for goconst (#1786)
747e3aea add doc for the profiling arguments (#1761)
dac2059e build(deps): bump github.com/kulti/thelper from 0.3.1 to 0.4.0 (#1764)
326d715b build(deps): bump github.com/sirupsen/logrus from 1.7.0 to 1.8.0 (#1763)
067cfac3 build(deps): bump golangci/golangci-lint-action from v2.4.0 to v2.5.1 (#1798)
d6db13d7 build(deps): bump sonatype-nexus-community/nancy-github-action (#1762)
2880d89b bump durationcheck from 0.0.4 to 0.0.6 (#1757)
5ca29739 fix: use same default linter as go vet. (#1793)
eefb9743 ineffassign: use upstrea  instead of golangci fork (#1780)
b407bb8f revive: add rule name in message. (#1772)

