### PR TITLE
osm 0.11.1

### DIFF
--- a/Food/osm.lua
+++ b/Food/osm.lua
@@ -1,5 +1,5 @@
 local name = "osm"
-local version = "0.11.0"
+local version = "0.11.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-darwin-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "706ea80438027311d9c6e47bc46b0284a0afec42be3771fc9f5c87bafc40b3ae",
+            sha256 = "5efffdc0e1aac163984af8b4a78f1cdce35f59375934c0f2e6636e6bc266c239",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-linux-amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "93d4b80625f72cfa7184f367b60ae1394e125422fefbe8c29a9f16690ffe335a",
+            sha256 = "55928d2431f884865ea7c50a8349115f0f0530cd2ac5a0e056ef3c09045e6aef",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/openservicemesh/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-v" .. version .. "-windows-amd64.zip",
             -- shasum of the release archive
-            sha256 = "fa97b662b95bc5128276e499d35159c5aabda1acf9f5ebeda56f456274ca47d4",
+            sha256 = "9d9743fff9ae9fee1a60dd8fbf5f74fae32b23baa36458ce2285f853fc01f71a",
             resources = {
                 {
                     path = "windows-amd64/" .. name .. ".exe",


### PR DESCRIPTION
Updating package osm to release v0.11.1. 

# Release info 

 ## CRD Updates

No CRD changes between tags v0.11.0 and v0.11.1

## Changelog

* chore(release): update version to v0.11.1 545e8543b80e03da3d9b5862853618b53b4b0538 (Sneha Chhabria)
* fix(MeshConfig): Remove omitEmpty from bool values in the meshconfig 6a5b8047891f2a59d7969c7a4733bf2896027d87 (Sneha Chhabria)
* chore(release): update version to v0.11.1-rc.1 dcc91b75f1a81c2377c18e86248eac4168d526db (Sneha Chhabria)
* CI: fix image scan job for pre-release 3312be3d6f73fcd52288fd517be54ff793fbcd84 (Sneha Chhabria)
* fix(pre-release): fix indentation in pre-release workflow e503c02ff83326253a59fd6afae703d0a054ab1c (Sneha Chhabria)
* charts(cleanup): delete secrets on cleanup 9563464073ce5fce42bd44980ec2537fba3fbd1e (Sanya Kochhar)
* ref(*): removes unnecessary namespace check (#<!-- -->4251) 5e619560640208d6fac46f84682f7a1a266cbf7b (Michelle Noorali)
* docs(chart): template chart README versions 09c58254ca70e6d589d11caef2993f20ececd9d9 (Jon Huhn)
* chore(ci): Update codecov uploader 93d862e364196877a02c54e453bf8eebea9faf5c (Jon Huhn)
* chore(chart): increase osm-controller memory limit 473bffdd6e9cbf411777a957ea8b2ad95d96b980 (Jon Huhn)
* chore(security/scan): Scan docker images d1a8858868153c65cce7bcf9ff00ef44285bd7f6 (nshankar13)
* fix(preset-mesh-config<span/>.yaml): add json check (#<!-- -->4241) 04736da74ae52761c55acf1f2a406352826ffe68 (Michelle Noorali)
* ingress/client: remove unnecessary check for namespace (#<!-- -->4244) 0a5fa82159a1a407ae21b51e6d4b0f3358481231 (Shashank Ram)
* fix(cleanuphook): Delete mwhc and vwhc in all scenarios 3ce755cae0d28a1dcc33a59a09110dea3bf9f20d (Sneha Chhabria)
* messaging/broker: batch proxy update events (#<!-- -->4240) 11af38e30f441d90b21049ebcc46ddacdf1bf367 (Shashank Ram)
* chore(security/scan): Add codeql scan a23f83c67d14d693a0aeb15de8ea6863ad96a47d (nshankar13)
* fix(ads): properly sync proxy disconnect c055b1de19d2dbd750f3dd65a0b1faa0b3612e92 (Jon Huhn)
* chore(release): update version to v0.11 in chart c40ad8f17c4a5906a73909960bc6fe4241fe69c0 (jaellio)
* events: log event kind being processed and disable resyncs (#<!-- -->4231) 09f483871ec63336ca7b71947f2603c7e187ed6e (Shashank Ram)
* chore(tlsversion): Add a tls minimum version for webhooks 2e1ebea543d7d78a38fc74f85ba2ac1a20e49de5 (Sneha Chhabria)
* Update tests to resolve missing mock calls 4d140cfed6554b4fa07fafce28c375e4af0963db (jaellio)
* go/deps: update Helm to v3.7.0 and kubernetes packages db5d919571c4212f87369d32492ee3e2d57ae00c (jaellio)
* fix(UpgradeTest) : Fix the upgrade e2e test 50c0a50d7d18969228390e104d8fc8a08b68286e (Sneha Chhabria)
* fix(ImageTags) : Update image pull to use tags if specified over the digest 6e40f0dfb1f6ca9a841bf8e07692f9e008215606 (Sneha Chhabria)
* metrics: add counters related to proxy response send (#<!-- -->4219) 0e3f7468cdb2dfcaada0e9f96cda1a08939b42ff (Shashank Ram)
* envoy/registry: do not track disconnected proxies (#<!-- -->4216) d0d5d9721752b07b3e3d0147ebb8c596d3ab1ed3 (Shashank Ram)
* messaging: use message broker in control plane (#<!-- -->4212) 0309a0fd42d2bba1929234a1c358db5d72c5a324 (Shashank Ram)
* fix(tests): disable smi validate test for NoInstall (#<!-- -->4209) 1caae978f9b60297bb11aeeee0a09bd8e6adc44c (Michelle Noorali)
* messaging: introduce message broker (#<!-- -->4210) f454b0784a578fde5db8fcc71e9593ae3bcebd40 (Shashank Ram)
* feat(*): ignore invalid traffic targets (#<!-- -->4177) ae5c9d89664885f7fc458e7ad0f4443d4c38a778 (Michelle Noorali)
* feat(charts): Adding priorityClassName to the OSM deployments a6b59b9b5edbebd44b52385e294eeac08f06b43c (Shalier Xia)
* catalog/ingress: check backend's port in addition to name (#<!-- -->4202) 37c3d65f3b61e40b1380962df355763662494e27 (Shashank Ram)
