### PR TITLE
cosign 1.3.1

### DIFF
--- a/Food/cosign.lua
+++ b/Food/cosign.lua
@@ -1,5 +1,5 @@
 local name = "cosign"
-local version = "1.3.0"
+local version = "1.3.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "885974dd064ceb6a6b2c1d3b0db1999376d0887b2dae8ccb3ae2d104312fd3da",
+            sha256 = "c62684f0e4fa66ff15e9cca4f0b3cd6009bd322773f2e83b3aa68d704a989554",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",
@@ -24,7 +24,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-linux-amd64",
-            sha256 = "9604a5eb171748113f92a67495556007dde6f45804f0b38d3e55c3bc7e151774",
+            sha256 = "1227b270e5d7d21d09469253cce17b72a14f6b7c9036dfc09698c853b31e8fc8",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -37,7 +37,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-arm64",
-            sha256 = "5c204f0a8543d695e4037d090d3dc1f97c26ffae67b8740c4b4098ad2cca4abd",
+            sha256 = "eda58f090d8f4f1db5a0e3a0d2d8845626181fe8aa1cea1791e0afa87fee7b5c",
             resources = {
                 {
                     path = name .. "-darwin-arm64",
@@ -50,7 +50,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/sigstore/" .. name .. "/releases/download/v" .. version .. "/" .. name .. "-darwin-amd64",
-            sha256 = "bf8423700e8bbf01f03769f7b4bd078a4c8527ce98c28cd4c9bf2f83144e9485",
+            sha256 = "bcffa19e80f3e94d70e1fb1b0f591b0dec08926b31d3609fe3d25a1cc0389a0a",
             resources = {
                 {
                     path = name .. "-darwin-amd64",


### PR DESCRIPTION
Updating package cosign to release v1.3.1. 

# Release info 

 ## Breaking Changes

* [cosign/pkg]: `cosign.Verify` has been removed in favor of explicit `cosign.VerifyImageSignatures` and `cosign.VerifyImageAttestations`
 (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/1026)

## Enhancements

* Add ability for verify-blob to find signing cert in transparency log (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/991)
* root policy: add optional issuer to maintainer keys (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/999)
* PKCS11 signing support (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/985)
* Included timeout option for uploading to Rekor (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/1001)

## Bug Fixes

* Bump sigstore/sigstore to pickup a fix for azure kms (https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/1011 / https:<span/>/<span/>/github<span/>.com<span/>/sigstore<span/>/cosign<span/>/pull<span/>/1028)

## Contributors

* Asra Ali (@<!-- -->asraa)
* Batuhan Apaydın (@<!-- -->developer-guy)
* Carlos Panato (@<!-- -->cpanato)
* Dan Lorenc (@<!-- -->dlorenc)
* Dennis Leon (@<!-- -->DennisDenuto)
* Erkan Zileli (@<!-- -->erkanzileli)
* Furkan Türkal (@<!-- -->Dentrax)
* garantir-km (@<!-- -->garantir-km)
* Jake Sanders (@<!-- -->dekkagaijin)
* Naveen (@<!-- -->naveensrinivasan)

## Changelog

645ebf0 add change to 1.3.1 changelog (#<!-- -->1036)
5a33731 remove `Verify` in favor of explicit `VerifyImage{Signatures, Attestations}` (#<!-- -->1026)
5d866c3 fix help msg upload=>no-upload (#<!-- -->1033)
076e179 add changelog for v1.3.1 (#<!-- -->1032)
c2c3a1d fix variable (#<!-- -->1031)
ff2104c ci: update oidc ci tests (#<!-- -->1029)
ce7cf28 update sigstore/sigstore to v1.0.1 (#<!-- -->1028)
0c771f8 Bump the thales pkcs11 library to v1.2.5 (#<!-- -->1009)
cb41bd4 make the purpose of secrets checked into `.github/workflows` explicit (#<!-- -->1025)
5a350e4 fix(doc): add an example for existing option on verify-blob command (#<!-- -->1024)
c0744b3 Add the missing GIT_HASH env var in the post-submit github-oidc<span/>.yaml action. (#<!-- -->1022)
88313ee Remove fuzzing check - unsupported go-fuzz (#<!-- -->1020)
d442592 Included timeout option for uploading to Rekor (#<!-- -->1001)
d3440b5 remove not needed dockerfiles (#<!-- -->1017)
82c9cee refactor release process to use ko to build the images (#<!-- -->1008)
55471fc Add an initial comparison document between nv2 and cosign. (#<!-- -->1014)
bb05c81 Bump sigstore/sigstore to pickup a fix for azure kms. (#<!-- -->1011)
db34c33 refactor version and add version command to sget (#<!-- -->1010)
391bac3 Bump k8s<span/>.io<span/>/apimachinery and opa. (#<!-- -->1004)
7066f12 PKCS11 signing support (#<!-- -->985)
9b9cd94 add optional issuer to root policy (#<!-- -->999)
5deaca0 Add ability for verify-blob to find signing cert in transparency log (#<!-- -->991)
6573dcd update automation to use 1.3.0 release (#<!-- -->997)
c6c032e update deps, `go mod tidy` (#<!-- -->994)

### Thanks for all contributors!

