### PR TITLE
eksctl 0.40.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.39.0"
+local version = "0.40.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "a6a63ada4aabe1e6e404813b5a91b2c5dfa6b4ac0423a0cd8a4ad46ad717f593",
+            sha256 = "ec212c4d17e032394a1c5a321ad8ce77839b6190b97ae53935c7f206ea5a5443",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "68696ce4b1062f5a35baf229a31d59b45eac995778010b5f1ab4a35dd1323b2b",
+            sha256 = "f8f72b930a85d356bdf1717143a9e79e4a4337a5c7f3be40e066951f54763c1a",
             resources = {
                 {
                     path = name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/weaveworks/" .. name .. "/releases/download/" .. version .. "/" .. name .. "_Windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "8eb9efd65c4028845f9b869c285cf99d18c351021d49f5b0b648ae68ffb525f7",
+            sha256 = "5e1b0be4d59038385b871f89a63e738319c7d14fe63248a989bacf11b384cf7d",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release 0.40.0. 

# Release info 

 # Release 0.40.0

## Features
- Add EFA support (#2688)
- Add support for Asia Pacific (Osaka) region (#3347)
- Add disable-eviction flag for nodegroup drain and delete (#3330)
- Allow referring to subnets by ID in nodegroups (#3331)
- Create nodegroups/managed-nodegroups on unowned clusters (#3388)


## Improvements
- Update back to upstream kris-nova/logger (#3359)
- Update aws-node to v1.7.9 (#3353)
- Create the FargatePodExecutionRole resource only when podExecutionRoleARN is unspecified (#3346)
- Improve error when nodegroup is missing privateNetworking (#3342)
- Also check managed groups for plugin requirements (#3337)
- Ignore fields in JSON schema that are explicitly hidden
- Log suggestion to delete IRSA when create stack fails (#3332)
- Add sample template for new nodegroup CFN format (#3294)


## Bug Fixes
- Prevent setting internal NodeGroup fields via ClusterConfig (#3339)
- Fix 3393: fully-private clusters are not supported in region "" (#3394)
- Set systemd cgroupdriver when HasMixedInstances (fix 3391) (#3398)


## Acknowledgments
Weaveworks would like to sincerely thank:
    @saada

