### PR TITLE
skaffold 1.33.0

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,5 +1,5 @@
 local name = "skaffold"
-local version = "1.32.0"
+local version = "1.33.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "49006efbf456c7942743b3d58065773a6d8adc82e872d3f4d0032eec697e816b",
+            sha256 = "729df1a642b520c7645f782775310bf8554be68061828858872ba68afe46febf",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "b76a0381a05c5d410e3c2c44b53c592209ac798c13931c6cf3a538e4c64e5375",
+            sha256 = "80d0b11d5384282d84e11517d14933f03c0d1091a000747fd136d2c9b5de0a68",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "e9385d29dd5d27363d3c157b68462283718bd2ef9a34b9b1f0d05e1934f5b22e",
+            sha256 = "5d51443e2442bf8a1d1a2f3f6b23b64ffa86d8f3a486f46c9d23b9647ed858b8",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.33.0. 

# Release info 

 # v1.33.0 Release - 10/07/2021

**Linux**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.0<span/>/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**macOS**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.0<span/>/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**Windows**
https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.0<span/>/skaffold-windows-amd64<span/>.exe

**Docker image**
`gcr<span/>.io<span/>/k8s-skaffold<span/>/skaffold:v1<span/>.33<span/>.0`

Note: This release comes with a new config version, `v2beta24`. To upgrade your skaffold<span/>.yaml, use `skaffold fix`. If you choose not to upgrade, skaffold will auto-upgrade as best as it can.

Highlights:
* Skaffold healthcheck now monitors standalone pods.

New Features and Additions:
* feat: status-check for standalone pods https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6697
* feat: prototype control api devloop intent https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6636
* feat: use cloud build location service to create builds in workerpool across regions https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6666
* feat: Add distinct error codes for GCB failures https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6664
* feat: add preliminary support for Config Connector service KRM https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6645
* feat:(build/docker): support env as secret source https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6632
* Update to grpc-gateway v2 https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6567

Fixes:
* fix: Kubectl port fwd returns on context canceled https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6700
* fix: Sanitize image names when default repo unset https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6678
* fix: ensure run-id is added to resources in skaffold apply https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6674
* fix: correct ko package imports and logging function call https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6673
* fix: Use gcloud spec pool instead of deprecated WorkerPool https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6658
* fix: fix unit test for skaffold inspect tests list https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6656
* fix: Wait for context cancel in k8s pod watcher https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6643
* Create port map on container config if empty https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6621
* fix: remove "managed-by" fixing helm conflict (fixes #<!-- -->6421) https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6618
* Check for nil when retrieving docker support mounts https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6620
* fix: make `useBuildkit` field nullable across all config versions https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6612

Updates and Refactors:
* Support globstar in dependencies for file watching https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6605
* chore: log errors when retrieving build logs https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6663
* chore(deps): bump flask from 2.0.1 to 2.0.2 in /integration/examples https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6677
* chore(deps): bump flask from 2.0.1 to 2.0.2 in /examples https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6676
* introduce schema v2beta24 https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6628
* Update pack image to v0.21.1 https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6630
* Add image label support to ko builder https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6597
* Clean up deps https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6611

Docs, Test, and Release Updates:
* Add initial docs for Docker deployer https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6613
* doc: document Helm deployer's IMAGE_NAME<N>, IMAGE_TAG<N>, IMAGE_DIGEST<N> https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6649
* docs: update skaffold development guide to include information about commit messages https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6670
* Validate changed examples with "local" builder https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6133
* fix: properly generate enums for config schemas when running `make generate-schemas` https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6651
* refactor: Rename a couple of scripts for consistency https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6625
* chore: update skaffold Q4 planning board https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6631
* Remove `hack/release-notes` binary and update script to remove after running https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6610
* Drop codecov threshold to 30% https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6608
* build: 30 min timeout for integration tests https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6684

Huge thanks goes out to all of our contributors for this release:

- Aaron Prindle
- Ahmet Alp Balkan
- Brian de Alwis
- Gaurav
- Glenn Pratt
- Halvard Skogsrud
- Marlon Gamez
- Nick Kubala
- Seth Nickell
- Tejal Desai