### PR TITLE
cloud_sql_proxy 1.27.0

### DIFF
--- a/Food/cloud_sql_proxy.lua
+++ b/Food/cloud_sql_proxy.lua
@@ -1,5 +1,5 @@
 local name = "cloud_sql_proxy"
-local version = "1.26.0"
+local version = "1.27.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. ".darwin.amd64",
-            sha256 = "826938c31403cb83cb964d647d2fc94608468cdba67e83d615d2046613d19b5f",
+            sha256 = "66ccf2c4fea647334fd0bafa5a3ea25bcf4523a9f0b3f8ec2798748b7651584e",
             resources = {
                 {
                     path = name .. ".darwin.amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. ".linux.amd64",
-            sha256 = "18b34e33b529b770b8dca9f540e4269ff61d1f07d7cae6276eedf492887c586d",
+            sha256 = "80934dfd7fd4097e2782be51d21c6e7d3d99327fb4e2fee3a151f4990809f63f",
             resources = {
                 {
                     path = name .. ".linux.amd64",
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. "_x86.exe",
-            sha256 = "cf4b2cab5175667ccc6a9bf59b26858d7c2bc37123ed2d6081c7dca17b5d1b19",
+            sha256 = "638947455fd0f0afefafb3e22acc27ffcbe1b42ba2dfe4b4f2ecba74a408ef2c",
             resources = {
                 {
                     path = name .. "_x86.exe",


### PR DESCRIPTION
Updating package cloud_sql_proxy to release v1.27.0. 

# Release info 

 

### Features

* switch to supported FUSE library (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/953)) ([10f2133](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/10f2133010f3bf7ef8a13b43e0bfa16bdca8cedb)
* verify FUSE is installed on macOS / linux (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/959)) ([9ab868e](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/9ab868ef344b9a82c06f97928420f98a4d37c5ce)


### Bug Fixes

* fail fast on invalid config (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/999)) ([18a0960](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/18a096037d9ceb2ca71218984b65fe342fc2a778)
* respect context deadline for TLS handshakes (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/987)) ([12ff12c](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/12ff12c9f87459dc40e2e6e4a2d08bebb0786ee7)), closes [#<!-- -->986](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/986
* validate instance connections in liveness probe (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/995)) ([e5cc8d4](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/e5cc8d4f8676fed2013cc491578a1aaf7416ec3e)

| filename | sha256 hash |
|----------|-------------|
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.darwin<span/>.amd64 | 66ccf2c4fea647334fd0bafa5a3ea25bcf4523a9f0b3f8ec2798748b7651584e |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.darwin<span/>.arm64 | 5df9000a10c498e41a0e771f738a00957a64ae60a5131c2ce244cded74c5c2e4 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.linux<span/>.386 | d37fb716dcda8f4872ffec9ee140878dd23aeac29f72ba157afcb3245a06b1c8 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.linux<span/>.amd64 | 80934dfd7fd4097e2782be51d21c6e7d3d99327fb4e2fee3a151f4990809f63f |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.linux<span/>.arm | a241fa03a7ccee0e096e77931cc369175390105c5ef98a4f679c8f8448c7b26a |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy<span/>.linux<span/>.arm64 | e6a1e1c740511a791341119cc6ff89f992f05d0e5019ca02000703b5667d8c9b |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy_x64<span/>.exe | 598aebb714782e39a29d3cbccd4fb66d2747bcdb4265b7798552cb08f68fa426 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.0<span/>/cloud_sql_proxy_x86<span/>.exe | 638947455fd0f0afefafb3e22acc27ffcbe1b42ba2dfe4b4f2ecba74a408ef2c |

