### PR TITLE
flux 0.21.0

### DIFF
--- a/Food/flux.lua
+++ b/Food/flux.lua
@@ -1,5 +1,5 @@
 local name = "flux"
-local version = "0.20.1"
+local version = "0.21.0"
 local release = "v" .. version
 
 food = {
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
-            sha256 = "ad676f9d63d56c3bd2f50f2e0c87f47e3e5c7dbfe82292580db564673b97b637",
+            sha256 = "7d1112e8c50abda00c5208bf83efecdb56e9e123a4f579657c2e2d54685db9e1",
             resources = {
                 {
                     path = name,
@@ -26,7 +26,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_arm64.tar.gz",
-            sha256 = "71cad9fb35b49d4ab4f7946fe469453a8a82df08b85ea44838db36a4d9dc0c01",
+            sha256 = "739b820f5426baef4b970b2ecd46d69e3430b427e9ac0483b18b435124017df0",
             resources = {
                 {
                     path = name,
@@ -39,7 +39,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
-            sha256 = "b6d296aefa0d77631c98ea810c1c2e572d110cd68cc98193cab5d996dae676d2",
+            sha256 = "3fd32882f08e009f58d44a594941752f0a7e1c56adff023b393facb315c0565a",
             resources = {
                 {
                     path = name,
@@ -52,7 +52,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_arm64.tar.gz",
-            sha256 = "3ce280804d0193617fd2e3cf0fbc6d14e1d31605e756837167adeb79f4b1d85a",
+            sha256 = "d1260f727095aec1a187f7a76c406c81e34325d930cb7fabaa1ef2fddc998b12",
             resources = {
                 {
                     path = name,
@@ -65,7 +65,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/fluxcd/flux2/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
-            sha256 = "c354905f704e0d1e0843be7fb281371036a00a03bdc09ebc78cd9cabd93e1c18",
+            sha256 = "284b7b7b40137800ae2e4bdb31b7dd909ed70140781f00fce6769fd21952069a",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package flux to release v0.21.0. 

# Release info 

 This release comes with **ECDSA** as the default SSH key algorithm used by `flux bootstrap` and all the other commands that generate SSH keys. This change was imposed by GitHub that is https:<span/>/<span/>/github<span/>.blog<span/>/2021-09-01-improving-git-protocol-security-github<span/>/<span/>.

To rotate your SSH deploy keys for the repositories bootstrapped with Flux:

- download the Flux CLI v0.21.0 binary
- delete the deploy key secret from your cluster `kubectl -n flux-system delete secret flux-system`
- using the Flux CLI v0.21.0 rerun `flux bootstrap github` with the same arguments as before
- Flux will generate a `ecdsa-sha2-nistp384` SSH key and will update the deploy key on GitHub

CHANGELOG
- PR #<!-- -->2042 - @<!-- -->stefanprodan - Set ECDSA as the default algorithm for `flux create source git`
- PR #<!-- -->2041 - @<!-- -->stefanprodan - bootstrap: Set ECDSA as the default SSH key algorithm
- PR #<!-- -->2036 - @<!-- -->stefanprodan - Switch to `app<span/>.kubernetes<span/>.io<span/>/part-of` label selector
- PR #<!-- -->2035 - @<!-- -->stefanprodan - Add fetch timeout arg to create source commands
- PR #<!-- -->2034 - @<!-- -->stefanprodan - Set default ns with `FLUX_SYSTEM_NAMESPACE` env var
- PR #<!-- -->2033 - @<!-- -->stefanprodan - Add flux version to issue template
- PR #<!-- -->2032 - @<!-- -->stefanprodan - Enable completion for flux tree cmd


## Docker images

- `docker pull fluxcd/flux-cli:v0.21.0`
- `docker pull ghcr<span/>.io<span/>/fluxcd<span/>/flux-cli:v0<span/>.21<span/>.0`
