### PR TITLE
arkade 0.8.6

### DIFF
--- a/Food/arkade.lua
+++ b/Food/arkade.lua
@@ -1,5 +1,5 @@
 local name = "arkade"
-local version = "0.8.5"
+local version = "0.8.6"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. "-darwin",
-            sha256 = "1b45e05cd616bbf555739c796cb74dfa9e68dd55977c153460381217ce47197b",
+            sha256 = "b123c9beb264d44b65fa0adc72e40034404c7c5749d8e85ac3ebff0fdd8551ed",
             resources = {
                 {
                     path = name .. "-darwin",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name,
-            sha256 = "8c526e7164d1d44a884416b899e3c9bd4331080c3dab67af942f34a4245d57a4",
+            sha256 = "d2d5c1069315258e53738b28bc3aea36f5ecce6b1fa5eb47266f994c14cc49cd",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. ".exe",
-            sha256 = "6bf1d2cb866ca500cbb551b0c8729fd12c8f24ba2df683e5a57aefa6ebe16298",
+            sha256 = "4741b7d83ab9456b7c34c9421f191f7eef790f9da728d180249664d1d888bf85",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package arkade to release 0.8.6. 

# Release info 

 Changelog for 0.8.6:
* PR #<!-- -->544 Fix docker registry ingress app for k8s 1.22 by @<!-- -->ocpu
* PR #<!-- -->546 Update istio app version to 1.11.4 by @<!-- -->alexellis
* PR #<!-- -->545 Bump version of cert-manager to v1.5.4 by @<!-- -->alexellis
* PR #<!-- -->538 kubectl: update kubectl version to the one that supports arm64 by @<!-- -->cpanato

Commits
aa4ddbb05dbf9affd068d6065de5ae92296d1870 Fix docker registry ingress app for k8s 1.22 by @<!-- -->ocpu
3efc6aaa3618c7b1cbf9ab2a94854508929dc2f4 Add new-line after arkade get completes by @<!-- -->alexellis
85e6b1eccc8eb4c24e3c4385f688d4ededba6d76 Update istio app version by @<!-- -->alexellis
a5b5e496f3864935045f92c5b7eabc3649d71064 Bump version of cert-manager to v1.5.4 by @<!-- -->alexellis
cf373d3dce6bf86127752d724f53cc5385040bdf Update README<span/>.md by @<!-- -->alexellis
08fd073047c990d34e4a607d66399c31817ed352 Update README<span/>.md by @<!-- -->alexellis
1e43d6ead0ef958e9caf08e0ec23b49fe6563ffb kubectl: update kubectl version to the one that supports arm64 by @<!-- -->cpanato

Generated by https:<span/>/<span/>/github<span/>.com<span/>/alexellis<span/>/derek<span/>/
