### PR TITLE
berglas 0.6.1

### DIFF
--- a/Food/berglas.lua
+++ b/Food/berglas.lua
@@ -1,5 +1,5 @@
 local name = "berglas"
-local version = "0.5.3"
+local version = "0.6.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://storage.googleapis.com/" .. name .. "/" .. version .. "/darwin_amd64/" .. name,
-            sha256 = "366f47bc21dfc81759acb428620ca48f6344cbfdd3f79693b1163d9d5ca852d0",
+            sha256 = "1107d944ab0780943df0db514e5ba4ebfa6b8c10aa8d82893949eb8ab3e32b7e",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://storage.googleapis.com/" .. name .. "/" .. version .. "/linux_amd64/" .. name,
-            sha256 = "ceea6cf4ea6db940010be89fadc13774e8c5665f105183c8fe129fa44128f2b0",
+            sha256 = "19d2fee12383286bd35a0b2da1a999442b6a27f0e38ec4aa5c0614cfd55d57ac",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://storage.googleapis.com/" .. name .. "/" .. version .. "/windows_amd64/" .. name,
-            sha256 = "db857c9f9a4d441074ab645fb95f63a78a7a1838fbc796c2963941dd8a6ec53c",
+            sha256 = "4fe09ed02999d94f38ec747d1b0218fb446ab3da6fc60e25ea040184e5af29b5",
             resources = {
                 {
                     path = name,


### PR DESCRIPTION
Updating package berglas to release v0.6.1. 

# Release info 

 ## What's Changed
* Implemented option for custom SM locations by @<!-- -->MartijnNPO in https:<span/>/<span/>/github<span/>.com<span/>/GoogleCloudPlatform<span/>/berglas<span/>/pull<span/>/165
* Bump puma from 3.12.6 to 4.3.8 in /examples/cloudrun/ruby by @<!-- -->dependabot in https:<span/>/<span/>/github<span/>.com<span/>/GoogleCloudPlatform<span/>/berglas<span/>/pull<span/>/166
* Bump Go to 1.17
* Updated all dependencies

## New Contributors
* @<!-- -->MartijnNPO made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/GoogleCloudPlatform<span/>/berglas<span/>/pull<span/>/165

**Full Changelog**: https:<span/>/<span/>/github<span/>.com<span/>/GoogleCloudPlatform<span/>/berglas<span/>/compare<span/>/v0<span/>.6<span/>.0<span/>.<span/>.<span/>.v0<span/>.6<span/>.1