### PR TITLE
Removing double definition of os/arch.

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -12,37 +12,11 @@ food = {
         {
             os = "darwin",
             arch = "amd64",
-            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "8111d393424aaf141ad4dc6c520979ca6e1ba39249d07df3979c9a6152adf9e6",
-            resources = {
-                {
-                    path = name .. "-darwin-amd64",
-                    installpath = "bin/" .. name,
-                    executable = true
-                }
-            }
-        },
-        {
-            os = "darwin",
-            arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
             sha256 = "5c706ae9c88faefd2f0b3cf3dcdc8d3e157a1f36407b33faee7a5d4d74a98e2c",
             resources = {
                 {
-                    path = name,
-                    installpath = "bin/" .. name,
-                    executable = true
-                }
-            }
-        },
-        {
-            os = "linux",
-            arch = "amd64",
-            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "e4df939a230d6eb35aafd2971d0bb6ec27f4e0ebee9a41cb8cf5ae144de97af8",
-            resources = {
-                {
-                    path = name .. "-linux-amd64",
+                    path = "out/" .. name .. "-darwin-amd64",
                     installpath = "bin/" .. name,
                     executable = true
                 }
@@ -55,21 +29,9 @@ food = {
             sha256 = "c5f1e0cedb5328d485d18bebe961c076e98d487766e5a97eac09c518a86d5904",
             resources = {
                 {
-                    path = name,
+                    path = "out/" .. name .. "-linux-amd64",
                     installpath = "bin/" .. name,
                     executable = true
-                }
-            }
-        },
-        {
-            os = "windows",
-            arch = "amd64",
-            url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "5ebfff08582aa7b4a9aa75517bedc3fbde4e0dca3a412f1f9001b29eacef1ae1",
-            resources = {
-                {
-                    path = name .. "-windows-amd64.exe",
-                    installpath = "bin\\" .. name .. ".exe"
                 }
             }
         },
@@ -80,7 +42,7 @@ food = {
             sha256 = "6471d624b470d9d704601f6d7a2b7cf935daa4ead876bccc4c82e3b0e85c02bc",
             resources = {
                 {
-                    path = name .. ".exe",
+                    path = "out\\" .. name .. "-windows-amd64.exe",
                     installpath = "bin\\" .. name .. ".exe"
                 }
             }


### PR DESCRIPTION
Updating minikube:
 - Removing double definition of os/arch.
 - Fix path for zipped/tar'ed binaries