### PR TITLE
goreleaser 0.184.0

### DIFF
--- a/Food/goreleaser.lua
+++ b/Food/goreleaser.lua
@@ -1,5 +1,5 @@
 local name = "goreleaser"
-local version = "0.183.0"
+local version = "0.184.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Darwin_all.tar.gz",
-            sha256 = "d5aba48f35606190d7b34eb29426c34eb056a44abafbfa0a95a2c3b9e8cdf59b",
+            sha256 = "97a01fae41173e8387a28a54ef4a054f37ccbd3e384fcf88434a9ed3e0200aa9",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Linux_x86_64.tar.gz",
-            sha256 = "03e6b0da36f65a942ca0279e767ab5cae145958d3a8f91a0204f5ad71371787f",
+            sha256 = "0972c17d94f2a95aafbef0c9f6d01ea774abfb8d37b85778e8cb4885efc24511",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/" .. name .. "/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "_Windows_x86_64.zip",
-            sha256 = "cd41158809713f51e7c0459ec4f5a65edcda56c618f53db87df66307884d807c",
+            sha256 = "a4ccca17576e91ebe8fd244f2e34a83c857a90e861624ad7aab9395c760ddfa5",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package goreleaser to release v0.184.0. 

# Release info 

 ## Changelog

69f89279703d32c4e7386ccc28cb269763c0f88d: feat(deps): bump sigstore/cosign-installer from 1.2.0 to 1.2.1 (#<!-- -->2602) (@<!-- -->dependabot[bot])
e5a9e18050ae5d64b003fb169dc91d132ad01ce0: feat(schema): add command that generates jsonschema (#<!-- -->2589) (@<!-- -->patrick246)
48d774970c3a47af150964ddd8cf37e8e6943ef6: fix: add debug log for changelog file load (@<!-- -->caarlos0)
9fd61fb9562d12151a52882347e14949ee2fc70e: fix: goFish check for same OS/Arch is unnecessary (#<!-- -->2604) (@<!-- -->dirien)
5de2a8bb86540088165d2e5e6c5c2f2a679317dd: fix: goreleaser should conflict with goreleaser-pro (@<!-- -->caarlos0)
01fa7a68276f7191773bd1db3ca16140dc71e575: refactor: organize config a bit (#<!-- -->2619) (@<!-- -->caarlos0)


## Docker images

- `docker pull goreleaser/goreleaser:v0.184.0`
- `docker pull ghcr<span/>.io<span/>/goreleaser<span/>/goreleaser:v0<span/>.184<span/>.0`
## What to do next?

- Check out the https:<span/>/<span/>/goreleaser<span/>.com<span/>/pro distribution;
- Join our https:<span/>/<span/>/discord<span/>.gg<span/>/RGEBtg8vQ6;
- Follow us on https:<span/>/<span/>/twitter<span/>.com<span/>/goreleaser;
- Read the https:<span/>/<span/>/goreleaser<span/>.com<span/>/intro<span/>/<span/>.

