### PR TITLE
infracost 0.9.11

### DIFF
--- a/Food/infracost.lua
+++ b/Food/infracost.lua
@@ -1,5 +1,5 @@
 local name = "infracost"
-local version = "0.9.10"
+local version = "0.9.11"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "e9231dcf45bd74d106e599ef6cc2fddafa680b84eda805e2e76317b2c9f10059",
+            sha256 = "0babfd0ee80025a5f3ad033050c5c944179a55ea06556ccd2f1e81d3fc1a8a62",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "d1797a1c2ff157c612cf67a094b4c60dd3f57cdab6d4042d7b887ebeb3662a70",
+            sha256 = "d41b50ee4478206b5aef0cd00bc0c6c89d3b73142af0002dcf00a8ce0267e328",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "3cd2ecbb20d09c873cba479da485bc98a96603daa2d5fc2e31fd91147d322e97",
+            sha256 = "c173a5f9f9232997f257862372eacb2d272d3310e62cf5e759882a7dafc43ae7",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package infracost to release v0.9.11. 

# Release info 

 ## What's Changed
* Add support for Azure Synapse by @<!-- -->dgcaron in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/912
* Add support for map/nested data types in `UsageData` by @<!-- -->hugorut in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1019
* Refactor S3 to new structure by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1025
* Add usage file YAML comments by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1036
* Usage comment improvements by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1046
* Simplify CloudFront output by @<!-- -->hugorut in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1049
* Add S3 estimation by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1045
* Add EKS Node Group estimation for instance count by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1050
* Add some initial logs for usage queries by @<!-- -->aliscott in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1056
* Don't show items with zero usage in table or html output by @<!-- -->tim775 in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1042

* Fix sync usage file flag to not be destructive by @<!-- -->ajoulie in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1055
* Fix CloudFront nested usage param lookup by @<!-- -->tim775 in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1044
* Fix CloudFront monthly http requests usage by @<!-- -->hugorut in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1048
* Fix example usage file comments so the usage-file generator picks them up by @<!-- -->alikhajeh1 in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1058
* Fix CloudFront checking for empty keys by @<!-- -->tim775 in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1051

* Refactor: move from io/ioutil to io and os package by @<!-- -->Juneezee in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1052
* The usage file parameter `monthly_retrieval_gb` has been renamed to `monthly_data_retrieval_gb`

## New Contributors
* @<!-- -->Juneezee made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/pull<span/>/1052

**Full Changelog**: https:<span/>/<span/>/github<span/>.com<span/>/infracost<span/>/infracost<span/>/compare<span/>/v0<span/>.9<span/>.10<span/>.<span/>.<span/>.v0<span/>.9<span/>.11