### PR TITLE
cosign 1.3.0

### DIFF
--- a/Food/cosign.lua
+++ b/Food/cosign.lua
@@ -1,5 +1,5 @@
 local name = "cosign"
-local version = "1.2.1"
+local version = "1.3.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "617e219b322bb26c2e3cee0310a817469b23c902b7ec286196ea6e707cced3b6",
+            sha256 = "885974dd064ceb6a6b2c1d3b0db1999376d0887b2dae8ccb3ae2d104312fd3da",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -24,7 +24,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "490cb1941aa317cd24a0bd9f2fe38932805dbaaba0ae89c12ec8138d15bdd8a0",
+            sha256 = "9604a5eb171748113f92a67495556007dde6f45804f0b38d3e55c3bc7e151774",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -37,7 +37,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-arm64",
-            sha256 = "917e56e1966d31a98e455904d4996563061ab0ce845e541434bba796b1f5b027",
+            sha256 = "5c204f0a8543d695e4037d090d3dc1f97c26ffae67b8740c4b4098ad2cca4abd",
             resources = {
                 {
                     path = name .. "-darwin-arm64",
@@ -50,7 +50,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "94872d7882e2fc6b8aebe864101395d2769f31783399282545156ccc2c516cf4",
+            sha256 = "bf8423700e8bbf01f03769f7b4bd078a4c8527ce98c28cd4c9bf2f83144e9485",
             resources = {
                 {
                     path = name .. "-darwin-amd64",


### PR DESCRIPTION
Updating package cosign to release v1.3.0. 

# Release info 

 # Release 1.3.0

## Highlights

* BREAKING: `verify-manifest` is now `manifest verify` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/712)
* BREAKING: `/pkg` has been heavily refactored. https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/issues<span/>/844 will make its way into 1.4.0
* WARNING: The CLI now uses POSIX-style (double-dash `--flag`) for long-form flags. It will temporarily accept the single-dash `-flag` form with a warning, which will become an error in a future release (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/835)
* Added `sget` as part of Cosign's releases (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/752)
* The `copasetic` utility was unceremoniously https:<span/>/<span/>/www<span/>.youtube<span/>.com<span/>/watch?v=07h0ksKx5sM) (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/785

## Enhancements

* Began reworking `/pkg` around new abstrations for signing, verification, and storage (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/issues<span/>/666)
    * Notice: refactoring of `/pkg` will continue in the next minor release (1.4.0). Please leave feedback, especially if you've been experimenting with `cosign` as a library and found it lacking (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/issues<span/>/844)
    * https:<span/>/<span/>/github<span/>.com<span/>/google<span/>/go-containerregistry#philosophy) for interacting with images now exist under `pkg/oci` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/770
    * `pkg/cosign/remote.UploadSignature` API was been removed in favor of new `pkg/oci/remote` APIs (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/774)
    * The function signature of `cosign.Verify` was changed so that callers must be explicit about which signatures (or attestations) to verify. For matching signatures, see also `cosign.Verify{Signatures,Attestations}` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/782)
    * Removed `cremote.UploadFile` in favor of `static.NewFile` and `remote.Write` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/797)
* Innumerable other improvements to the codebase and automation (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/commits?author=mattmoor)
* Migrated the CLI to `cobra` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/commits?author=n3wscott)
* Added the `--allow-insecure-registry` flag to disable TLS verification when interacting with insecure (e.g. self-signed) container registries (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/669)
* 🔒 `cosigned` now includes a mutating webhook that resolves image tags to digests (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/800)
* 🔒 The `cosigned` validating webhook now requires image digest references (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/799)
* The `cosigned` webhook now ignores resources that are being deleted (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/803)
* The `cosigned` webhook now supports resolving private images that are authenticated via `imagePullSecrets` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/804)
* `manifest verify` now supports verifying images in all Kubernetes objects that fit within `PodSpec`, `PodSpecTemplate`, or `JobSpecTemplate`, including CRDs (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/697)
* Added shell auto-completion support (Clutch collab from @<!-- -->erkanzileli, @<!-- -->passcod, and @<!-- -->Dentrax! https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/836)
* `cosign` has generated Markdown docs available in the `doc/` directory (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/839)
* Added support for verifying with secrets from a Gitlab project (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/934)
* Added a `--k8s-keychain` option that enables cosign to support ambient registry credentials based on the "k8schain" library (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/972)
* CI (test) Images are now created for every architecture distroless ships on (currently: amd64, arm64, arm, s390x, ppc64le) (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/973)
* `attest`: replaced `--upload` flag with a `--no-upload` flag (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/979)

## Bug Fixes

* `cosigned` now verifies `CronJob` images (Terve, @<!-- -->vaikas https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/809)
* Fixed the `verify` `--cert-email` option to actually work (Sweet as, @<!-- -->passcod https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/821)
* `public-key -sk` no longer causes  `error: x509: unsupported public key type: *crypto.PublicKey` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/864)
* Fixed interactive terminal support in Windows (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/871)
* The `-ct` flag is no longer ignored in `upload blob` (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/910)

## Contributors

* Aditya Sirish (@<!-- -->adityasaky)
* Asra Ali (@<!-- -->asraa)
* Axel Simon (@<!-- -->axelsimon)
* Batuhan Apaydın (@<!-- -->developer-guy)
* Brandon Mitchell (@<!-- -->sudo-bmitch)
* Carlos Panato (@<!-- -->cpanato)
* Chao Lin (@<!-- -->blackcat-lin)
* Dan Lorenc (@<!-- -->dlorenc)
* Dan Luhring (@<!-- -->luhring)
* Eng Zer Jun (@<!-- -->Juneezee)
* Erkan Zileli (@<!-- -->erkanzileli)
* Félix Saparelli (@<!-- -->passcod)
* Furkan Türkal (@<!-- -->Dentrax)
* Hector Fernandez (@<!-- -->hectorj2f)
* Ivan Font (@<!-- -->font)
* Jake Sanders (@<!-- -->dekkagaijin)
* Jason Hall (@<!-- -->imjasonh)
* Jim Bugwadia (@<!-- -->JimBugwadia)
* Joel Kamp (@<!-- -->mrjoelkamp)
* Luke Hinds (@<!-- -->lukehinds)
* Matt Moore (@<!-- -->mattmoor)
* Naveen (@<!-- -->naveensrinivasan)
* Olivier Gaumond (@<!-- -->oliviergaumond)
* Priya Wadhwa (@<!-- -->priyawadhwa)
* Radoslav Gerganov (@<!-- -->rgerganov)
* Ramkumar Chinchani (@<!-- -->rchincha)
* Rémy Greinhofer (@<!-- -->rgreinho)
* Scott Nichols (@<!-- -->n3wscott)
* Shubham Palriwala (@<!-- -->ShubhamPalriwala)
* Viacheslav Vasilyev (@<!-- -->avoidik)
* Ville Aikas (@<!-- -->vaikas)

## Full Changelog

a91aa20 Fix the release (#<!-- -->987)
ae36ba5 update changelog for 1.3.0 (#<!-- -->986)
6d5f08c Bump opa and apis. (#<!-- -->980)
daa78e4 Add luhring to codeowners (#<!-- -->981)
58f8d20 Invert upload flag to allow for not uploading attestation (#<!-- -->979)
0ebe3b5 refactor: move from io/ioutil to io and os packages (#<!-- -->978)
79c0dc9 Remove commented out sections in CI configs (#<!-- -->960)
c875e7e Bump google<span/>.golang<span/>.org<span/>/api and github<span/>.com<span/>/go-openapi<span/>/strfmt<span/>. (#<!-- -->975)
bd469e7 Fixed modtime for reproducible goreleaser (#<!-- -->971)
70138fb Ship multi-arch images for all the cosign components. (#<!-- -->973)
fbe6fab Add support for using k8schain under a flag. (#<!-- -->972)
51803c2 Fix `cosign attach sbom` with `COSIGN_REPOSITORY`. (#<!-- -->970)
6f3aec5 Included trimpath in goreleaser (#<!-- -->968)
bfeb7d4 Add issuer URL to the verification blob. (#<!-- -->967)
c45f841 Have `download sbom` use the `Attachment` API. (#<!-- -->965)
068a277 Return better errors from `cosigned` (#<!-- -->964)
7957228 Make the DSSE wrapped private. (#<!-- -->966)
0bf537f release: fix registry name, push to gcr and not to ghcr (#<!-- -->958)
9314b85 Add a "filesystem" OIDC provider. (#<!-- -->956)
2f6560f Use setup-ko. (#<!-- -->957)
46e2740 Allow disabling `verifySCT`. (#<!-- -->955)
19fce84 Improve GitHub OIDC example (#<!-- -->954)
7c48e9a feat: extract pub key from GitLab (#<!-- -->941)
91bb398 fix codeql workflow permission (#<!-- -->951)
1f67ea7 cmd/policy: ability to pass expire days (#<!-- -->938)
7e295f1 Scorecard improvements (#<!-- -->949)
be6ab36 Reproducible builds with trimpath (#<!-- -->944)
b753a22 fix: Fixed multiple public keys issue (#<!-- -->942)
9f80297 Verify a signature using secrets from a gitlab project (#<!-- -->934)
9e304d1 Return k8schain error. (#<!-- -->937)
23ccfd8 fix: add dollars (#<!-- -->933)
0915b41 Document Red Hat Quay support (#<!-- -->929)
b2351d3 Add keyless signing w/ storage in rekor to FUN<span/>.md (#<!-- -->924)
9e406b3 fix issue 919 (#<!-- -->930)
617bc78 docs: fix broken link (#<!-- -->926)
fc58838 Bump go-github, go-gitlab, and cloudstorage. (#<!-- -->922)
f482fff Hook up k8schain to verification. (#<!-- -->920)
dcfb11d Don't ignore the media type flag to upload-blob! (#<!-- -->910)
0bab648 Add the OIDC options to `AttestOptions`. (#<!-- -->918)
f34112c Bump in-toto and cloud storage. (#<!-- -->909)
2594f7a Fix two bugs in the pivkey code related to cleanup and certs. (#<!-- -->912)
699fab4 Add Attachment to empty. (#<!-- -->911)
c9bf33a add `Attachment` to SignedEntity (#<!-- -->857)
7991c87 Bump dependencies and tidy. (#<!-- -->902)
7dd85a7 Fix the KO_VERSION variable in the post-merge container build. (#<!-- -->905)
19300db Replace predicate file path with io.Reader (#<!-- -->904)
42e5df0 Sign without pulling from the registry (#<!-- -->903)
7d2d51d update root ux (#<!-- -->747)
e2f034e feat: store public key within GitHub/GitLab variable (#<!-- -->900)
a1180fa Pin crane dependency used in e2e tests (#<!-- -->896)
c041930 verify: add support for rsapkcs15 keys (#<!-- -->851)
a9aa82b Fix verify-blob error message (#<!-- -->676) (#<!-- -->895)
5e54075 Fix verify command line options (#<!-- -->894)
aa1028f Fix CI (#<!-- -->897)
8e3be12 Add a test/example for signing using GitHub OIDC (#<!-- -->901)
0605155 fix: use GITLAB_HOST env var name (#<!-- -->899)
8588a92 fix: show reasons of the rego validations (#<!-- -->885)
4c5112c fix: safer way to install google/ko (#<!-- -->889)
37bcea0 Error with the filename provided (#<!-- -->891)
5499d63 chore: KO_VERSION as environment var (#<!-- -->886)
42ec945 Clarify how to install sget (#<!-- -->882)
a064fab Re-expose commands. (#<!-- -->883)
f85fe3f chore: add image details to the error msg (#<!-- -->875)
5302c87 add github&gitlab reference support to generate-key-pair (#<!-- -->848)
8a67024 fix: make isTerminal suitable for windows (#<!-- -->871)
a04f060 disable usage on errors (#<!-- -->878)
1bd3067 added keyvault doc (#<!-- -->870)
cc4ce1b Remove the preallocation of signatures slice. (#<!-- -->869)
2ba1605 Allow `cosigned` to validate `Fulcio` signatures. (#<!-- -->867)
b0408bf feat: add validation for predicates via cue or rego policy files support (#<!-- -->641)
278ad7d make `COSIGN_REPOSITORY` use explicit again (#<!-- -->860)
142e7ed fix `x509: unsupported public key type: *crypto.PublicKey` (#<!-- -->864)
c79fa81 `TagOptions` -> `ReferenceOptions` (#<!-- -->863)
5c1240b feat: add custom signature tag registry options (#<!-- -->808)
2f6a293 release: update golang-cross image to image tag v1.17.2 (#<!-- -->861)
d49fa54 [root policy] Add root policy signing (#<!-- -->856)
0142711 get rid of "." in default tag suffixes (#<!-- -->853)
2919bf0 `oic.` -> `oci.` (#<!-- -->852)
9962e87 Add changelog for v1.3.0 (#<!-- -->849)
37000c8 update select dependencies (#<!-- -->850)
e6d08d6 support user customizable predicates (#<!-- -->847)
75c326b move `make help` below the default rules so that naked `make` does the right thing (#<!-- -->845)
6c5c65f Only run CI on PRs and push to main or releases (#<!-- -->842)
061393d Generate docs for new CLI surfaces (#<!-- -->843)
371845b Generate Markdown docs for cosign (#<!-- -->839)
4cc0fbd Fix attest bug with rekor URL (#<!-- -->840)
7aaad1f feat: auto-completion support (#<!-- -->836)
8e3dc18 fix and fix examples where we are using the single dash style flags. (#<!-- -->835)
7b9e92a Allow both lower and upper cases in transparency commit confirmation (#<!-- -->831)
e1f3e36 fix (#<!-- -->832)
a44fefa Migrate all verify commands to cobra … (#<!-- -->830)
e50b61f Migrate the attach command tree to cobra (#<!-- -->829)
76b921a migrate download tree to cobra (#<!-- -->828)
a568dad Add a policy-init using TUF metadata and Fulcio signers (#<!-- -->469)
5e2ee28 Migrate piv-tool tree to cobra (#<!-- -->827)
849057c Migrate upload tree to cobra (#<!-- -->826)
f1d816c Migrate triangulate and initalize to cobra (#<!-- -->823)
27d68e0 Switch DSSE provider to go-securesystemslib (#<!-- -->812)
3df9404 Make --cert-email actually do something (#<!-- -->821)
c632c91 correct docs for `go install` (#<!-- -->819)
4ebd94c add e2e test status badge (#<!-- -->818)
d671345 fix codeql-action (#<!-- -->814)
ecc92b0 Fix e2e postsubmit (#<!-- -->817)
838f8c7 add blurp / pointer to cosigned (#<!-- -->816)
7ce09c8 Fix issue #<!-- -->802, validate cronjobs (#<!-- -->809)
cae4d7b Fix the postsubmit failure introduced by #<!-- -->795 (#<!-- -->813)
874644e Migrate copy and clean to cobra. Add RegistryOptions to match the style of other flags. Move init. Move triangulate (#<!-- -->806)
a42b124 Integrate `k8schain` to authenticate digest resolution. (#<!-- -->804)
ff31e13 Don't block things being deleted. (#<!-- -->803)
549e301 Add digest resolution to `cosigned`. (#<!-- -->800)
f9fa769 Reject tags in `cosigned`. (#<!-- -->799)
52faaca Eliminate `cremote.UploadFile`. (#<!-- -->797)
d77d120 Have `GetAttachedImageRef` take `name.Reference`. (#<!-- -->798)
9d4070e Define `oci.File`. (#<!-- -->796)
59a6200 Change `UploadFiles` to return a `name.Digest`. (#<!-- -->795)
07f1d31 Actually use `types.MediaType`, drop useless cast. (#<!-- -->794)
a57a2b2 Use `ref.Context().Digest()` to make digest. (#<!-- -->793)
49a4cdf Remote err nil check before return (#<!-- -->792)
241c2d1 Migrate to `AddFlags` pattern. (#<!-- -->791)
c7528fb Migrate generate to cobra. (#<!-- -->788) (#<!-- -->789)
20209b4 Use `cmd.Context()` everywhere. (#<!-- -->790)
aefe69c Migrate generate to cobra. (#<!-- -->788)
849a87a Migrating attest to cobra, moving public-key impl to folder (#<!-- -->781)
b114e73 Drop a stale TODO. (#<!-- -->787)
26dea0f Remove `copasetic`. (#<!-- -->785)
c278ff3 Hoist the `name.ParseReference` to avoid passing strings. (#<!-- -->783)
b22a7b1 Rework `cosign.Verify` to specify what's verified. (#<!-- -->782)
182936d Try out `Attestations()`. (#<!-- -->779)
c9bd912 Create a `NewAttestation` constructor. (#<!-- -->778)
220861e Migrate generate-key-pair to cobra (#<!-- -->780)
6bb70a8 Refactor the signature loop to reduce boilerplate. (#<!-- -->777)
f7c3a20 Ensure we resolve tags once. (#<!-- -->776)
8ef5810 fix panic on creating annotation maps. (#<!-- -->775)
05dda07 Switch `attach` to new library. (#<!-- -->774)
7ad192b Switch `attest` to use `remote.WriteSignatures`. (#<!-- -->773)
e4147f4 Rename `RemoteOpts` to `RegistryClientOpts` for consistency. (#<!-- -->772)
ef9683a Migrate cosign public-key to cobra. (#<!-- -->771)
1aeef2c Move `internal/oci` to `pkg/oci` (#<!-- -->770)
4d792c6 Drop `Attestations` from `SignedEntity`. (#<!-- -->769)
ece4f52 Add a readonly variant of `mutate.Map`. (#<!-- -->768)
8a92755 Migrate cosign sign-blob to cobra. (#<!-- -->767)
54f2ef0 Migrate `SignCmd` to several new helpers. (#<!-- -->764)
9f73943 Add `ociremote.WriteSignatures`. (#<!-- -->763)
513328c Add `mutate.SignEntity` and friends. (#<!-- -->761)
efee38d Fix the CI (#<!-- -->766)
9235888 Bumo go-containerregistry and repair prior crimes against immutability. (#<!-- -->765)
4ed933a Add `sget` to the release artifacts (#<!-- -->745)
db5af1f Migrate cosign sign to cobra (#<!-- -->762)
2474b54 Migrate `image.Digest` to `ociremote.ResolveDigest`. (#<!-- -->760)
f2946fe Share more of the tlog upload logic. (#<!-- -->759)
a231bf9 Add a `DupeDetector` interface, implement using `signature.Verifier`. (#<!-- -->757)
cfa29ac Drop this bit of dead code. (#<!-- -->758)
23cead2 Add sget to the goreleaser release pipeline (#<!-- -->752)
6b7c9b2 Use `oci.SignedEntity` with the `SBOM` suffix. (#<!-- -->756)
b6b0a2f Do a pass cleaning up `regOpts.GetRegistryClientOpts` (#<!-- -->755)
09a2302 Move the `empty.Signatures()` on 404 semantic into the lib. (#<!-- -->754)
37c3193 Bump opa to v0.32.1. (#<!-- -->753)
2e8c404 Add `mutate.AppendSignatures` to further simplify `UploadSignature`. (#<!-- -->751)
1e1b678 Drop unused method. (#<!-- -->750)
cad2e01 Make `UploadSignature` take an `oci.Signature`. (#<!-- -->749)
b90c965 Start building `internal/oci/static.New{Signature,File}` (#<!-- -->748)
36fbadc Add `Annotations` to `oci.Signature`. (#<!-- -->741)
d2044ca Check for nil before dereferencing InclusionProof (#<!-- -->746)
8bc60a4 Bump googleapis to 0.57.0. (#<!-- -->742)
be8a0f8 Drop unused return value. (#<!-- -->740)
87f2162 Remove `SigSuffixOverride` fold into `ociremote.Option`. (#<!-- -->739)
f815e25 Switch `CheckOpts` to take `ociremote.Option`s. (#<!-- -->738)
e7395a7 Eliminate `AttachedImageTag` in favor of `ociremote` variants. (#<!-- -->737)
ba649cc Eliminate `BundleVerified` from `CheckOpts` in favor of new return value. (#<!-- -->736)
32433e1 Switch most things to use `oci.Signature` directly. (#<!-- -->735)
2595f4d Eliminate methods on `SignedPayload`. (#<!-- -->733)
5fb178c phase 1, migrate the outer shell of cosign to cobra (#<!-- -->728)
19af18e Drop VerifyOpts from CheckOpts (#<!-- -->732)
01464b3 Drop option that only passes default behavior. (#<!-- -->731)
8790771 Start to build up a `mutate` package. (#<!-- -->729)

## Docker images

- `docker pull gcr<span/>.io<span/>/projectsigstore<span/>/cosign:1<span/>.3<span/>.0`
- `docker pull gcr<span/>.io<span/>/projectsigstore<span/>/cosigned:1<span/>.3<span/>.0`
- `docker pull gcr<span/>.io<span/>/projectsigstore<span/>/sget:1<span/>.3<span/>.0`

Thanks for all contributors!

