### PR TITLE
Helm (linux/darwin) arm64

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -48,6 +48,19 @@ food = {
             }
         },
         {
+            os = "linux",
+            arch = "arm64",
+            url = "https://get.helm.sh/helm-v" .. version .. "-linux-arm64.tar.gz",
+            sha256 = "57875be56f981d11957205986a57c07432e54d0b282624d68b1aeac16be70704",
+            resources = {
+                {
+                    path = "linux-arm64/" .. name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",

--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -22,6 +22,19 @@ food = {
             }
         },
         {
+            os = "darwin",
+            arch = "arm64",
+            url = "https://get.helm.sh/helm-v" .. version .. "-darwin-arm64.tar.gz",
+            sha256 = "733fa6731b396514071b4dbc66614bd3be8e1f079f86594ab449649441bf18f1",
+            resources = {
+                {
+                    path = "darwin-arm64/" .. name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",


### PR DESCRIPTION
Add references to the arm64 binaries available for Helm, for both darwin and linux