### PR TITLE
tilt 0.22.15

### DIFF
--- a/Food/tilt.lua
+++ b/Food/tilt.lua
@@ -1,5 +1,5 @@
 local name = "tilt"
-local version = "0.22.14"
+local version = "0.22.15"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".mac.x86_64.tar.gz",
-            sha256 = "3191a3d50fd55950dc11f4786a98bac3ad75a0d0a1dc6c6a1a55578beca88416",
+            sha256 = "e3f00907a3f3fbe17e2f028f76dee016db0ee55372a5a9d330663a05e28beae0",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".linux.x86_64.tar.gz",
-            sha256 = "95d3a629bea113255b61e48ba360d69d64bdc6ff1e6d831af06ebd664bc22569",
+            sha256 = "0a68d51f9ba34f7bc67393016759f042e6a4cf7d91ac37a21ee182d208ad10a8",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/tilt-dev/" .. name .. "/releases/download/" .. release .. "/" .. name .. "." .. version .. ".windows.x86_64.zip",
-            sha256 = "bc1a7273de3c6b911b75b266c08f080d5ae85d69aace65fc719c5e2a9b9bcd17",
+            sha256 = "35118a7a217b3c67c24038fac5d56410fe7fb4821af04447b04bbeebe3d29a06",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package tilt to release v0.22.15. 

# Release info 

 https:<span/>/<span/>/docs<span/>.tilt<span/>.dev<span/>/install<span/>.html) ⬇️ | [Upgrade Tilt](https:<span/>/<span/>/docs<span/>.tilt<span/>.dev<span/>/upgrade<span/>.html) ⬆️ | [Tilt Extensions](https:<span/>/<span/>/github<span/>.com<span/>/tilt-dev<span/>/tilt-extensions<span/>/ 🧰

## Notable Changes

TBD

## Changelog

86012b939 Update README<span/>.md
9ef9faa4c Update version numbers: 0.22.14
be548b734 api: add RestartOn support to KubernetesApply reconciler (#<!-- -->5094)
15f872cd0 api: add custom Cmd field to KubernetesApply (#<!-- -->5089)
daaedf919 api: add stub handler for KubernetesApply Cmd deploy (#<!-- -->5095)
45e4dda1c api: propagate image hold targets (#<!-- -->5083)
fc7b3ba1e api: refactor how disable configmaps are passed (#<!-- -->5084)
49dbcaae4 api: set UIResource.Status.DisableStatus counts (#<!-- -->5037)
43cac953a api: share RestartOn/StartOn logic (#<!-- -->5093)
1372bb5f9 apis: add a LiveUpdateSource object for pulling files (#<!-- -->5074)
1acb3f246 apis: add some API docs that were missing (#<!-- -->5090)
ad6f04df7 apis: add waiting field to live update containers (#<!-- -->5079)
1a58420b2 build: expose hold info on UIResource (#<!-- -->5080)
3c22da280 buildcontrol: move actions and reducers into their own package (#<!-- -->5087)
76960befe flag: add feature flag for enabling and disabling resources (#<!-- -->5085)
12b79e482 goreleaser: arm builds no longer in alpha (#<!-- -->5078)
e9e89d8cc liveupdate: add a flag for liveupdatev2 (#<!-- -->5076)
87cde0367 liveupdate: add syncing logic to the reconciler (#<!-- -->5072)
f0490542e liveupdate: handle object NotFound errors (#<!-- -->5075)
742a91f3b liveupdate: reconciler tracks and diffs dependencies it's aware of (#<!-- -->5069)
d294bee24 liveupdate: update status to reflect all containers, not just running containers (#<!-- -->5081)
df3218084 model: live-update should watch any files on any base images (#<!-- -->5071)
87a74d461 script: fix local codegen (#<!-- -->5091)
d07190c5a server: disable websocket compression to fix macos monterey safari (#<!-- -->5082)
ca418d1a4 store: fix a regression in how live-update interacts with selector-based pod discovery (#<!-- -->5073)
d3ef5eced upgrade to go 1.17 (#<!-- -->5088)
70e4cd6c4 web: use default values when clicking uibutton (#<!-- -->5060)


## Docker images

- `docker pull tiltdev/tilt:v0.22.15`
