### PR TITLE
Add Dive, SOPS and Tkn as Food 

### DIFF
--- a/Food/dive.lua
+++ b/Food/dive.lua
@@ -1,0 +1,55 @@
+local name = "dive"
+local version = "0.10.0"
+local release = "v" .. version
+local org = "wagoodman"
+local repo = "dive"
+local url = "https://github.com/" .. org .. "/" .. repo
+
+food = {
+    name = name,
+    description = "A tool for exploring a docker image, layer contents, and discovering ways to shrink the size of your Docker/OCI image",
+    homepage = "https://github.com/wagoodman/dive",
+    version = version,
+    packages = {
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_darwin_amd64.tar.gz",
+            sha256 = "b4cad081146defcb90b418215cdfdf835372abd4adf1b0f33aaf1ea5d9bb3244",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_linux_amd64.tar.gz",
+            sha256 = "9541997876d4985de66d0fa5924dac72258a3094ef7d3f6ef5fa5dcf6f6a47ad",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "_" .. version .. "_windows_amd64.zip",
+            sha256 = "e88cf463b48d9edc22f71b63d43f076826f32f6777ac9a8d288dd3dd8f0599e3",
+            resources = {
+                {
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        }
+
+
+    }
+}

--- a/Food/sops.lua
+++ b/Food/sops.lua
@@ -1,0 +1,53 @@
+local name = "sops"
+local version = "3.7.1"
+local release = "v" .. version
+local org = "mozilla"
+local repo = "sops"
+local url = "https://github.com/" .. org .. "/" .. repo
+
+food = {
+    name = name,
+    description = "sops is an editor of encrypted files that supports YAML, JSON, ENV, INI and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault, age, and PGP",
+    homepage = url,
+    version = version,
+    packages = {
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "-" .. release .. ".darwin",
+            sha256 = "43d2f9c63921a57bf607268a05d480cc309e9979bb81269248dd117e5efac133",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "-" .. release .. ".linux",
+            sha256 = "185348fd77fc160d5bdf3cd20ecbc796163504fd3df196d7cb29000773657b74",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. name,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. name .. "-" .. release .. ".exe",
+            sha256 = "a514bd0ade6d955a73f9c8b9dde6c33eca006430b0e72289467d2152c5321767",            
+            resources = {
+                {
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. name .. ".exe"
+                }
+            }
+        }
+    }
+}

--- a/Food/tektoncd-cli.lua
+++ b/Food/tektoncd-cli.lua
@@ -1,0 +1,54 @@
+local name = "tektoncd-cli"
+local version = "0.21.0"
+local release = "v" .. version
+local org = "tektoncd"
+local repo = "cli"
+local url = "https://github.com/" .. org .. "/" .. repo
+local bin = "tkn"
+
+food = {
+    name = name,
+    description = "The Tekton Pipelines CLI project provides a command-line interface (CLI) for interacting with Tekton, an open-source framework for Continuous Integration and Delivery (CI/CD) systems",
+    homepage = url,
+    version = version,
+    packages = {
+        {
+            os = "darwin",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. bin .. "_" .. version .. "_Darwin_x86_64.tar.gz",
+            sha256 = "927171af0df17b52bf5b4b6012d9114ec323463f17449b4958b8f6989fd9519b",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. bin,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "linux",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. bin .. "_" .. version .. "_Linux_x86_64.tar.gz",
+            sha256 = "2158a202e4b04ff73e6427b565355c7bfc8cbe16dc7058a0414fb16e7b97008c",
+            resources = {
+                {
+                    path = name,
+                    installpath = "bin/" .. bin,
+                    executable = true
+                }
+            }
+        },
+        {
+            os = "windows",
+            arch = "amd64",
+            url = url .. "/releases/download/" .. release .. "/" .. bin .. "_" .. version .. "_Windows_x86_64.zip",
+            sha256 = "cfa6968e4c4ba4408043c62150886c40ba577fa34ea0c6d977fa8259d2098a26",
+            resources = {
+                {
+                    path = name .. ".exe",
+                    installpath = "bin\\" .. bin .. ".exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds three new foods to the rig:

  * [https://github.com/wagoodman/dive](https://github.com/wagoodman/dive)
  * [https://github.com/mozilla/sops](https://github.com/mozilla/sops)
  * [https://github.com/tektoncd/cli](https://github.com/tektoncd/cli)

Tested all three foods locally:

```
$ gofish lint Food/dive.lua 
🐠  No errors discovered in 'dive'

$ gofish lint Food/sops.lua 
🐠  No errors discovered in 'sops'

$ gofish lint Food/tektoncd-cli.lua 
🐠  No errors discovered in 'tektoncd-cli'
```