### PR TITLE
tilt 0.22.12

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.22.11"
+local version = "0.22.12"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "53bca242917817315b4e660ecd2b853bd32181f25511ef22f16a48a5f769d691",
+            sha256 = "0ac7d6b637a09c50f301f63123cebd23b1503885b7edf600afb06e7377965400",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "750818e010275f0abbb2a2f50f2cdc917a599e8512623c31d1886f5f3da18342",
+            sha256 = "35fd910f19132c706417a905e5312db1cc15233d57371f54181c8b1b8a605408",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "6328cd054f123f2b2afe454552365906def24220652d2b6102bfe480a1cd707e",
+            sha256 = "d890dba4e61f8f1164da5e1ddef8eb6ec0d0d98c2a90f7adb5bf130274f9e90f",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.22.12. 

# Release info 

 ## Changelog

646fafc6a Update version numbers: 0.22.11
d7c9ae633 api: add ToggleButton types (#<!-- -->4983)
0785aecf1 apis: add ApplyName to LiveUpdateKubernetesSelector (#<!-- -->5008)
b8cbd9a3e apis: flesh out LiveUpdateStatus (#<!-- -->5019)
e60db6137 controllers: add Kubernetes{Discovery,Apply} watch to Live Update (#<!-- -->5010)
6e95e7a05 controllers: move core live update logic into the reconciler (#<!-- -->5016)
492001359 docker-compose: use .env when loading (#<!-- -->5021)
085a0ed47 docker: ignore changes to Tiltfile (#<!-- -->5025)
333ce8741 docker: pass the correct path to Tiltfile (#<!-- -->5024)
fb220fc6b dockercompose: create a data model that uses YAML instead of ConfigPaths (#<!-- -->5022)
b3181f1e9 engine: Pass KubernetesResource and KubernetesSelector to BuildState (#<!-- -->5011)
71dd14b10 engine: create a LiveUpdateInput struct that does not depend on ImageTarget (#<!-- -->5012)
939084d3b engine: create links for dynamically allocated Docker Compose ports (#<!-- -->5006)
84b41dbe9 engine: don't treat Jobs as "OK" until they complete (#<!-- -->5013)
80dae43e4 engine: infer liveupdate pods from KubernetesApply+KubernetesDiscovery (#<!-- -->5004)
e50c69a00 engine: remove dead code (#<!-- -->5015)
8b719b272 script: update Toast configuration for Go 1.16+ (#<!-- -->5009)
8a17e5808 store: create helper objects for summarizing Discovery+Apply (#<!-- -->5002)
2bd491d16 tilt: rename/organize codegen makefile targets (#<!-- -->5000)
56012de24 tiltfile: add config_map builtin (#<!-- -->5027)


## Docker images

- `docker pull tiltdev/tilt`
- `docker pull tiltdev/tilt:v0.22.12`
