### PR TITLE
arkade 0.8.7

### DIFF
--- a/Food/arkade.lua
+++ b/Food/arkade.lua
@@ -1,5 +1,5 @@
 local name = "arkade"
-local version = "0.8.6"
+local version = "0.8.7"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. "-darwin",
-            sha256 = "b123c9beb264d44b65fa0adc72e40034404c7c5749d8e85ac3ebff0fdd8551ed",
+            sha256 = "445d7f5b1c716f83e9b540bc3e5013711b14ea1279dcf43a070a99cca03e66eb",
             resources = {
                 {
                     path = name .. "-darwin",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name,
-            sha256 = "d2d5c1069315258e53738b28bc3aea36f5ecce6b1fa5eb47266f994c14cc49cd",
+            sha256 = "9eaaeb10f2320d79a43a429fc6eca7445337c370d635246629317d187867cbe2",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/alexellis/" .. name .. "/releases/download/" .. version .. "/" .. name .. ".exe",
-            sha256 = "4741b7d83ab9456b7c34c9421f191f7eef790f9da728d180249664d1d888bf85",
+            sha256 = "0b32cdba214a0680e69f0a38c569e7041ca9783573dc79ab3db69327ebc71489",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package arkade to release 0.8.7. 

# Release info 

 The new override for `arkade get` means you can download binaries you need, despite your current operating system and platform.

This is useful for testing new CLIs, but also for downloading CLIs to transfer to another machine, RPi or VM

```bash
arkade get kubectl --os linux --platform arm7vl
arkade get kubectl --os darwin --platform x86_64
```

Changelog for 0.8.7:
* PR #<!-- -->554 fix: update krew binary download by @<!-- -->dirien
* PR #<!-- -->539 Support --arch and --os flags for arkade get by @<!-- -->YuviGold
* PR #<!-- -->556 Rename flags for inlets-operator by @<!-- -->alexellis
* PR #<!-- -->555 Added GitHub Actions build status using workflow name by @<!-- -->rashedkvm

Commits
f749281c2dcca738d5bc090627f452d5f3b7c422 fix: update krew binary download by @<!-- -->dirien
547b139381f15db974f465b97cf9c83dc1bf9dc3 Support --arch and --os flags for arkade get by @<!-- -->YuviGold
586c702e02e5f177719e4d8ad7a66934a90f7b42 Rename flags for inlets-operator by @<!-- -->alexellis
6ae3255d767f372c47558fa98f672c30d0a17b4c Added GitHub Actions build status using workflow name by @<!-- -->rashedkvm

Changes: https:<span/>/<span/>/github<span/>.com<span/>/alexellis<span/>/arkade<span/>/compare<span/>/0<span/>.8<span/>.6<span/>.<span/>.<span/>.0<span/>.8<span/>.7

Generated by https:<span/>/<span/>/github<span/>.com<span/>/alexellis<span/>/derek<span/>/
