### PR TITLE
fzf 0.27.3

### DIFF
--- a/Food/fzf.lua
+++ b/Food/fzf.lua
@@ -1,6 +1,6 @@
 local name = "fzf"
-local release = "0.27.2"
-local version = "0.27.2"
+local release = "0.27.3"
+local version = "0.27.3"
 food = {
     name = name,
     description = ":cherry_blossom: A command-line fuzzy finder",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/junegunn/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-darwin_amd64.zip",
-            sha256 = "dd61f38651852400bff4e38d4a13709a38d515da68a8069ab442228cc7d0f912",
+            sha256 = "b2fa3c6d4d3e6fece02609c5ddcdb50bc9b25ae709b34fbe9d2f04a195d168cc",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/junegunn/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-linux_amd64.tar.gz",
-            sha256 = "bfdfbade5e62ef47e2b0707293120ed7829583fdcafe763a5dc904e3e1642271",
+            sha256 = "afb0e460bdb924e15c34589e8b19eba4e5c2435dbf272f5bb10881515f66e0a9",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/junegunn/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-" .. version .. "-windows_amd64.zip",
-            sha256 = "c9b5c8bdbef06305a2d0a33b0d82218bebd5a81a3f2187624d4a9d8fe972fc09",
+            sha256 = "4d264b04bee6e500fc2787a4748b26e5efe12d2a4ff7a906849a8ce3b75edbdd",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package fzf to release 0.27.3. 

# Release info 

 - Preview window is `hidden` by default when there are `preview` bindings but `--preview` command is not given
- Fixed bug where `{n}` is not properly reset on `reload`
- Fixed bug where spinner is not displayed on `reload`
- Enhancements in tcell renderer for Windows (#<!-- -->2616)
- Vim plugin
    - `sinklist` is added as a synonym to `sink*` so that it's easier to add a function to a spec dictionary
      ```vim
      let spec = { 'source': 'ls', 'options': ['--multi', '--preview', 'cat {}'] }
      function spec.sinklist(matches)
        echom string(a:matches)
      endfunction

      call fzf#run(fzf#wrap(spec))
      ```
    - Vim 7 compatibility

