### PR TITLE
clusterctl 1.0.2

### DIFF
--- a/Food/clusterctl.lua
+++ b/Food/clusterctl.lua
@@ -1,5 +1,5 @@
 local name = "clusterctl"
-local version = "1.0.1"
+local version = "1.0.2"
 local release = "v" .. version
 local org = "kubernetes-sigs"
 local repo = "cluster-api"
@@ -16,7 +16,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
             -- shasum of the release archive
-            sha256 = "bd98f89d0cdf21005eaf406f179d9a89d70d6a4617f73f7169414049f9b4b398",
+            sha256 = "a50dba25373a0137cf1835320baec34b70cccae8f3b294e3d0d6096bfdf8f299",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -30,7 +30,7 @@ food = {
             arch = "amd64",
             url = url .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
             -- shasum of the release archive
-            sha256 = "6c6d695e4893f9b0cc2252d9d3b7d3b966fb78ebbd99ac5e10455b6286d2f534",
+            sha256 = "f9262671d02733b1c627886dda04ee5faf28d73afe540acd3f41692f7755b6c2",
             resources = {
                 {
                     path = name .. "-linux-amd64",


### PR DESCRIPTION
Updating package clusterctl to release v1.0.2. 

# Release info 

 Changes since v1.0.1
---
## :bug: Bug Fixes
- Fix adding appended list directly causing changing previous value (#<!-- -->5765)
- Clusterctl init should report the correct namespace when detecting a provider is already installed (#<!-- -->5743)
- Backport clusterctl discovery fix to branch release-1.0 (#<!-- -->5718)
- Ensure etc client generators never return nil without an error (#<!-- -->5720)
- Add proper rbac rule in KCP controller for CRD (#<!-- -->5687)

## :seedling: Others
- Run GitHub workflows on all pull requests (#<!-- -->5745)

_Thanks to all our contributors!_ 😊
