### PR TITLE
kustomize 4.4.0

### DIFF
--- a/Food/kustomize.lua
+++ b/Food/kustomize.lua
@@ -1,5 +1,5 @@
 local name = "kustomize"
-local version = "4.1.3"
+local version = "4.4.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. name .. "%2Fv" .. version .. "/" .. name .. "_v" .. version .. "_darwin_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "f1e54fdb659a68e5ec0a65aa52868bcc32b18fd3bc2b545db890ba261d3781c4",
+            sha256 = "f0e55366239464546f9870489cee50764d87ebdd07f7402cf2622e5e8dc77ac1",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. name .. "%2Fv" .. version .. "/" .. name .. "_v" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "f028cd2b675d215572d54634311777aa475eb5612fb8a70d84b957c4a27a861e",
+            sha256 = "bf3a0d7409d9ce6a4a393ba61289047b4cb875a36ece1ec94b36924a9ccbaa0f",
             resources = {
                 {
                     path = name,
@@ -35,18 +35,20 @@ food = {
                 }
             }
         },
-        {
-            os = "windows",
-            arch = "amd64",
-            url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. name .. "%2Fv" .. version .. "/" .. name .. "_v" .. version .. "_windows_amd64.tar.gz",
-            -- shasum of the release archive
-            sha256 = "67a21b674a8dad5e027224c3426e496028e10a65e779e950d07e5d6d8c1d9d2d",
-            resources = {
-                {
-                    path = name .. ".exe",
-                    installpath = "bin\\" .. name .. ".exe"
-                }
-            }
-        }
+        -- windows builds are broken and currently stuck at 4.1.3
+        -- https://github.com/kubernetes-sigs/kustomize/issues/4028
+        -- {
+        --     os = "windows",
+        --     arch = "amd64",
+        --     url = "https://github.com/kubernetes-sigs/" .. name .. "/releases/download/" .. name .. "%2Fv" .. version .. "/" .. name .. "_v" .. version .. "_windows_amd64.tar.gz",
+        --     -- shasum of the release archive
+        --     sha256 = "67a21b674a8dad5e027224c3426e496028e10a65e779e950d07e5d6d8c1d9d2d",
+        --     resources = {
+        --         {
+        --             path = name .. ".exe",
+        --             installpath = "bin\\" .. name .. ".exe"
+        --         }
+        --     }
+        -- }
     }
 }


### PR DESCRIPTION
Windows build is busted past `4.1.3`. We could:
- Have two versions at the same time
- Disable windows temporarily
- Wait for a windows fix

A tricky situation