### PR TITLE
gh 2.2.0

### DIFF
--- a/Food/gh.lua
+++ b/Food/gh.lua
@@ -1,5 +1,5 @@
 local name = "gh"
-local version = "2.1.0"
+local version = "2.2.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_macOS_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "258944c59cb34c9e8716ecc1e7a3d90f72da9b96b4d85ec9b7b773b4370c88ff",
+            sha256 = "c9c8a716f79fbd8f0a165292e94550f15d0208e6cd3383e5ce942fd2a9ada57f",
             resources = {
                 {
                     path = name .. "_" .. version .. "_macOS_amd64" .. "/bin/" .. name,
@@ -26,7 +26,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
             -- shasum of the release archive
-            sha256 = "eddadd0cf7ecf340614dd5914eaad1543d8491c966a3a3a41f8a03832dfac184",
+            sha256 = "76bd37160c61cf668b96a362ebc01d23736ebf94ec9dfe3090cacea37fd3b3fb",
             resources = {
                 {
                     path = name .. "_" .. version .. "_linux_amd64" .. "/bin/" .. name,
@@ -40,7 +40,7 @@ food = {
             arch = "amd64",
             url = "https://github.com/cli/cli/releases/download/v" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
             -- shasum of the release archive
-            sha256 = "34fa202c7cf731f7ff134535200da92af3d7cde05275c3621a92a3fdd65f6a07",
+            sha256 = "736d3a6090687b1a3d4f98d9cd8344b50bb3c37264e32890936052c3725574c5",
             resources = {
                 {
                     path = "bin/" .. name .. ".exe",


### PR DESCRIPTION
Updating package gh to release v2.2.0. 

# Release info 

 ## Support for GitHub Codespaces

The new `gh codespace` commands allow creating, listing, connecting to, and otherwise managing your codespaces.

```sh
# list your codespaces
$ gh codespace list

# create a new codespace
$ gh codespace create --repo cli/cli

# start an interactive shell within a codespace
$ gh codespace ssh
```

To get started, check out `gh help codespace`. You can also use the `gh cs <command>` alias for short.

Thank you @<!-- -->josebalius, @<!-- -->adonovan, and code contributors: @<!-- -->asciimike @<!-- -->CamiloGarciaLaRotta @<!-- -->CGA1123 @<!-- -->edgonmsft @<!-- -->geramirez @<!-- -->georgebrock @<!-- -->issyl0 @<!-- -->joshmgross @<!-- -->koddsson @<!-- -->marwan-at-work @<!-- -->maxbeizer @<!-- -->nickfyson @<!-- -->Raffo @<!-- -->Shanduur!

## What's New
* Add `repo delete` command by @<!-- -->meiji163 in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4451
* Add `run cancel` command by @<!-- -->cristiand391 in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/3833
* Add `gpg-key` management commands by @<!-- -->owenvoke in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/3822
* Support logging in to `github.localhost` by @<!-- -->joshmgross in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4523

## What's Changed
* `browse`: respect the current working directory for file arguments by @<!-- -->bchadwic in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4007
* `release create`: respect the `--draft` flag in interactive mode by @<!-- -->Sixeight in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4542
* `api`: avoid repeating GET parameters when paginating by @<!-- -->mislav in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4559
* The progress spinner is now visible against a light background https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4556
* Dispatch binary extensions directly by @<!-- -->vilmibm in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4568
* Fix copy/paste mistake in docs by @<!-- -->stdtom in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4582

## New Contributors
* @<!-- -->nickfyson made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4529
* @<!-- -->asciimike made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4538
* @<!-- -->owenvoke made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/3822
* @<!-- -->Sixeight made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4542
* @<!-- -->joshmgross made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4523
* @<!-- -->stdtom made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4582
* @<!-- -->dhiemaz made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/cli<span/>/cli<span/>/pull<span/>/4586
