### PR TITLE
helm 3.7.2

### DIFF
--- a/Food/helm.lua
+++ b/Food/helm.lua
@@ -1,5 +1,5 @@
 local name = "helm"
-local version = "3.7.1"
+local version = "3.7.2"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-amd64.tar.gz",
-            sha256 = "3a9efe337c61a61b3e160da919ac7af8cded8945b75706e401f3655a89d53ef5",
+            sha256 = "5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436",
             resources = {
                 {
                     path = "darwin-amd64/" .. name,
@@ -25,7 +25,7 @@ food = {
             os = "darwin",
             arch = "arm64",
             url = "https://get.helm.sh/helm-v" .. version .. "-darwin-arm64.tar.gz",
-            sha256 = "733fa6731b396514071b4dbc66614bd3be8e1f079f86594ab449649441bf18f1",
+            sha256 = "260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec",
             resources = {
                 {
                     path = "darwin-arm64/" .. name,
@@ -38,7 +38,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-amd64.tar.gz",
-            sha256 = "6cd6cad4b97e10c33c978ff3ac97bb42b68f79766f1d2284cfd62ec04cd177f4",
+            sha256 = "4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e",
             resources = {
                 {
                     path = "linux-amd64/" .. name,
@@ -51,7 +51,7 @@ food = {
             os = "linux",
             arch = "arm64",
             url = "https://get.helm.sh/helm-v" .. version .. "-linux-arm64.tar.gz",
-            sha256 = "57875be56f981d11957205986a57c07432e54d0b282624d68b1aeac16be70704",
+            sha256 = "b0214eabbb64791f563bd222d17150ce39bf4e2f5de49f49fdb456ce9ae8162f",
             resources = {
                 {
                     path = "linux-arm64/" .. name,
@@ -64,7 +64,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://get.helm.sh/helm-v" .. version .. "-windows-amd64.tar.gz",
-            sha256 = "f50194256e756e63e59923900e6cb753d36e5381defd5765540e7afcf527c4f0",
+            sha256 = "de2257577c657f8e3cdc78fefcfec63e73010e1f618157379923ea9cbb2599c4",
             resources = {
                 {
                     path = "windows-amd64\\" .. name .. ".exe",


### PR DESCRIPTION
Updating package helm to release v3.7.2. 

# Release info 

 Helm v3.7.2 is a patch release. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in https:<span/>/<span/>/kubernetes<span/>.slack<span/>.com:
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via https:<span/>/<span/>/zoom<span/>.us<span/>/j<span/>/696660622
- Test, debug, and contribute charts: https:<span/>/<span/>/artifacthub<span/>.io<span/>/packages<span/>/search?kind=0

## Installation and Upgrading

Download Helm v3.7.2. The common platform binaries are here:

- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-darwin-amd64<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-darwin-amd64<span/>.tar<span/>.gz.sha256sum) / 5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-darwin-arm64<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-darwin-arm64<span/>.tar<span/>.gz.sha256sum) / 260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-amd64<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-amd64<span/>.tar<span/>.gz.sha256sum) / 4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-arm<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-arm<span/>.tar<span/>.gz.sha256sum) / ab73727f1c00903aff010a3557ab4366a1a13ce2d243c9cb191e703fbb76c915
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-arm64<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-arm64<span/>.tar<span/>.gz.sha256sum) / b0214eabbb64791f563bd222d17150ce39bf4e2f5de49f49fdb456ce9ae8162f
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-386<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-386<span/>.tar<span/>.gz.sha256sum) / 9bd6f50307fdaa26100bca3fd55aaac3016a985424c8482f37d3a3a4c8a9dbed
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-ppc64le<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-ppc64le<span/>.tar<span/>.gz.sha256sum) / a2a44726bee7d69b08fadc72fb3716428b9963f78ea5290711fe6fcb9bac3f14
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-s390x<span/>.tar<span/>.gz) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-linux-s390x<span/>.tar<span/>.gz.sha256sum) / 036167ca03f5e00ac1e8f27dc260c8316d8596d8eb3ddac2c5431b4b692d55af
- https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-windows-amd64<span/>.zip) ([checksum](https:<span/>/<span/>/get<span/>.helm<span/>.sh<span/>/helm-v3<span/>.7<span/>.2-windows-amd64<span/>.zip.sha256sum) / 299165f0af46bece9a61b41305cca8e8d5ec5319a4b694589cd71e6b75aca77e

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @<!-- -->mattfarina https:<span/>/<span/>/keybase<span/>.io<span/>/mattfarina<span/>. Please use the attached signatures for verifying this release using `gpg`.

The https:<span/>/<span/>/helm<span/>.sh<span/>/docs<span/>/intro<span/>/quickstart<span/>/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https:<span/>/<span/>/helm<span/>.sh<span/>/docs<span/>/intro<span/>/install<span/>/). You can also use a [script to install](https:<span/>/<span/>/raw<span/>.githubusercontent<span/>.com<span/>/helm<span/>/helm<span/>/main<span/>/scripts<span/>/get-helm-3 on any system with `bash`.

## What's Next

- 3.8.0 is the next feature release and will be released on January 12, 2022.

## Changelog

- Channel should remain open if there is still a routine that wants to write into it 663a896f4a815053445eec4153677ddc24a0a361 (Jerome Küttner)
- Fix memory leak in upgrade action 95c03eecdb87feae2ba5d5651225ef6f53d6892a (Jerome Küttner)
- chore(deps): bump github<span/>.com<span/>/Masterminds<span/>/squirrel from 1.5.1 to 1.5.2 cf8b02d3187c2a190b9f7c1a956a3fe4451c66e9 (dependabot[bot])
- chore(deps): bump github<span/>.com<span/>/Masterminds<span/>/squirrel from 1.5.0 to 1.5.1 013632b2c56c7b45a2e2ea2631d130ee4833808d (dependabot[bot])
- chore(deps): bump github<span/>.com<span/>/gofrs<span/>/flock from 0.8.0 to 0.8.1 339681484da195543461a1b9340b7eb47a0978a0 (dependabot[bot])
- Updating to Kubernetes 1.22.4 packages d5bd91cb91702291e16da3b7975162bfe88cf986 (Matt Farina)
- Fix specifying of Kubernetes version from build scripts bb7f8b2b4092f4040247525ab406f62babc174c5 (Matt Farina)
- allow ldflags to overwrite k8s version 7e750ff4e9d3099f0087719c50e81a76500bb08a (Sverre Boschman)
- Use buffered channel for signal notification dfb24521ac68eb88e55c3d255d9e10727fb39e14 (Martin Hickey)