### PR TITLE
hugo 0.90.0

### DIFF
--- a/Food/hugo.lua
+++ b/Food/hugo.lua
@@ -1,5 +1,5 @@
 local name = "hugo"
-local version = "0.89.4"
+local version = "0.90.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-64bit.tar.gz",
-            sha256 = "ed9025b6c606242446c6724e92d177275d48c0a6212793c7f316e84fa5a889ba",
+            sha256 = "41d1b257e1cf378b6bd1c2f4540cac3baa6bba74117c0a5c896fc3d55c9aa3aa",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_macOS-ARM64.tar.gz",
-            sha256 = "b36c5b368b4ef5ceda120b61c7e1767dbc7ae874dc497153f6e17df143fa1915",
+            sha256 = "4556b2a3442bb2f1450b65fde9bd7acb6722fdb230bb0ae758e0d02d753c66a6",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Linux-64bit.tar.gz",
-            sha256 = "88bcff016b16974909615bafc6e89a95f44999576034893e32ef1f1a2124af46",
+            sha256 = "3720af3612622fcc2ade160845d0b10fa731c6db08caa404d1ef05930b65777c",
             resources = {
                 {
                     path = name,
@@ -51,7 +51,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://github.com/gohugoio/" .. name .. "/releases/download/v" .. version .. "/" .. "hugo_" .. version .. "_Windows-64bit.zip",
-            sha256 = "aed50fc354f1d30ddf845812ca34136e4c168edc03be5e9a7d6ec98d79680d31",
+            sha256 = "c2d6053054e20fb551e4602ad8ac1596e907cd1b6c9614986705aa6c5fe3ea7e",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package hugo to release v0.90.0. 

# Release info 

 **Hugo 0.90** finally brings remote support to `resources.Get`, XML support (in `/data` and `transform.Unmarshal`), and a new `images.Text` filter. A special shoutout and thanks to https:<span/>/<span/>/github<span/>.com<span/>/vanbroup for his work on these features.

The support for remote `Resources` in `resources.Get` has been a feature in great demand. This means that you can fetch remote files (images, JSON files, RSS feeds ...) and use them in https:<span/>/<span/>/gohugo<span/>.io<span/>/hugo-pipes<span/>/introduction<span/>/ functions as they were local. A contrived example may look like this:

```htmlbars
{{ $font := resources.Get "https:<span/>/<span/>/github<span/>.com<span/>/google<span/>/fonts<span/>/raw<span/>/main<span/>/apache<span/>/roboto<span/>/static<span/>/Roboto-Black<span/>.ttf" }}
{{ $img := resources.Get "https:<span/>/<span/>/gohugo<span/>.io<span/>/images<span/>/gohugoio-card-1<span/>.png" }}
{{ $img = $img | images.Filter (images.Text 
                        "Rocks!" 
                        (dict 
                            "color" "#E6B405" 
                            "size" 100
                            "lineSpacing" 8 
                            "x" 400 "y" 320
                            "font" $font))
                     
}}
<img src="{{ $img.RelPermalink }}" />
```

The above fetches both a font and an image remotely and then uses the new `images.Text` filter to overlay a text on top of the image.

## Numbers

This release represents **58 contributions by 6 contributors** to the main Hugo code base<span/>.https:<span/>/<span/>/github<span/>.com<span/>/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@<!-- -->jmooring](https:<span/>/<span/>/github<span/>.com<span/>/jmooring), [@<!-- -->vanbroup](https:<span/>/<span/>/github<span/>.com<span/>/vanbroup), and [@<!-- -->dependabot[bot]](https:<span/>/<span/>/github<span/>.com<span/>/apps<span/>/dependabot for their ongoing contributions.

And thanks to https:<span/>/<span/>/github<span/>.com<span/>/digitalcraftsman for his ongoing work on keeping the themes site in pristine condition.

Many have also been busy writing and fixing the documentation in https:<span/>/<span/>/github<span/>.com<span/>/gohugoio<span/>/hugoDocs), which has received **17 contributions by 6 contributors**. A special thanks to [@<!-- -->jmooring](https:<span/>/<span/>/github<span/>.com<span/>/jmooring), [@<!-- -->bep](https:<span/>/<span/>/github<span/>.com<span/>/bep), [@<!-- -->santosh](https:<span/>/<span/>/github<span/>.com<span/>/santosh), and [@<!-- -->coliff](https:<span/>/<span/>/github<span/>.com<span/>/coliff for their work on the documentation site.

Hugo now has:

* 55686+ https:<span/>/<span/>/github<span/>.com<span/>/gohugoio<span/>/hugo<span/>/stargazers
* 431+ https:<span/>/<span/>/github<span/>.com<span/>/gohugoio<span/>/hugo<span/>/graphs<span/>/contributors
* 415+ http:<span/>/<span/>/themes<span/>.gohugo<span/>.io<span/>/

## Notes

* deps: Upgrade github<span/>.com<span/>/evanw<span/>/esbuild v0.13.12 => v0.14.2 (note) b4f27ef8 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9244 

## Changes

* Add custom font support to images.Text e71d715b https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9253 
* images: Fix cache busting of image text filter e61cdf33 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9238 
* build(deps): bump github<span/>.com<span/>/getkin<span/>/kin-openapi from 0.80.0 to 0.85.0 6c3bc5eb [@<!-- -->dependabothttps:<span/>/<span/>/github<span/>.com<span/>/apps<span/>/dependabot 
* images: Text filter that draws text with the given options (#<!-- -->9239) 283394a4 https:<span/>/<span/>/github<span/>.com<span/>/vanbroup #<!-- -->9238 
* tpl/transform: Optional options for highlight func 5538507e https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9249 
* deps: Upgrade github<span/>.com<span/>/evanw<span/>/esbuild v0.13.12 => v0.14.2 (note) b4f27ef8 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9244 
* releaser: Add "note" to Note regexp 3473e31e https:<span/>/<span/>/github<span/>.com<span/>/bep 
* build(deps): bump github<span/>.com<span/>/mitchellh<span/>/mapstructure from 1.4.2 to 1.4.3 fa0da004 [@<!-- -->dependabothttps:<span/>/<span/>/github<span/>.com<span/>/apps<span/>/dependabot 
* releaser: Rework and simplify to use GitHub only for release notes 24a893cf https:<span/>/<span/>/github<span/>.com<span/>/bep 
* build(deps): bump google<span/>.golang<span/>.org<span/>/api from 0.51.0 to 0.61.0 bf1564bd [@<!-- -->dependabothttps:<span/>/<span/>/github<span/>.com<span/>/apps<span/>/dependabot 
* media: Add rss suffix for application/rss+xml cd44d409 https:<span/>/<span/>/github<span/>.com<span/>/vanbroup #<!-- -->9233 
* parser: Add a test case in format resolution 9a326d56 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9233 
* lazy: Reset error in Reset b10381fb https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->7043 #<!-- -->9194 
* Implement XML data support 0eaaa8fe https:<span/>/<span/>/github<span/>.com<span/>/vanbroup #<!-- -->4470 
* Validate private use language tags 58adbeef https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9119 
* resources: Add timeout to the HTTP request in Get 93572e53 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Add a remote retry for resources.Get 94f149b2 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Make resources.Get use a file cache for remote resources 66753416 https:<span/>/<span/>/github<span/>.com<span/>/vanbroup #<!-- -->9228 
* Remove empty href element from pagination template 133e4bfb https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9149 
* Check for empty deployment targets and matchers f122771f https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9220 
* resources: Adjust the remote Get cache so it does not get evicted on restarts 08a863e1 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Add remote support to resources.Get 8aa7257f https:<span/>/<span/>/github<span/>.com<span/>/vanbroup #<!-- -->5255 
* Add deprecation warning to google_news template 75a823a3 https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9172 
* helpers: Make UniqueStringsReuse allocation free 5e0947c5 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Prepare repository for 0.90.0-DEV 0b70b46a https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes to /docs for release of 0.89.4 ab01ba6e https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Bump versions for release of 0.89.4 cc08c095 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes for 0.89.4 [ci skip] f97da9ec https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Fix content dir resolution when main project is a Hugo Module 2e70f61f https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9177 
* releaser: Prepare repository for 0.90.0-DEV 1ed8069a https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes to /docs for release of 0.89.3 c88cdb56 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Bump versions for release of 0.89.3 e1064d21 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes for 0.89.3 [ci skip] bf489b96 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Improve error when we cannot determine content directory in "hugo new" b8155452 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9166 
* deps: Upgrade github<span/>.com<span/>/yuin<span/>/goldmark v1.4.3 => v1.4.4 08552a7a https:<span/>/<span/>/github<span/>.com<span/>/jmooring #<!-- -->9159 
* commands: Make sure pollInterval is always set fdad91fd https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9165 
* create: Improve archetype directory discovery and tests 5f3f6089 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9146 
* create: Add a log statement when archetype is a directory 057d02de https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9157 
* create: Always print "Content ... created" 43ac59da https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9157 
* commands: Fix missing file locking in server partial render ab5c6990 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9162 
* modules: Improve error message 9369d13e https:<span/>/<span/>/github<span/>.com<span/>/davidsneighbour 
* releaser: Prepare repository for 0.90.0-DEV 805c24c3 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes to /docs for release of 0.89.2 63e3a5eb https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Bump versions for release of 0.89.2 eaa6c96a https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes for 0.89.2 [ci skip] cf3eb580 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Fix path resolution in hugo new 2b01c85d https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9129 
* deps: Upgrade github<span/>.com<span/>/yuin<span/>/goldmark v1.4.2 => v1.4.3 c09f5c5f https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9137 
* releaser: Prepare repository for 0.90.0-DEV 9232e284 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes to /docs for release of 0.89.1 b6a4ae4a https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Bump versions for release of 0.89.1 84de0c32 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Add release notes for 0.89.1 [ci skip] a0741022 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* Revert "releaser: Fat MacOS binaries" da4406ea https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9131 #<!-- -->9128 
* create: Make sure the build lock is released before we open editor 166862a0 https:<span/>/<span/>/github<span/>.com<span/>/bep #<!-- -->9121 
* readme: Update dependency list 82c33c71 https:<span/>/<span/>/github<span/>.com<span/>/deining 
* releaser: Add "note" to Note regexp 3473e31e https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Rework and simplify to use GitHub only for release notes 24a893cf https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Simplify the release process 0fa40ce5 https:<span/>/<span/>/github<span/>.com<span/>/bep 
* releaser: Remove unused code bf537f1c https:<span/>/<span/>/github<span/>.com<span/>/bep 
* docs: Regenerate docs helper e86b3311 https:<span/>/<span/>/github<span/>.com<span/>/bep 





