### PR TITLE
skaffold 1.33.1

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,5 +1,5 @@
 local name = "skaffold"
-local version = "1.33.0"
+local version = "1.33.1"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "729df1a642b520c7645f782775310bf8554be68061828858872ba68afe46febf",
+            sha256 = "2c379941adaa0c50556d59474018d796ca0e16a3f16f0d22f8400e140e6aad72",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "80d0b11d5384282d84e11517d14933f03c0d1091a000747fd136d2c9b5de0a68",
+            sha256 = "98a403d36a57a76f55bb8236c882d806de8a544bc4652d42b74af80a237888be",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "5d51443e2442bf8a1d1a2f3f6b23b64ffa86d8f3a486f46c9d23b9647ed858b8",
+            sha256 = "23ed6cb241548a2c4e6dd6c91c1d3ae293708e111a5c64a495c5d00966fb75b0",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.33.1. 

# Release info 

 # v1.33.1 Release - 10/21/2021
**Linux**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.1<span/>/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**macOS**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.1<span/>/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**Windows**
https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.33<span/>.1<span/>/skaffold-windows-amd64<span/>.exe

**Docker image**
`gcr<span/>.io<span/>/k8s-skaffold<span/>/skaffold:v1<span/>.33<span/>.1`

Note: This is a patch release only including https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6714 for the bug introduced in v1.33.0 release.