### PR TITLE
gh 1.7.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "1.6.2"
+local version = "1.7.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "b9534cb9927d8ec658db73256a35a19b3e1dd216bf185954ecc92bc27b913f79",
+            sha256 = "1fe7c9679067ceb2348cd18f556dfbba3447c77fbe874d4decb499e955df9980",
             resources = {
                 {
                     path = name .. "_" .. version .. "_macOS_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "f7d858ff84b2f60793a989399ec12d0d7d8067192e87cf59bd74b1196ac0f5fa",
+            sha256 = "30299170a8e48fa88f0d85613dd93bffc806761d902c8144809f80092759513f",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "c8e5cffbc818f66bf644d38b4cac65aa500a8888fe28970e98b601a3472f8300",
+            sha256 = "8574f8eda8b20b131201b72c68d88f9ac25400379932c9100ffd30b1a751959b",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v1.7.0. 

# Release info 

 ## New features

### The `repo list` command

The `gh repo list` command lists GitHub repositories under a user or organization account (#2953).

<img width="1066" alt="Screen Shot 2021-03-04 at 18 13 36" src="https://user-images.githubusercontent.com/887/110009278-15e84800-7d1d-11eb-8861-f0abd2087457.png">

### Improvements to the `api` command

The `gh api` command is a tool to directly access the GitHub API with in your scripts. This release adds functionality to make it easier to working with the resulting JSON.

The `api --jq` option takes a query in [jq syntax](https://stedolan.github.io/jq/manual/v1.6/) and prints only the result (#3012). This works even if the `jq` utility isn't present on the system:
```sh
$ gh api repos/:owner/:repo --jq '.full_name, .description'
cli/cli
GitHub’s official command line tool
```

For more complex output formatting, the `api --template` option renders the output according to the provided [Go template](https://golang.org/pkg/text/template) (#3011).
```sh
template='{{ range .items -}}
{{.full_name | color "blue+h"}} ({{.stargazers_count | color "yellow"}})
{{ end }}'

gh api -X GET search/repositories -f q='cli language:go' -f per_page=10 -t "$template"
```

<img width="911" alt="Screen Shot 2021-03-04 at 19 00 54" src="https://user-images.githubusercontent.com/887/110009318-200a4680-7d1d-11eb-830a-4b5ff171d7ca.png">

To make experimenting with output formats quicker and to avoid API rate limits, the `api --cache` option allows caching the response on disk for a specified amount of time (#3010).

Finally, the `api --preview` option makes it easier to opt into [GitHub API previews](https://docs.github.com/en/rest/overview/api-previews) (#3077):
```sh
$ gh api repos/cli/cli/issues/3012/reactions -p squirrel-girl --jq '.[] | "\(.user.login): \(.content)"'
samcoe: heart
gagliardetto: heart
cristiand391: heart
laughedelic: heart
casperdcl: heart
```

### Other new functionality

* Allow passing `issue/pr create` body from file or standard input  #3018

* Add `pr edit --base` to change the base branch of a PR  #3022

* Allow `pr edit` without the pull request argument  #3024

* Allow `gist view` without arguments  #3008

* Add `gist edit -a <file>` flag to add files to a gist  #2997


## Fixes

* Fix setting up a local repository on `repo create --template`  #2991

* Clarify the `repo create` interactive prompt  #2991

* Avoid crash in `pr merge` when the pull request has no commits  #3036

* Fix git authentication when the token comes from environment  #3009

* Have git authentication be resilient to PATH changes  #3075

* Avoid checking for new releases when authenticating git  #3083

* When gh is installed via Homebrew, avoid showing the upgrade notice until the homebrew formula is updated  #3020

* Validate `gist` arguments  #3021

* Have `gh` exit with non-zero status when the user cancels a command  #3023


## Contributors

Thank you:

- Gowtham Munukutla @g14a
- Cristian Dominguez @cristiand391
- Ben @ganboonhong
- @fossdd
- @castaneai

for contributing code that went into this release! And, as always, thank you to everyone who reported or upvoted bugs on our [issue tracker](https://github.com/cli/cli/issues) and gave feedback in the [Discussions section](https://github.com/cli/cli/discussions).
