### PR TITLE
skaffold 1.34.0

### DIFF
--- a/Food/skaffold.lua
+++ b/Food/skaffold.lua
@@ -1,5 +1,5 @@
 local name = "skaffold"
-local version = "1.33.1"
+local version = "1.34.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "2c379941adaa0c50556d59474018d796ca0e16a3f16f0d22f8400e140e6aad72",
+            sha256 = "d05067373ad3a4594de089675606c2fa974da916d6fa47c1a141c5819d7592ca",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "98a403d36a57a76f55bb8236c882d806de8a544bc4652d42b74af80a237888be",
+            sha256 = "8a10e0ba16016a058a35996659b72911e3693e64b5f376976fb69ae25662d47f",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/GoogleContainerTools/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "23ed6cb241548a2c4e6dd6c91c1d3ae293708e111a5c64a495c5d00966fb75b0",
+            sha256 = "1c001e04e6959e05980a080d165f5c10a12c73d51348b0121cf96e9ce372c7a8",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package skaffold to release v1.34.0. 

# Release info 

 # v1.34.0 Release - 10/26/2021
**Linux**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.34<span/>.0<span/>/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**macOS**
`curl -Lo skaffold https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.34<span/>.0<span/>/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`

**Windows**
https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/skaffold<span/>/releases<span/>/v1<span/>.34<span/>.0<span/>/skaffold-windows-amd64<span/>.exe

**Docker image**
`gcr<span/>.io<span/>/k8s-skaffold<span/>/skaffold:v1<span/>.34<span/>.0`

Note: This release comes with a new config version, `v2beta25`. To upgrade your skaffold<span/>.yaml, use `skaffold fix`. If you choose not to upgrade, skaffold will auto-upgrade as best as it can.

Highlights:
* `skaffold deploy`, `skaffold render` and `skaffold test` now support the `--images` flag for providing a list of images to run against.
* The `--images` flag now supports `NAME=TAG` pairs.

New Features and Additions:
* feat: trap SIGUSR1 to dump current stacktrace https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6751
* feat: skaffold lint core logic, CLI command+flags, and MVP skaffold<span/>.yaml support https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6715

Fixes:
* fix: fix non-determinism in skaffoldyamls_test<span/>.go https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6757
* fix: use new stringslice lib https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6752
* fix: correctly rewrite debug container entrypoint and bind host port https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6682
* Fix new version generation https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6616
* fix: panic caused by multiple channel closes https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6714
* fix: sanity check kpt deployer versions https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6711

Updates and Refactors:
* refactor: move some of `pkg/skaffold/util` into into packages https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6731

Docs, Test, and Release Updates:
* doc: update CI-CD article to decouple `render` and `deploy` use from GitOps https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6750
* chore: update image dependencies https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6736
* chore: use ad-hoc signing on darwin to avoid network popups https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6738
* chore: add cluster type to the instrumentation meter https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6734
* chore: Update globstar syntax in examples dependencies https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6614
* docs: add Cloud Code install instructions https:<span/>/<span/>/github<span/>.com<span/>/GoogleContainerTools<span/>/skaffold<span/>/pull<span/>/6716

Huge thanks goes out to all of our contributors for this release:

- Aaron Prindle
- Brian de Alwis
- Conor A. Callahan
- Dave Dorbin
- Gaurav
- Halvard Skogsrud
- Marlon Gamez
- Mike Verbanic
- Nick Kubala
- Tejal Desai
- Yuwen Ma