### PR TITLE
k3d 5.2.1

### DIFF
--- a/Food/k3d.lua
+++ b/Food/k3d.lua
@@ -1,5 +1,5 @@
 local name = "k3d"
-local version = "5.2.0"
+local version = "5.2.1"
 local release = "v" .. version
 
 food = {
@@ -14,7 +14,7 @@ food = {
             arch = "amd64",
             
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-darwin-amd64",
-            sha256 = "65309369d0b93bb6212e616f2b113a84a5c882a92fbb6887765eafeba2deb42b",
+            sha256 = "fb7f0ed1b507b14cb8ff6c9a186d5534aa2dd9083b342cae9dbce7a2eb7c3248",
             resources = {
                 {
                     path = name .. "-darwin-amd64",
@@ -27,7 +27,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-amd64",
-            sha256 = "223bcbf2a6c407e72910727d47dcaae5d4ed1c90d356d9bee968b385d645e806",
+            sha256 = "70141637bbe7531d17cf313688520287572e78711361e7162237648a59a6e91d",
             resources = {
                 {
                     path = name .. "-linux-amd64",
@@ -40,7 +40,7 @@ food = {
             os = "linux",
             arch = "386",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-386",
-            sha256 = "613be1192ade4f8014074950c6e7840882556222f9ea40366807ccdba91f2f0a",
+            sha256 = "eb52ce7fefd519793129d2c45e4a134c1cf8c3f5ad69aa447a679f352fd05104",
             resources = {
                 {
                     path = name .. "-linux-386",
@@ -53,7 +53,7 @@ food = {
             os = "linux",
             arch = "arm",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm",
-            sha256 = "ecca7b0d6f1d47a2e93da854367f2b993b8cd8642f90eb535057853f580451b6",
+            sha256 = "366d5383045d8de2404c29378733e283262673e89bfca16fa0b3349ae49249e2",
             resources = {
                 {
                     path = name .. "-linux-arm",
@@ -66,7 +66,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-linux-arm64",
-            sha256 = "a3f7231734e1657e1248a40fd7851504390343bb15a8d503b681d734b298f1da",
+            sha256 = "85a13d34afd59ff815da80e3b111833cd51ce0dab0a38042018cb85fd10bf7b7",
             resources = {
                 {
                     path = name .. "-linux-arm64",
@@ -79,7 +79,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/rancher/" .. name .. "/releases/download/" .. release .. "/" .. name .. "-windows-amd64.exe",
-            sha256 = "2885580967d951e0fdae1142d5e07db11e9d0793b37f782f6f6dcdafe43aaa6d",
+            sha256 = "6053d0142b4423d6344ee3d11bec63eba740468d6d6a9f77f5694c918fcbc4d9",
             resources = {
                 {
                     path = name .. "-windows-amd64.exe",


### PR DESCRIPTION
Updating package k3d to release v5.2.1. 

# Release info 

 ## v5.2.1

### Features & Enhancements

- improved Podman compatibility (#<!-- -->868, @<!-- -->serverwentdown)
  - last missing piece: release of <https:<span/>/<span/>/github<span/>.com<span/>/containers<span/>/podman<span/>/pull<span/>/12328>
- improved error handling and logs when waiting for container logs (ca47fac)

### Fixes

- fix: only replace default api host with docker host (#<!-- -->879)
- fix: use available hardcoded K3s version in version<span/>.go (0bbb5b9)

## New Contributors
* @<!-- -->serverwentdown made their first contribution in https:<span/>/<span/>/github<span/>.com<span/>/rancher<span/>/k3d<span/>/pull<span/>/868

**Full Changelog**: https:<span/>/<span/>/github<span/>.com<span/>/rancher<span/>/k3d<span/>/compare<span/>/v5<span/>.2<span/>.0<span/>.<span/>.<span/>.v5<span/>.2<span/>.1