### PR TITLE
k3d 5.2.1

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "5.0.3"
+local version = "5.2.1"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "21c3587166b6f9c62b461eb4d0e6cad2f1080328189154d75d848bf0c58e4ff1",
+            sha256 = "fb7f0ed1b507b14cb8ff6c9a186d5534aa2dd9083b342cae9dbce7a2eb7c3248",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "018421fdff567df5df3840e75501a40199501ce6bf25e1f2dd259f74e13519f3",
+            sha256 = "70141637bbe7531d17cf313688520287572e78711361e7162237648a59a6e91d",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "45309efdd6674499129057dee1f75594b7baa07abc2750239b6017da7330b5da",
+            sha256 = "eb52ce7fefd519793129d2c45e4a134c1cf8c3f5ad69aa447a679f352fd05104",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "8b7efc0d1727b0ed493b7a860afa5bc5f35b8d3aec68fc41cf7590e10cb9fb7e",
+            sha256 = "366d5383045d8de2404c29378733e283262673e89bfca16fa0b3349ae49249e2",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "ebf696c1b3047ecfc041087abceddcf2f120769269defc919779cec2e6ca786b",
+            sha256 = "85a13d34afd59ff815da80e3b111833cd51ce0dab0a38042018cb85fd10bf7b7",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "9081316aade8288a810b6e730db1f9688cc08d6ba5b4bb1e73e70803587ba950",
+            sha256 = "6053d0142b4423d6344ee3d11bec63eba740468d6d6a9f77f5694c918fcbc4d9",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v5.2.1. 

# Release info 

 ## v5.2.1

### Features & Enhancements

- improved Podman compatibility (#<!-- -->868, @<!-- -->serverwentdown)
  - last missing piece: release of <https:<span/>/<span/>/github<span/>.com<span/>/containers<span/>/podman<span/>/pull<span/>/12328>
- improved error handling and logs when waiting for container logs (ca47fac)

### Fixes

- fix: only replace default api host with docker host (#<!-- -->879)
- fix: use available hardcoded K3s version in version<span/>.go (0bbb5b9)

## New Contributors
* @<!-- -->serverwentdown made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/rancher<span/>/k3d<span/>/pull<span/>/868

**Full Changelog**: https:<span/>/<span/>/github<span/>.com<span/>/rancher<span/>/k3d<span/>/compare<span/>/v5<span/>.2<span/>.0<span/>.<span/>.<span/>.v5<span/>.2<span/>.1