### PR TITLE
goreleaser 0.183.0

### DIFF
--- a/Food/goreleaser.lua
+++ b/Food/goreleaser.lua
@@ -1,5 +1,5 @@
 local name = "goreleaser"
-local version = "0.182.1"
+local version = "0.183.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Darwin_all.tar.gz",
-            sha256 = "748cf9064af38f19d3a6ab09b885ae21042c686fc4a1e5e1f8e7a0d1dc261816",
+            sha256 = "d5aba48f35606190d7b34eb29426c34eb056a44abafbfa0a95a2c3b9e8cdf59b",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "bb0b3a96bb38ba86fb3f363d303ce6079c04ada2797a892bed2e2a61ad41daf2",
+            sha256 = "03e6b0da36f65a942ca0279e767ab5cae145958d3a8f91a0204f5ad71371787f",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Windows_x86_64.zip",
-            sha256 = "66af1c25dc8153f7df1919938111d3e01d5fb717ea089238e4cec9fd67290183",
+            sha256 = "cd41158809713f51e7c0459ec4f5a65edcda56c618f53db87df66307884d807c",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package goreleaser to release v0.183.0. 

# Release info 

 ## Changelog

a2ff2b8ddafe86900940386427a7e9f52662002b: feat(brew): multi-arch brew on binary archives (#<!-- -->2590) (@<!-- -->caarlos0)
ae6814466ede9c5ca7f162cea985ce0e92dcf2c3: feat(deps): upgrade go-github (#<!-- -->2581) (@<!-- -->caarlos0)
f4cef9605525f200fffdf9479cf166abfc07a4cf: feat(gofish): support binary releases (#<!-- -->2577) (@<!-- -->caarlos0)
c99071eb9eaee25f50daa49e4c29a8dcf2446dd8: feat(homebrew): support binary releases (#<!-- -->2576) (@<!-- -->caarlos0)
cbb567ca743a78477cb5d6c5c8248f4beb642bf6: fix(archive): add extra fields to the archives (#<!-- -->2578) (@<!-- -->caarlos0)
ba9b75a0950e665b5c69ba1efac8979ef8908409: fix(brew): remove deprecated `bottle :unneeded` (#<!-- -->2591) (@<!-- -->markcornick)
160d97af40bb747e86e4c7ff8f7ed68e87ec1768: fix: check if builds<span/>.dir is a directory (#<!-- -->2587) (@<!-- -->pmareke)
b5aefe6571effbd26a13f2664eb57e8e8e9477f5: fix: improve logging (@<!-- -->caarlos0)
870dc146fa2aae9a699f5cd939defc4f9f8d7b4d: fix: universal binary should be in dist/$x_darwin_all dir (@<!-- -->caarlos0)
df2f00fc8bae7bc59c5e18704cbd551681b32d7a: refactor: put common extra keys in the artifact package  (#<!-- -->2580) (@<!-- -->caarlos0)


## Docker images

- `docker pull goreleaser/goreleaser:v0.183.0`
- `docker pull ghcr<span/>.io<span/>/goreleaser<span/>/goreleaser:v0<span/>.183<span/>.0`
## What to do next?

- Check out the https:<span/>/<span/>/goreleaser<span/>.com<span/>/pro distribution;
- Join our https:<span/>/<span/>/discord<span/>.gg<span/>/RGEBtg8vQ6;
- Follow us on https:<span/>/<span/>/twitter<span/>.com<span/>/goreleaser;
- Read the https:<span/>/<span/>/goreleaser<span/>.com<span/>/intro<span/>/<span/>.

