### PR TITLE
terraform 1.1.0

### DIFF
--- a/Food/terraform.lua
+++ b/Food/terraform.lua
@@ -1,5 +1,5 @@
 local name = "terraform"
-local version = "1.0.11"
+local version = "1.1.0"
 
 food = {
     name = name,
@@ -12,7 +12,7 @@ food = {
             os = "darwin",
             arch = "amd64",
             url = "https://releases.hashicorp.com/" .. name .. "/" .. version .. "/" .. name .. "_" .. version .. "_darwin_amd64.zip",
-            sha256 = "92f2e7eebb9699e23800f8accd519775a02bd25fe79e1fe4530eca123f178202",
+            sha256 = "6fb2af160879d807291980642efa93cc9a97ddf662b17cc3753065c974a5296d",
             resources = {
                 {
                     path = name,
@@ -25,7 +25,7 @@ food = {
             os = "linux",
             arch = "amd64",
             url = "https://releases.hashicorp.com/" .. name .. "/" .. version .. "/" .. name .. "_" .. version .. "_linux_amd64.zip",
-            sha256 = "eeb46091a42dc303c3a3c300640c7774ab25cbee5083dafa5fd83b54c8aca664",
+            sha256 = "763378aa75500ce5ba67d0cba8aa605670cd28bf8bafc709333a30908441acb5",
             resources = {
                 {
                     path = name,
@@ -38,7 +38,7 @@ food = {
             os = "windows",
             arch = "amd64",
             url = "https://releases.hashicorp.com/" .. name .. "/" .. version .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
-            sha256 = "b2903d4866bda5579e46eeadff569d1eee4468ad9c03eb688769978f6cff8ae3",
+            sha256 = "a7cb68e34c49336f8bd9792dba3ee350a9eccffb0b9c3ce7275e18e35ad4776b",
             resources = {
                 {
                     path = name .. ".exe",


### PR DESCRIPTION
Updating package terraform to release v1.1.0. 

# Release info 

 ## 1.1.0 (December 08, 2021)

Terraform v1.1.0 is a new minor release, containing some new features and some bug fixes whose scope was too large for inclusion in a patch release.

NEW FEATURES:

* `moved` blocks for refactoring within modules: Module authors can now record in module source code whenever they've changed the address of a resource or resource instance, and then during planning Terraform will automatically migrate existing objects in the state to new addresses.

    This therefore avoids the need for users of a shared module to manually run `terraform state mv` after upgrading to a version of the module, as long as the change is expressible as static configuration. However, `terraform state mv` will remain available for use in more complex migration situations that are not well-suited to declarative configuration.
* A new `cloud` block in the `terraform` settings block introduces a native Terraform Cloud integration for the https:<span/>/<span/>/www<span/>.terraform<span/>.io<span/>/docs<span/>/cloud<span/>/run<span/>/cli<span/>.html<span/>.

    The Cloud integration includes several enhancements, including per-run variable support using the `-var` flag, the ability to map Terraform Cloud workspaces to the current configuration via https:<span/>/<span/>/www<span/>.terraform<span/>.io<span/>/docs<span/>/cloud<span/>/api<span/>/workspaces<span/>.html#get-tags, and an improved user experience for Terraform Cloud and Enterprise users with actionable error messages and prompts.
* `terraform plan` and `terraform apply` both now include additional annotations for resource instances planned for deletion to explain why Terraform has proposed that action.

    For example, if you change the `count` argument for a resource to a lower number then Terraform will now mention that as part of proposing to destroy any existing objects that exceed the new count.

UPGRADE NOTES:

This release is covered by the https:<span/>/<span/>/www<span/>.terraform<span/>.io<span/>/docs<span/>/language<span/>/v1-compatibility-promises<span/>.html, but does include some changes permitted within those promises as described below.

* Terraform on macOS now requires macOS 10.13 High Sierra or later; Older macOS versions are no longer supported.
* The `terraform graph` command no longer supports `-type=validate` and `-type=eval` options. The validate graph is always the same as the plan graph anyway, and the "eval" graph was just an implementation detail of the `terraform console` command. The default behavior of creating a plan graph should be a reasonable replacement for both of the removed graph modes. (Please note that `terraform graph` is not covered by the Terraform v1.0 compatibility promises, because its behavior inherently exposes Terraform Core implementation details, so we recommend it only for interactive debugging tasks and not for use in automation.)
* `terraform apply` with a previously-saved plan file will now verify that the provider plugin packages used to create the plan fully match the ones used during apply, using the same checksum scheme that Terraform normally uses for the dependency lock file. Previously Terraform was checking consistency of plugins from a plan file using a legacy mechanism which covered only the main plugin executable, not any other files that might be distributed alongside in the plugin package.

    This additional check should not affect typical plugins that conform to the expectation that a plugin package's contents are immutable once released, but may affect a hypothetical in-house plugin that intentionally modifies extra files in its package directory somehow between plan and apply. If you have such a plugin, you'll need to change its approach to store those files in some other location separate from the package directory. This is a minor compatibility break motivated by increasing the assurance that plugins have not been inadvertently or maliciously modified between plan and apply.
* `terraform state mv` will now error when legacy `-backup` or `-backup-out` options are used without the `-state` option on non-local backends. These options operate on a local state file only. Previously, these options were accepted but ignored silently when used with non-local backends. 
* In the AzureRM backend, the new opt-in option `use_microsoft_graph` switches to using MSAL authentication tokens and Microsoft Graph rather than using ADAL tokens and Azure Active Directory Graph, which is now https:<span/>/<span/>/docs<span/>.microsoft<span/>.com<span/>/en-us<span/>/graph<span/>/migrate-azure-ad-graph-faq<span/>. The new mode will become the default in Terraform v1.2, so please plan to migrate to using this setting and test with your own Azure AD tenant prior to the Terraform v1.2 release.

ENHANCEMENTS:

* config: Terraform now checks the syntax of and normalizes module source addresses (the `source` argument in `module` blocks) during configuration decoding rather than only at module installation time. This is largely just an internal refactoring, but a visible benefit of this change is that the `terraform init` messages about module downloading will now show the canonical module package address Terraform is downloading from, after interpreting the special shorthands for common cases like GitHub URLs. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/28854)
* config: Variables can now be declared as "nullable", which defines whether a variable can be null within a module. Setting `nullable = false` ensures that a variable value will never be `null`, and may instead take on the variable's default value if the caller sets it explicitly to `null`. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29832)
* `terraform plan` and `terraform apply`: When Terraform plans to destroy a resource instance due to it no longer being declared in the configuration, the proposed plan output will now include a note hinting at what situation prompted that proposal, so you can more easily see what configuration change might avoid the object being destroyed. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/pull<span/>/29637)
* `terraform plan` and `terraform apply`: Terraform will now report explicitly in the UI if it automatically moves a resource instance to a new address as a result of adding or removing the `count` argument from an existing resource. For example, if you previously had `resource "aws_subnet" "example"` _without_ `count`, you might have `aws_subnet.example` already bound to a remote object in your state. If you add `count = 1` to that resource then Terraform would previously silently rebind the object to `aws_subnet.example[0]` as part of planning, whereas now Terraform will mention that it did so explicitly in the plan description. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29605)
* `terraform workspace delete`: will now allow deleting a workspace whose state contains only data resource instances and output values, without running `terraform destroy` first. Previously the presence of data resources would require using `-force` to override the safety check guarding against accidentally forgetting about remote objects, but a data resource is not responsible for the management of its associated remote object(s) and so there's no reason to require explicit deletion. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29754)
* `terraform validate`: Terraform now uses precise type information for resources during config validation, allowing more problems to be caught that that step rather than only during the planning step. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29862)
* provisioner/remote-exec and provisioner/file: When using SSH agent authentication mode on Windows, Terraform can now detect and use https:<span/>/<span/>/devblogs<span/>.microsoft<span/>.com<span/>/powershell<span/>/using-the-openssh-beta-in-windows-10-fall-creators-update-and-windows-server-1709<span/>/)'s SSH Agent, when available, in addition to the existing support for the third-party solution [Pageant](https:<span/>/<span/>/documentation<span/>.help<span/>/PuTTY<span/>/pageant<span/>.html) that was already supported. ([#<!-- -->29747](https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29747)
* cli: `terraform state mv` will now return an error for `-backup` or `-backup-out` options used without the `-state` option, unless the working directory is initialized to use the local backend. Previously Terraform would silently ignore those options, since they are applicable only to the local backend. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/27908)
* `terraform console`: now has a new `type()` function, available only in the interactive console, for inspecting the exact type of a particular value as an aid to debugging. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/28501)

BUG FIXES:

* config: `ignore_changes = all` now works in override files. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29849)
* config: Upgrading an unknown single value to a list using a splat expression now correctly returns an unknown value and type. Previously it would sometimes "overpromise" a particular return type, leading to an inconsistency error during the apply step. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/30062)
* config: Terraform is now more precise in its detection of data resources that must be deferred to the apply step due to their `depends_on` arguments referring to not-yet-converged managed resources. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29682)
* config: `ignore_changes` can no longer cause a null map to be converted to an empty map, which would otherwise potentially cause surprising side-effects in provider logic. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29928)
* core: Provider configuration obtained from interactive prompts will now be merged properly with settings given in the configuration. Previously this merging was incorrect in some cases. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29000)
* `terraform plan`: Improved rendering of changes inside attributes that accept lists, sets, or maps of nested object types. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29827), [#<!-- -->29983](https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29983), [#<!-- -->29986](https:<span/>/<span/>/github<span/>.com<span/>/terraform<span/>/issues<span/>/29986)
* `terraform apply`: Will no longer try to apply a stale plan that was generated against an originally-empty state. Previously this was an unintended exception to the rule that a plan can only be applied to the state snapshot it was generated against. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29755)
* `terraform show -json`: Attributes that are declared as using the legacy https:<span/>/<span/>/www<span/>.terraform<span/>.io<span/>/docs<span/>/language<span/>/attr-as-blocks<span/>.html) behavior are now represented more faithfully in the JSON plan output. ([#<!-- -->29522](https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29522)
* `terraform init`: Will now update the backend configuration hash value at a more approprimate time, to ensure properly restarting a backend migration process that failed on the first attempt. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29860)
* backend/oss: Flatten `assume_role` block arguments, so that they are more compatible with the `terraform_remote_state` data source. (https:<span/>/<span/>/github<span/>.com<span/>/hashicorp<span/>/terraform<span/>/issues<span/>/29307)

