### PR TITLE
flux 0.19.0

### DIFF
--- a/Food/flux.lua
+++ b/Food/flux.lua
@@ -1,5 +1,5 @@
 local name = "flux"
-local version = "0.18.3"
+local version = "0.19.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,20 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "aaf93adef9c3f9c3340e7545126d7aea8a29051ee70d62024765d23f1af1f5a4",
+            sha256 = "5dc8635ecd91fbef5eff47f723ce9fe479ea18c877b82748b2bb0f45c08cd244",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "darwin",
+            arch = "arm64",
+            url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_arm64.tar.gz",
+            sha256 = "85607128573ba8aa7d0bca9f88bafc68eb49dcb70bb50d0636b03d89cdf27788",
             resources = {
                 {
                     path = name,
@@ -26,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "848c7d135f851a64983626d231123b3570aa2b65d74da136a14a7c1ea807cc46",
+            sha256 = "56ee2b37a1e6c6c0d694de9727447bfae232b8a4ee5c0924aca7619f9b59a12b",
             resources = {
                 {
                     path = name,
@@ -39,7 +52,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_arm64.tar.gz",
-            sha256 = "3c6817fd3459bf50d73d4f5d90a903a3db1f0e4805be8104aadb0e9013f9146a",
+            sha256 = "6a57c138e1112f6038e0f74fef2a7ae7366f358ec1fe7c6a4edbbfec1c056e76",
             resources = {
                 {
                     path = name,
@@ -52,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
-            sha256 = "cca203d1caa46aa15e03df1d1ccb9faaa4d75d268a28cf83c472746a43f2c200",
+            sha256 = "9ba69eb1c360ed662280ce5a6b1da36f2e6486823259dc2675420c5d0f10d747",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package flux to release v0.19.0. 

# Release info 

 If you are upgrading from 0.17 or older versions, please see the https:<span/>/<span/>/github<span/>.com<span/>/fluxcd<span/>/flux2<span/>/discussions<span/>/1916 guide.

## Components changelog

- https:<span/>/<span/>/github<span/>.com<span/>/fluxcd<span/>/kustomize-controller<span/>/blob<span/>/v0<span/>.16<span/>.0<span/>/CHANGELOG<span/>.md
- https:<span/>/<span/>/github<span/>.com<span/>/fluxcd<span/>/helm-controller<span/>/blob<span/>/v0<span/>.12<span/>.1<span/>/CHANGELOG<span/>.md
- https:<span/>/<span/>/github<span/>.com<span/>/fluxcd<span/>/notification-controller<span/>/blob<span/>/v0<span/>.18<span/>.0<span/>/CHANGELOG<span/>.md
- https:<span/>/<span/>/github<span/>.com<span/>/fluxcd<span/>/image-reflector-controller<span/>/blob<span/>/v0<span/>.13<span/>.0<span/>/CHANGELOG<span/>.md

## CLI changelog

- PR #<!-- -->1961 - @<!-- -->stefanprodan - Add wait flag to create kustomization cmd
- PR #<!-- -->1948 - @<!-- -->darkowlzz - Makefile: set install target as phony
- PR #<!-- -->1946 - @<!-- -->fluxcdbot - Update toolkit components
- PR #<!-- -->1943 - @<!-- -->stefanprodan - Add missing copyright headers
- PR #<!-- -->1942 - @<!-- -->stefanprodan - Add part-of label to the static manifests
- PR #<!-- -->1938 - @<!-- -->relu -  Allow namespaces readonly access in crd-controller RBAC ClusterRole
- PR #<!-- -->1937 - @<!-- -->SomtochiAma - Fix description for resume --all


## Docker images

- `docker pull fluxcd/flux-cli:v0.19.0`
- `docker pull ghcr<span/>.io<span/>/fluxcd<span/>/flux-cli:v0<span/>.19<span/>.0`
