### PR TITLE
add flux linux/arm64 to fish food

### DIFF
--- a/Food/flux.lua
+++ b/Food/flux.lua
@@ -36,6 +36,19 @@ food = {
             }
         },
         {
+            os = "linux",
+            arch = "arm64",
+            url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_arm64.tar.gz",
+            sha256 = "dd740fb16864470ae50db13ecaad6915fede7665f59a174ec4528fd8a5027eb7",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",


### PR DESCRIPTION
I do not know if this is the right way to add support for another arch+os pair to gofish, but Flux supports all of these pairs (looks to be pretty much everything except Windows+arm64)

https://github.com/fluxcd/flux2/releases/tag/v0.14.1

I wonder how the fish bot upgrade process works? Is it in this repo too, or live somewhere else? (Does this PR have to do anything else besides add the block to make sure the fish bot will pick it up for upgrades, and touch the sha256sum there appropriately whenever a new release is pushed?)

I tested this locally by adding my remote and checking the branch out at `/usr/local/gofish/Rigs/github.com/fishworks/fish-food` – seems to work great (I am testing this on arm64 node from Oracle Linux, thanks to new free offer from Oracle cloud.)