### PR TITLE
anycable-go 1.0.4

### DIFF
--- a/Food/anycable-go.lua
+++ b/Food/anycable-go.lua
@@ -1,5 +1,5 @@
 local name = "anycable-go"
-local version = "1.0.3"
+local version = "1.0.4"
 
 food = {
     name = name,
@@ -11,7 +11,7 @@ food = {
             os = "darwin",
             arch = "386",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-darwin-386",
-            sha256 = "620a579de9bb32c822d513b9628b5c8397b62c56afdb13bdd1b0192234686ba8",
+            sha256 = "057374a14d09c13e16172a8ac45364c5114af996cb3ee6313572f6841a87e3b3",
             resources = {
                 {
                     path = name .. "-darwin-386",
@@ -24,7 +24,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-darwin-amd64",
-            sha256 = "db14ef7dc20d2bc8e539eef2c4b406a7a49f8539559e697ad89c5dbec567b2fc",
+            sha256 = "a9dde8bc13c6e781c813f4fdd2a9cada160c529478e829137931f82915a7b2b7",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -37,7 +37,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-linux-386",
-            sha256 = "58378d22153cc32fe189ae71a153e07ba49cb61a99f67c44d99498e0488ce951",
+            sha256 = "ff8515c397c701c70d1b7abebf02c01603684dfd4b00ed41949743563583c549",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -50,7 +50,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-linux-amd64",
-            sha256 = "2f276eb9c5b9fefbb51dfe610be34db526cf9725b53b0a46547991c4230c6466",
+            sha256 = "0063d66fbaa2b6639fe346193bf12884b39f46ef3fd1cb8a652d0d2f6ea6b2f3",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -63,7 +63,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-linux-arm",
-            sha256 = "f4d5a111b1fa6606dcefc82621a2e15da5b342b9b89cd52551ae59dc4f248ad6",
+            sha256 = "c0047292117617f9725af4d6ee82188fba4f20c93159d5c7533a523b413c8aab",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -76,7 +76,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-linux-arm64",
-            sha256 = "4778802ad41417aaafd168f9ab596f770dc48373e5f40401caff78ba0e91200f",
+            sha256 = "094a270700ccfa069707c94d61268ddb9deaa4231e32f3780560a64d9beb8bf5",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -89,7 +89,7 @@ food = {
             os = "windows",
             arch = "386",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-win-386.exe",
-            sha256 = "7ece2558f17117d1c569f523e2f1f087c941f2ce72e6aad637492cb3842bdea4",
+            sha256 = "24de60a4caeba898c607fd8087c8e4c48967a62565ca46868d4c57df85b4073c",
             resources = {
                 {
                     path = name .. "-win-386",
@@ -101,7 +101,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/anycable/anycable-go/releases/download/v" .. version .. "/anycable-go-win-amd64.exe",
-            sha256 = "72556e658a1c351b8aa2a6c30ef9a3a9aa91693963cd4ad6eb7493b93f5462eb",
+            sha256 = "8cf8457b71aa96c457ed22e6233fbb948f4f131eefdc83adbd817959241b0889",
             resources = {
                 {
                     path = name .. "-win-amd64",


### PR DESCRIPTION
Updating package anycable-go to release v1.0.4. 

# Release info 

 ## Features

- Added `sid=xxx` tag to RPC logs.

## Fixes

- Fixed race conditions in Hub caused incorrect clients num in stats sometimes.
