### PR TITLE
gh 2.1.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "2.0.0"
+local version = "2.1.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "33dd2c9aff1ef2397100263e6c63d4f2a119add725eb4fb10d684412879e6d0a",
+            sha256 = "258944c59cb34c9e8716ecc1e7a3d90f72da9b96b4d85ec9b7b773b4370c88ff",
             resources = {
                 {
                     path = name .. "_" .. version .. "_macOS_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "20c2d1b1915a0ff154df453576d9e97aab709ad4b236ce8313435b8b96d31e5c",
+            sha256 = "eddadd0cf7ecf340614dd5914eaad1543d8491c966a3a3a41f8a03832dfac184",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "3c33ac49e2f969cc76d082a88db13f6c8050a5677ff149bce7adaca06a2b81c6",
+            sha256 = "34fa202c7cf731f7ff134535200da92af3d7cde05275c3621a92a3fdd65f6a07",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v2.1.0. 

# Release info 

 ### New features
* Add `repo archive` command by @<!-- -->pxrth9 & @<!-- -->meiji163 in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4410=
* Add support for precompiled extensions by @<!-- -->vilmibm in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4308 https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4373

  If an extension repository publishes Releases with uploaded binary assets named with a suffix formatted like `{OS}-{ARCH}` (e.g. `linux-amd64`), the matching binary will be downloaded and installed as the extension instead of cloning the code from the extension repository.
* `pr list`: add `--draft`, `--non-draft`, and `--head` filters by @<!-- -->SiarheiFedartsou in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4316 https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4279
* `pr diff`: add `--patch` flag by @<!-- -->m4ver1k in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4460
* `browse`: add `--commit` flag to open the permalink for the latest commit by @<!-- -->bchadwic in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/3950

### Fixes
* `api`: add docs hint on how to use use stdin by @<!-- -->rethab in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4291
* `pr checks`/`run`: revised "pending" and "skipped" symbols by @<!-- -->bchadwic in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4090
* `pr checkout`: also set `pushRemote` for new branches by @<!-- -->RasmusWL in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4363
* `extension list`: speed up checking for updates by @<!-- -->samcoe in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4396
* `extension install`: document installing using a full URL by @<!-- -->wrslatz in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4271
* `extension create`: use `/usr/bin/env bash` instead of `/bin/bash` in generated shebang by @<!-- -->kidonng in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4203
* `browse`: add support for line ranges browse by @<!-- -->despreston in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4253
* `browse`: fix markdown files with line ranges by @<!-- -->andrewhsu in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4310
* `repo garden`: use the `x/term` package instead of shelling out to stty by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4214
* `repo sync`: allow user input for `git fetch` by @<!-- -->samcoe in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4328
* `repo create`: avoid swallowing error from a prompt by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4331
* Skip authentication requirement for internal completion commands by @<!-- -->cuonglm in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4189
* Add quotes around `@<!-- -->me` in documentation to ensure examples work in PowerShell by @<!-- -->Jernik in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4239
* Suggest to re-authenticate to fix "SAML enforcement" error by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4241
* Print warning when limit exceeds search API maximum by @<!-- -->despreston in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/3967
* Add `git+https` to the list of supported git remote URL protocols by @<!-- -->danburzo in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4347
* Fix detecting the current `gh` executable in PATH by @<!-- -->wilso199 in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4243
* Bump Survey library to fix the "Unexpected escape sequence" error by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4405
* Warn about missing OAuth scopes when printing HTTP 4xx errors by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4513

### New Contributors
* @<!-- -->cuonglm made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4189
* @<!-- -->Jernik made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4239
* @<!-- -->wrslatz made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4271
* @<!-- -->andrewhsu made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4299
* @<!-- -->SiarheiFedartsou made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4316
* @<!-- -->danburzo made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4347
* @<!-- -->rethab made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4291
* @<!-- -->RasmusWL made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4363
* @<!-- -->geramirez made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4439
* @<!-- -->lcnzg made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4412
* @<!-- -->m4ver1k made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4460
* @<!-- -->neil465 made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4473
* @<!-- -->dependabot made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4475
* @<!-- -->Shanduur made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4453
* @<!-- -->pxrth9 made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4410
* @<!-- -->adonovan made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4504
* @<!-- -->alefranz made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4507
* @<!-- -->marwan-at-work made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4497
