### PR TITLE
arkade 0.8.5

### DIFF
--- a/Food/arkade.lua
+++ b/Food/arkade.lua
@@ -1,5 +1,5 @@
 local name = "arkade"
-local version = "0.8.4"
+local version = "0.8.5"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. "-darwin",
-            sha256 = "43886a5d47c77c104c9ac1ac88ff919efc1b723f8b9eda0fa6c9f0f42f0272da",
+            sha256 = "1b45e05cd616bbf555739c796cb74dfa9e68dd55977c153460381217ce47197b",
             resources = {
                 {
                     path = name .. "-darwin",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name,
-            sha256 = "9338122b18614b92ec84379dda5f829b88b55018a340c90b744fbe9ea7eaf36f",
+            sha256 = "8c526e7164d1d44a884416b899e3c9bd4331080c3dab67af942f34a4245d57a4",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. ".exe",
-            sha256 = "4d2021703e00dfd1e6abc9478148c7b5138de5f9c637593f1e8a0bc1246c0552",
+            sha256 = "6bf1d2cb866ca500cbb551b0c8729fd12c8f24ba2df683e5a57aefa6ebe16298",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package arkade to release 0.8.5. 

# Release info 

 New `arkade get` superpowers:

```bash
arkade get faas-cli

arkade get kubectl@<!-- -->v1.22.0

arkade get kubectl@<!-- -->v1.22.0 \
  faas-cli \
  inlets-pro@<!-- -->0.9.0 \
  helm
```

New CockroachDB app:

```bash
arkade install cockroachdb
```

New Kasten sponsored app functionality for preflight checks

```bash
arkade kasten k10 preflight
arkade kasten k10 preflight --dry-run
```

Changelog for 0.8.5:
* PR #<!-- -->537 Add K10 preflight command by @<!-- -->alexellis
* PR #<!-- -->533 Add line break after post installation msg by @<!-- -->yankeexe
* PR #<!-- -->532 Update version overwriting in tool check by @<!-- -->yankeexe
* PR #<!-- -->528 Add CockroachDB Helm Chart to the apps by @<!-- -->Shikachuu
* PR #<!-- -->516 Add multi-tool download support by @<!-- -->yankeexe

Commits
ef3938e08a51af9eacb3c920c1f5222eac76f0ab Add dry-run flag for preflight command by @<!-- -->alexellis
16afbf37d24cf723fe08708af3c0887fa9cb58eb Add preflight command by @<!-- -->alexellis
6dfd4bd223c13d626386f9d279b3a97cc9f8bb1f Add line break after post installation msg by @<!-- -->yankeexe
b5037204900ff23673ad509556897549ac3f1dce Add tests for DownloadURLs by @<!-- -->yankeexe
6f38ce0f386a5465a2dc73b38e9903101165f828 Update version overwriting in tool check by @<!-- -->yankeexe
2f6e3dbc15ae139782a9b851cc9863afbfefac05 Added CockroachDB to install command, with arm install prevention. by @<!-- -->Shikachuu
f391bff44a14652fe0756165401d71c10a087555 Update check for tools existence by @<!-- -->yankeexe
4bb64a60d5917172d4bb6807c00fbd2e322ee426 Refactor and add tests for post download msg templates by @<!-- -->yankeexe
0b1fe326ac6eef5713f147ed7223d4ecebd72d8d Add multi-tool download support by @<!-- -->yankeexe
47fb606827a793a9ff08f060e418abce8b00bb69 Rename flag for OIDC connector for openfaas by @<!-- -->alexellis
fd9c562c585d65c80afb95c11498086e266b0513 Refactoring a unit test for flags by @<!-- -->alexellis
0b175257d49c63bd828a56fdb5f434d811dfa7c3 Add rollout status command to block until ready by @<!-- -->alexellis

Generated by https:<span/>/<span/>/github<span/>.com<span/>/alexellis<span/>/derek<span/>/
