### PR TITLE
kubectl 1.23.0

### DIFF
--- a/Food/kubectl.lua
+++ b/Food/kubectl.lua
@@ -1,5 +1,5 @@
 local name = "kubectl"
-local version = "1.22.3"
+local version = "1.23.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-darwin-amd64.tar.gz",
-            sha256 = "fb531f7d9e7a0ebdf31819f96fd749b872e8f7f52eec49981491831fe1231822",
+            sha256 = "bbbde015a418c80c7ad3dfa4ddea2f1b1251cff05cb6948d0779da22f7fcd062",
             resources = {
                 {
                     path = "kubernetes/client/bin/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-linux-amd64.tar.gz",
-            sha256 = "36a24dcdc7a8eef1db37798b5c0c6425430fa4bc978f2dcb24418b06bc88c596",
+            sha256 = "457d68f7efbdc9ff4d69e035b98df0d5d81cfa10e5db0c5580e8dfc14a79c18a",
             resources = {
                 {
                     path = "kubernetes/client/bin/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://dl.k8s.io/v" .. version .. "/kubernetes-client-windows-amd64.tar.gz",
-            sha256 = "872067b8fe226221d750c5cb6bd0c704c5c2168769f6a5b8f19a4719c4694bf2",
+            sha256 = "b8ea0d8c5a8c0f3c4f0d9bfd83f2f71165bf40b9087253c688eac1a1eaa1fba2",
             resources = {
                 {
                     path = "kubernetes\\client\\bin\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package kubectl to release v1.23.0. 

# Release info 

 
See https:<span/>/<span/>/groups<span/>.google<span/>.com<span/>/forum<span/>/#!forum/kubernetes-announce). Additional binary downloads are linked in the [CHANGELOG](https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/kubernetes<span/>/blob<span/>/master<span/>/CHANGELOG<span/>/CHANGELOG-1<span/>.23<span/>.md<span/>.

See https:<span/>/<span/>/github<span/>.com<span/>/kubernetes<span/>/kubernetes<span/>/blob<span/>/master<span/>/CHANGELOG<span/>/CHANGELOG-1<span/>.23<span/>.md for more details.

### Release Assets


<table>
<tr><td colspan="2"><b>Kubernetes Source Code: </b> kubernetes<span/>.tar<span/>.gz</td><tr>
<tr><td>SHA256</td><td>8f70cd3d7aa12fd09d9d715feb3803814c82a0ecc905d4efa81da4a5a4b9907e</td></tr>
<tr><td>SHA512</td><td>850f92f4a4f397773ceabdacdb0513fa3cd2eb8867f7e3697f42bc595c3c710f81a8b9b34679d783ca2e1900dd272e0af209126cf55719e321af8da04a4b1c2b</td></tr>
</table>


