### PR TITLE
minikube 1.24.0

### DIFF
--- a/Food/minikube.lua
+++ b/Food/minikube.lua
@@ -1,7 +1,7 @@
 local name = "minikube"
 local org = "kubernetes"
-local release = "v1.23.2"
-local version = "1.23.2"
+local release = "v1.24.0"
+local version = "1.24.0"
 food = {
     name = name,
     description = "Run Kubernetes locally",
@@ -13,7 +13,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64.tar.gz",
-            sha256 = "c229ca33d2185e65c0e5f607a5846e11c64d4f1998158557cac8c19d402ce0b1",
+            sha256 = "a84313247f4ce4fbe3ee11fd862050ca4f72bd16282ce735a4adcbf643310565",
             resources = {
                 {
                     path = "out/" .. name .. "-darwin-amd64",
@@ -26,7 +26,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64.tar.gz",
-            sha256 = "141cde39fc31650fddb64cef8295a2625fa8447a8a653139d12cfcf9baef3558",
+            sha256 = "159768c164087203e2b71f6ca3dd3be5b7e7a40f73787f794bc9027e35850066",
             resources = {
                 {
                     path = "out/" .. name .. "-linux-amd64",
@@ -39,7 +39,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/kubernetes/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.tar.gz",
-            sha256 = "4460e713cb36e271b6a25e70820c57160edc7fde36da73daf3f2a776df778c99",
+            sha256 = "36d21aaaddafc8297d5fc0a8188eee74d54c2da528e3e73f1e00f395a708d700",
             resources = {
                 {
                     path = "out\\" .. name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package minikube to release v1.24.0. 

# Release info 

 📣😀 **Please fill out our https:<span/>/<span/>/forms<span/>.gle<span/>/Gg3hG5ZySw8c1C24A** so that we can learn how & why you use minikube, and what improvements we should make. Thank you! 💃🎉

## Release Notes

## Version 1.24.0 - 2021-11-04

Features:
* Add --no-kubernetes flag  to start minikube without kubernetes https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/pull<span/>/12848
* `minikube addons list` shows addons if cluster does not exist https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/pull<span/>/12837

Bug fixes:
* virtualbox: change default `host-only-cidr` https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/pull<span/>/12811
* fix zsh completion https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/pull<span/>/12841
* Fix starting on Windows with VMware driver on non `C:` drive https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/pull<span/>/12819

For a more detailed changelog, including changes occuring in pre-release versions, see https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/minikube<span/>/blob<span/>/master<span/>/CHANGELOG<span/>.md<span/>.

Thank you to our contributors for this release!

- Akira Yoshiyama
- Keyhoh
- Medya Ghazizadeh
- Nicolas Busseneau
- Sharif Elgamal
- Steven Powell
- Toshiaki Inukai

Thank you to our PR reviewers for this release!

- spowelljr (11 comments)
- sharifelgamal (10 comments)
- afbjorklund (6 comments)
- atoato88 (5 comments)
- medyagh (3 comments)
- yosshy (1 comments)

Thank you to our triage members for this release!

- sharifelgamal (13 comments)
- afbjorklund (9 comments)
- spowelljr (6 comments)
- medyagh (3 comments)
- Sarathgiggso (2 comments)

## Installation

See https:<span/>/<span/>/minikube<span/>.sigs<span/>.k8s<span/>.io<span/>/docs<span/>/start<span/>/

## ISO Checksum

`b4d2ab559f40c031fbebe6d967a625980c22aa6e65e3a12916b25f2105f23f56`