### PR TITLE
bicep 0.4.1008

### DIFF
--- a/Food/bicep.lua
+++ b/Food/bicep.lua
@@ -1,5 +1,5 @@
 local name = "bicep"
-local version = "0.4.613"
+local version = "0.4.1008"
 local release = "v" .. version
 
 
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-osx-x64",
             -- shasum of the release archive
-            sha256 = "829f7608c1a37dee402b8a075d780856477bf67ca4daac2120e8d96d4330cc9d",
+            sha256 = "c0872a6356787c29c2f95f67d5b9dfcfe07d95f8249f3fbd8bbee2a223e3024f",
             resources = {
                 {
                     path = name .. "-osx-x64",
@@ -28,7 +28,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-x64",
             -- shasum of the release archive
-            sha256 = "161eb7f93a28ffd0d82c65c9832329edf75a2f90e33c6f8291448a6dcb8c5951",
+            sha256 = "de4e27737622d44c553691e54ccb46d3f62ca62f377a51be9feec66ec29ebeb9",
             resources = {
                 {
                     path = name .. "-linux-x64",
@@ -42,7 +42,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/Azure/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-win-x64.exe",
             -- shasum of the release archive
-            sha256 = "ea977303a0bde7796f808301d49fa988c909bbd14eb56f96e344a3c833b43734",
+            sha256 = "8b7f813df90cca98acd1db2e458893b5d60f1fcdabe18da10dbf2b20c07f10b7",
             resources = {
                 {
                     path = name .. "-win-x64.exe",


### PR DESCRIPTION
Updating package bicep to release v0.4.1008. 

# Release info 

 
**UPDATE** (10/15/21 2:31PM PT):
We forgot to account for Az CLI and Azure PowerShell updates that need to be made in order to expose the new `publish` and `restore` commands. As a workaround, you will need to run these commands directly with the bicep CLI. If you are installing the bicep CLI automatically via Az CLI, then the binary is most likely located at either `%USERPROFILE%\.azure\bin` on windows or `$HOME<span/>/<span/>.azure<span/>/bin` on macOS or Linux. You can then add this directory to your PATH and run `bicep publish file<span/>.bicep --target 'br:foo<span/>.azurecr<span/>.io<span/>/myModule:v1<span/>.0'`. Apologies for this oversight.

## Highlights

Bicep team:
* Private Module registry support
  - Documentation:
    * https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/azure<span/>/azure-resource-manager<span/>/bicep<span/>/private-module-registry
    * https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/azure<span/>/azure-resource-manager<span/>/bicep<span/>/modules#file-in-registry
    * https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/azure<span/>/azure-resource-manager<span/>/bicep<span/>/bicep-cli#publish) and [`restore`](https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/azure<span/>/azure-resource-manager<span/>/bicep<span/>/bicep-cli#restore commands
    * https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/azure<span/>/azure-resource-manager<span/>/bicep<span/>/bicep-config#aliases-for-module-registry
  - **Note:** This does **not** include support for a planned *public* registry which will be released with Bicep v0.5 (ETA early November)
* Implement TemplateSpec module references (#<!-- -->4269)
  - Template specs can be used as a source for modules (documentation available soon)
  - Overview of template spec references from our recent https:<span/>/<span/>/youtu<span/>.be<span/>/TrAxi-cj1JM?t=791
  - Example: `module tsDeploy ts:<<SUB-GUID>>/<<RG-NAME>>/<<TEMPLATE-SPEC-NAME:<<VERSION>> = {...}` 
  - Example with alias: `module tsDeploy ts/myAlias:<<TEMPLATE-SPEC-NAME>>:<<VERSION>> = {...}`
* Add `items()` function to Bicep in order to convert a dictionary to an array (#<!-- -->4456)
  - Documentation available soon
  - https:<span/>/<span/>/youtu<span/>.be<span/>/TrAxi-cj1JM?t=1235
* Add support for `tenant()` & `managementGroup()` functions for retrieving scope metadata (#<!-- -->4478)
  - Documentation available soon
  - https:<span/>/<span/>/youtu<span/>.be<span/>/TrAxi-cj1JM?t=1176
* Expanded hover support
  - Can now add `@<!-- -->description` decorators to variables, resources, modules, outputs which will be displayed on hover (#<!-- -->4091)
* Add lightbulb option to disable linter rule (#<!-- -->4493)
* Add "build" command to tab context menu (#<!-- -->4155)
* rule: adminUsername-should-not-be-literal (#<!-- -->4702)
* Support symbolic management group references  to be used as scopes (#<!-- -->4476)
  - If you have a symbolic reference to a management group, you can now pass that as a scope for an management group scoped module

## Bug fixes and features

Bicep team:
* removed warning about allowed scopes for scope functions (#<!-- -->4784)
* Fix for exception compiling `listKeys()` on resource array access (#<!-- -->4282)
* Add errors for 2 unsupported decompiler features (#<!-- -->4375)
* Fix integer-key property access expression generation (#<!-- -->4385)
* Add decompilation support for null(), true() & false() (#<!-- -->4273)
* Allow use of `existing` parent resource scope if it is a valid deployment scope (#<!-- -->4394)
* Fix cycle detection with resource access syntax (#<!-- -->4684)
* Display function overload description on hover (#<!-- -->4669)
* Avoid optimizing empty string interpolation expression (#<!-- -->4683)
* Fix unhandled exception and stack overflow for resource parent property assignments (#<!-- -->4384)
* Change array merging behavior to "replace" for Bicep configs (#<!-- -->4767)
* module path completions do not show up url encoded (#<!-- -->4708)
* Ensure snippets and other completions use \n (#<!-- -->4180)
* Watch for creation/deletion/modification of local bicepconfig<span/>.json file (#<!-- -->4038)
* Fix exception thrown in CLI when bicepconfig<span/>.json is invalid (#<!-- -->4348)

@<!-- -->CoachAlexis
* Add icons (#<!-- -->4344)

@<!-- -->JimPaine
* Simplification of expressions on decompile (#<!-- -->4482)

@<!-- -->miqm
* In-lining Resources and Modules when assigned to a variable (#<!-- -->4069)
* Fix using existing resource of a discriminated type based on a property other than name (#<!-- -->4407)
* Fixed generating scope for looped modules and nested resources (#<!-- -->4639)

@<!-- -->pakrym
* Sort required properties first in completion (#<!-- -->4562)
* Add = to completion (#<!-- -->4599)
* Add a codefix for BCP035 (#<!-- -->4570)

## Docs, examples, snippet updates

Bicep team: 

@<!-- -->DamianFlynn
* Bump Homebrew to the current release (#<!-- -->4560)

@<!-- -->egullbrandsson
* Snippet res-rg - removed single quotes (#<!-- -->4275)

@<!-- -->mgreenegit
* guest config snippets (#<!-- -->4243)
* better version example; only reinforce identity for extension (#<!-- -->4309)
* Readme - Build badge should link to build results (#<!-- -->4431)

@<!-- -->rajyraman
* Logic App Workflow and Integration Account Snippet (#<!-- -->3919)

@<!-- -->StefanIvemo
* Updated readme with links to learn path and docs<span/>.microsoft<span/>.com (#<!-- -->4036)
* [Snippet] Added ExpressRoute Gateway snippet (#<!-- -->3920)
* [Snippet] Added Route Server snippet (#<!-- -->3976)
* Fixed bug in `res-container-registry` snippet (#<!-- -->4597)
