### PR TITLE
tilt 0.22.14

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.22.13"
+local version = "0.22.14"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "23eeb626663f6e73ec1b87db5c0fe4e1886aa3b9f17df0e2af95c4f02ea037ed",
+            sha256 = "3191a3d50fd55950dc11f4786a98bac3ad75a0d0a1dc6c6a1a55578beca88416",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "fafbf2f684d100f20ad6a755957f9d57c2ccb58a3e8d59f264eb708f85662e51",
+            sha256 = "95d3a629bea113255b61e48ba360d69d64bdc6ff1e6d831af06ebd664bc22569",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "0df49a4d42a8ccfe2001f65bb865ec43df2bf043bcd5247630ae4799e939afd7",
+            sha256 = "bc1a7273de3c6b911b75b266c08f080d5ae85d69aace65fc719c5e2a9b9bcd17",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.22.14. 

# Release info 

 ## Changelog

03b22911a Update version numbers: 0.22.13
4662ff9f2 api: implement ToggleButton reconciler (#<!-- -->5014)
cd38819a9 apis: add a mechanism to determine which file changes to sync (#<!-- -->5057)
ef496ee6d buildcontrol: triggered builds shouldn't bypass other checks (#<!-- -->5041)
d00ad10b0 controllers: LiveUpdate references to other API objects (#<!-- -->5064)
69720f3fc controllers: add indexers for FileWatch, ImageMap to LiveUpdate (#<!-- -->5061)
5953d8160 controllers: eliminate LU filter + export path mapping logic (#<!-- -->5059)
d494020b1 controllers: enable and disable filewatches with disable configmap (#<!-- -->5023)
43238fa54 controllers: write live update status (#<!-- -->5053)
b005094d0 controllers: write the LiveUpdate object to the apiserver (#<!-- -->5047)
c1f9921b8 docker: evaluate build args for base image ref (#<!-- -->5048)
8c75f4e6a dockercompose: re-roll dockercompose model so that it doesn't roundtrip through parsing (#<!-- -->5055)
3912b651f engine: cancel builds when resource is disabled (#<!-- -->5040)
475755fc7 engine: don't build disabled resources (#<!-- -->5042)
416702d43 engine: replicate ConfigMap back to EngineState (#<!-- -->5052)
c6420298a engine: replicate UIResource to EngineState (#<!-- -->5035)
0ecbd5a98 k8s: more robust CRD replacement (#<!-- -->5065)
6f58083dd liveupdate: update schema to support multiple FileWatch objects (#<!-- -->5067)
e01c651ca script: make install<span/>.sh arch-aware (#<!-- -->5050)
ee7468ce2 server: raise tilt client rate limits (#<!-- -->5049)
b78d83210 store: replicate LiveUpdate back to the EngineState (#<!-- -->5062)
3c081b095 tiltfile: add built-in for kubernetes-apply (#<!-- -->5033)
c09f1aaa3 tiltfile: add built-in for kubernetesdiscovery (#<!-- -->5028)
26331871e vendor: set explicit version for pkg/browser (#<!-- -->5036)
d4fd09ee1 vendor: upgrade tilt-dev/dockerignore to fix escape issues (#<!-- -->5066)
5f8f3961d vendor: upgrade tilt-dev/probe to fix dangling procs (#<!-- -->5068)
f491b4492 web: fix sidebar card display bug that shrinks star button when resource name is long


## Docker images

- `docker pull tiltdev/tilt`
- `docker pull tiltdev/tilt:v0.22.14`
