### PR TITLE
conftest 0.28.2

### DIFF
--- a/Food/conftest.lua
+++ b/Food/conftest.lua
@@ -1,6 +1,6 @@
 local name = "conftest"
-local release = "v0.28.1"
-local version = "0.28.1"
+local release = "v0.28.2"
+local version = "0.28.2"
 food = {
     name = name,
     description = "Write tests against structured configuration data using the Open Policy Agent Rego query language",
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/open-policy-agent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Darwin_x86_64.tar.gz",
-            sha256 = "16866e8066f629cf1a7ff3fb190b1ed9714025e45e7160857c9776d460238f3a",
+            sha256 = "7f1a04192acc77e21f50e0e2eb7ff3d0a60fbaa395f16f2b9192b20450f077f5",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/open-policy-agent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Linux_x86_64.tar.gz",
-            sha256 = "dc706990af32f0c7ba824e72015707a8a40a8d9032c87c3838a01ca14457b7e3",
+            sha256 = "72feafd426aa99d35411ef3d88ad48476303e8aa80855daa2676b7047d6d543c",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/open-policy-agent/" .. name .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_Windows_x86_64.zip",
-            sha256 = "d966cbee5959ce605328589e70a124d18a47df4185a029e4523bd6afaf098d91",
+            sha256 = "083156d4b1d921b92e2ef0dfe375dd669e1394c7fa949a829bcfed00593e36a0",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package conftest to release v0.28.2. 

# Release info 

 This is a maintenance release only and does not include any bug fixes or new features.

## Improvements

* Bump OPA to v0.33.1
* Bump Go to v1.17.2

## Changelog

6b6595d (chore) Bump Go to 1.17.2 (#<!-- -->625)
b721065 Bump github<span/>.com<span/>/open-policy-agent<span/>/opa from 0.32.1 to 0.33.0 (#<!-- -->615)
3f24df0 Bump github<span/>.com<span/>/open-policy-agent<span/>/opa from 0.33.0 to 0.33.1 (#<!-- -->616)
445878f Bump golang from 1.17.1-alpine to 1.17.2-alpine (#<!-- -->618)
186ae1b Bump mkdocs from 1.1 to 1.2.3 (#<!-- -->624)
19e754e Bump nltk from 3.5 to 3.6.5 (#<!-- -->619)
02462d5 Remove old examples (#<!-- -->620)
4ecfbdf upgrade Oras to oras-go v0.4.0 (#<!-- -->617)

