### PR TITLE
cloud_sql_proxy 1.27.1

### DIFF
--- a/Food/cloud_sql_proxy.lua
+++ b/Food/cloud_sql_proxy.lua
@@ -1,5 +1,5 @@
 local name = "cloud_sql_proxy"
-local version = "1.27.0"
+local version = "1.27.1"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. ".darwin.amd64",
-            sha256 = "66ccf2c4fea647334fd0bafa5a3ea25bcf4523a9f0b3f8ec2798748b7651584e",
+            sha256 = "fb40a8ce9cfbd814ba130ceeec0e03679d3b1f12764a09d64787f061089771fe",
             resources = {
                 {
                     path = name .. ".darwin.amd64",
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. ".linux.amd64",
-            sha256 = "80934dfd7fd4097e2782be51d21c6e7d3d99327fb4e2fee3a151f4990809f63f",
+            sha256 = "111f0a6ff68e3856e59cf7700d190273862a64d71a07b84510a0b4fd75b91d8e",
             resources = {
                 {
                     path = name .. ".linux.amd64",
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://storage.googleapis.com/cloudsql-proxy/v" .. version .. "/" .. name .. "_x86.exe",
-            sha256 = "638947455fd0f0afefafb3e22acc27ffcbe1b42ba2dfe4b4f2ecba74a408ef2c",
+            sha256 = "0a8dd85a4ef128768f6fff42bb7b86d6a59376830f3a8b3d436bf3f28b707f54",
             resources = {
                 {
                     path = name .. "_x86.exe",


### PR DESCRIPTION
Updating package cloud_sql_proxy to release v1.27.1. 

# Release info 

 

### Bug Fixes

* update dependencies to latest versions (https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/issues<span/>/1034)) ([8954d24](https:<span/>/<span/>/www<span/>.github<span/>.com<span/>/GoogleCloudPlatform<span/>/cloudsql-proxy<span/>/commit<span/>/8954d241a71b59d9bf82cb47469e6652d3f379e7)

| filename | sha256 hash |
|----------|-------------|
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.darwin<span/>.amd64 | fb40a8ce9cfbd814ba130ceeec0e03679d3b1f12764a09d64787f061089771fe |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.darwin<span/>.arm64 | 9c8a701a8a25391181802237af36d129b08d3003b0848721b0e2178e8e3e7419 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.linux<span/>.386 | 1cfe578ae38469f0222ebe74b58319374f728e218e2500e1584590441243cf99 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.linux<span/>.amd64 | 111f0a6ff68e3856e59cf7700d190273862a64d71a07b84510a0b4fd75b91d8e |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.linux<span/>.arm | bfd436b0e399d33c6b6cecbd79020487643a74898fe4820635b559cf24cd8a3b |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy<span/>.linux<span/>.arm64 | bffd60642668ba0df0543b290e5417dcd1655c0371819b2273990435ace01965 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy_x64<span/>.exe | cd78cf381ae98a50d2211df3b8d28975f355ec7e0eda8d8909dbdac1a2f11428 |
| https:<span/>/<span/>/storage<span/>.googleapis<span/>.com<span/>/cloudsql-proxy<span/>/v1<span/>.27<span/>.1<span/>/cloud_sql_proxy_x86<span/>.exe | 0a8dd85a4ef128768f6fff42bb7b86d6a59376830f3a8b3d436bf3f28b707f54 |
