### PR TITLE
eksctl 0.70.0

### DIFF
--- a/Food/eksctl.lua
+++ b/Food/eksctl.lua
@@ -1,5 +1,5 @@
 local name = "eksctl"
-local version = "0.69.0"
+local version = "0.70.0"
 
 food = {
     name = name,
@@ -11,7 +11,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/weaveworks/eksctl/releases/download/v" .. version .. "/" .. name .. "_Darwin_amd64.tar.gz",
-            sha256 = "803265099754c4d27aa1e4cdb6e939b43cf6fe0a4c0f20dbbbc2b680e5da4e16",
+            sha256 = "06d466e629c75cdaf79235f23f5404769878a77df50925749df46a40d252b4c9",
             resources = {
                 {
                     path = name,
@@ -24,7 +24,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/weaveworks/eksctl/releases/download/v" .. version .. "/" .. name .. "_Linux_amd64.tar.gz",
-            sha256 = "3f81cc7ce41a84f4ea275c0ffa7f0403b258260e050dbe6c5fbabc12d48891e5",
+            sha256 = "25490c48a2cefe003f51bd569a7fdab2eec7b5f23fd190b8bb344f8c2344cce2",
             resources = {
                 {
                     path = name,
@@ -37,7 +37,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/weaveworks/eksctl/releases/download/v" .. version .. "/" .. name .. "_Windows_amd64.zip",
-            sha256 = "13a6e4efaf7cc526870460dcba76711839c5d52ccc7fc4657d41c3e102e8da48",
+            sha256 = "ac74fa8e5455f1da7388d1d620c8da64fd22f0db8b29af4d56d05d05fc5429c7",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package eksctl to release v0.70.0. 

# Release info 

 # Release 0.70.0

## Features

- Parse task log to be more human readable (#<!-- -->4290)

## Improvements

- Add support for specifying latest version in cluster config (#<!-- -->4258)

