### PR TITLE
terragrunt 0.35.4

### DIFF
--- a/Food/terragrunt.lua
+++ b/Food/terragrunt.lua
@@ -1,6 +1,6 @@
 local name = "terragrunt"
-local release = "v0.34.3"
-local version = "0.34.3"
+local release = "v0.35.4"
+local version = "0.35.4"
 
 food = {
     name = name,
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gruntwork-io/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_darwin_amd64",
-            sha256 = "9bb0817d6245388e40393e008ffab9a3b86674b9b9132a50056a89f0368d621e",
+            sha256 = "00ff47656c9d805ef025ff8e28af144b0f6de897e65ef88e51b309bba7acd1d7",
             resources = {
                 {
                     path = name .. "_darwin_amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gruntwork-io/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_linux_amd64",
-            sha256 = "ed84bad121302450452bdf964684ba3d60280d1249d22c63dfe9ade4c360e6b7",
+            sha256 = "3b2bf4a89ba038ab211d0c7d5e7f2dda5b5e4b242f912a2f95714441e3bbbdea",
             resources = {
                 {
                     path = name .. "_linux_amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gruntwork-io/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_windows_amd64.exe",
-            sha256 = "4cc4b59bf08693637b28ca06bd655e45e2949e762495f294e0fc5178828805df",
+            sha256 = "b3032791bd06553f46ade95aba74dd0d1ac1d5c21c424559f36b66369fb07c1b",
             resources = {
                 {
                     path = name .. "_windows_amd64.exe",


### PR DESCRIPTION
Updating package terragrunt to release v0.35.4. 

# Release info 

 ## Updated CLI args, config attributes and blocks

- `run-all`

## Description

Terragrunt will now log the order in which modules are deployed when using `run-all`, instead of all the modules in the graph including those that are excluded. You can get the old format logs if you use `--terragrunt-log-level debug`.

### Example module

```
%~> tree .
.
├── account-baseline
│   ├── main<span/>.tf
│   └── terragrunt<span/>.hcl
└── services
    ├── myapp
    │   ├── main<span/>.tf
    │   └── terragrunt<span/>.hcl
    ├── mysql
    │   ├── main<span/>.tf
    │   └── terragrunt<span/>.hcl
    ├── redis
    │   ├── main<span/>.tf
    │   └── terragrunt<span/>.hcl
    └── vpc
        ├── main<span/>.tf
        └── terragrunt<span/>.hcl
```

The following runs are done from the `services` folder, so we expect the `account-baseline` to be skipped.

#### Graph output before

```
%~> terragrunt run-all apply --terragrunt-non-interactive
INFO[0000] Stack at ~/gruntwork/support/terragrunt-run-all-destroy/proj/services:
  => Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/account-baseline (excluded: false, dependencies: [])
  => Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/myapp (excluded: false, dependencies: [~/gruntwork/support/terragrunt-run-all-destroy/proj/services/mysql, ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/redis])
  => Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/mysql (excluded: false, dependencies: [~/gruntwork/support/terragrunt-run-all-destroy/proj/services/vpc])
  => Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/redis (excluded: false, dependencies: [~/gruntwork/support/terragrunt-run-all-destroy/proj/services/vpc])
  => Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/vpc (excluded: false, dependencies: [~/gruntwork/support/terragrunt-run-all-destroy/proj/account-baseline])
```

#### Graph output with this release (apply)

```
%~> ~/gruntwork/tools/terragrunt/terragrunt run-all apply --terragrunt-non-interactive
INFO[0000] The stack at ~/gruntwork/support/terragrunt-run-all-destroy/proj/services will be processed in the following order for command apply:
Group 1
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/vpc

Group 2
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/mysql
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/redis

Group 3
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/myapp
```

#### Graph output with this release (destroy)

```
%~> ~/gruntwork/tools/terragrunt/terragrunt run-all destroy --terragrunt-non-interactive
INFO[0000] The stack at ~/gruntwork/support/terragrunt-run-all-destroy/proj/services will be processed in the following order for command destroy:
Group 1
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/myapp

Group 2
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/mysql
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/redis

Group 3
- Module ~/gruntwork/support/terragrunt-run-all-destroy/proj/services/vpc
```


## Related links

- https:<span/>/<span/>/github<span/>.com<span/>/gruntwork-io<span/>/terragrunt<span/>/pull<span/>/1861