### PR TITLE
minectl 0.12.1

### DIFF
--- a/Food/minectl.lua
+++ b/Food/minectl.lua
@@ -1,5 +1,5 @@
 local name = "minectl"
-local version = "0.12.0"
+local version = "0.12.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://github.com/dirien/".. name .."/releases/download/v".. version .."/".. name .."_".. version .."_darwin_arm64.tar.gz",
-            sha256 = "9a717839dd3358d1268143476b768e18466704af5b006342c3f9548500345dcb",
+            sha256 = "13ddb1d0214ceb22f61473987dd16018476e04d81d17863078426714f1dc9fd5",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/dirien/".. name .."/releases/download/v".. version .."/".. name .."_".. version .."_darwin_amd64.tar.gz",
-            sha256 = "79d96d9edc435dad2df0c6ab0b386bc09bbdef39eb802eb26f959d4bf89f5a29",
+            sha256 = "f8294cb2967c8d916cdb5a29803fea722773fa8692262bfc6bad9c6937664534",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/dirien/".. name .."/releases/download/v".. version .."/".. name .."_".. version .."_linux_arm64.tar.gz",
-            sha256 = "b4d152762b78359ef9ec93ddf097a9dbbfd2a65a4a6eda9f10cdbb4b9ae2898f",
+            sha256 = "b888ecdf94045899381ed2616cd068a07faed4339068142b4d8245251e3ee441",
             resources = {
                 {
                     path = name,
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/dirien/".. name .."/releases/download/v".. version .."/".. name .."_".. version .."_linux_amd64.tar.gz",
-            sha256 = "e8423f05c60c68a240e95a72c1bdc9ef7d266055ebf39f4c2cde343553e9dfdc",
+            sha256 = "819e555e6dc113e5600e3ebaf304271e87be9f705fdf94b1a68db09a4e8c35d0",
             resources = {
                 {
                     path = name,
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/dirien/".. name .."/releases/download/v".. version .."/".. name .."_".. version .."_windows_amd64.zip",
-            sha256 = "97e94c215a9123abdc4cb2c96902cacf1df9ee0c036bc2edd5fa6106e51df9f3",
+            sha256 = "37d32ea6f60f8e2cd74d14a8a6c57599811b45360097573560cc18836a1c8276",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package minectl to release v0.12.1. 

# Release info 

 ## Changelog

8b886a6 chore: add gomodUpdateImportPaths (#<!-- -->272)
6d4a65e chore(deps): update module github<span/>.com<span/>/digitalocean<span/>/godo to v1.70.0 (#<!-- -->271)
a0e5afa chore(deps): update module github<span/>.com<span/>/melbahja<span/>/goph to v1.3.0 (#<!-- -->270)
80ac316 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.15 (#<!-- -->269)
2bb2a21 fix: remove make all call in action (#<!-- -->268)
1e03efc fix: remove make all call in action
9a6ec38 feat: add module caching in build (#<!-- -->267)
38152f6 chore: use :gitSignOff instead commitBody (#<!-- -->266)
1d8d172 chore(deps): update module google<span/>.golang<span/>.org<span/>/api to v0.60.0 (#<!-- -->263)
31ad283 chore(deps): update module github<span/>.com<span/>/azure<span/>/azure-sdk-for-go to v59 (#<!-- -->262)
19cda99 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.13 (#<!-- -->261)
9bc0e42 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.11 (#<!-- -->260)
64a541c chore(deps): update module github<span/>.com<span/>/oracle<span/>/oci-go-sdk<span/>/v49 to v50 (#<!-- -->259)
5333244 chore(deps): update module github<span/>.com<span/>/ionos-cloud<span/>/sdk-go<span/>/v5 to v5.1.9 (#<!-- -->257)
ffcb284 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.10 (#<!-- -->258)
d88b86c chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.9 (#<!-- -->256)
ff49cec chore(deps): update module github<span/>.com<span/>/azure<span/>/azure-sdk-for-go to v58.3.0 (#<!-- -->255)
d5ebf55 chore(deps): update module github<span/>.com<span/>/vultr<span/>/govultr<span/>/v2 to v2.9.2 (#<!-- -->254)
a0f63b4 chore(deps): update module google<span/>.golang<span/>.org<span/>/api to v0.59.0 (#<!-- -->253)
5d088f3 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.7 (#<!-- -->252)
b70a194 chore(deps): update module github<span/>.com<span/>/oracle<span/>/oci-go-sdk<span/>/v49 to v49.2.0 (#<!-- -->251)
bcad8eb chore(deps): update module github<span/>.com<span/>/vultr<span/>/govultr<span/>/v2 to v2.9.1 (#<!-- -->250)
bbf0a46 chore(deps): update module github<span/>.com<span/>/aws<span/>/aws-sdk-go to v1.41.5 (#<!-- -->249)


## Docker images

- `docker pull ghcr<span/>.io<span/>/dirien<span/>/minectl:0<span/>.12<span/>.1-arm64`
- `docker pull ghcr<span/>.io<span/>/dirien<span/>/minectl:0<span/>.12<span/>.1-amd64`
